### PR TITLE
getPeersForOrgOnChannel should return channel_peer

### DIFF
--- a/fabric-client/lib/Client.js
+++ b/fabric-client/lib/Client.js
@@ -1823,7 +1823,7 @@ var Client = class extends BaseClient {
 								let org_peer = org_peers[k];
 								logger.debug('%s - looking at org peer:%s',method,org_peer.getName());
 								if(org_peer.getName() === channel_peer.getName()) {
-									found_peers[org_peer.getName()] = org_peer;//to avoid Duplicate Peers
+									found_peers[org_peer.getName()] = channel_peer;//to avoid Duplicate Peers
 									logger.debug('%s - adding peer to list:%s',method,org_peer.getName());
 								}
 							}


### PR DESCRIPTION
org_peer doesn't have role information

[composer-connector-hlfv1/hlfconnection.js](https://github.com/hyperledger/composer/blob/master/packages/composer-connector-hlfv1/lib/hlfconnection.js) getChannelPeersInOrg function using this.
But there are no role info in org_peer. If this returns channel_peer, then I will be work.

Signed-off-by: ozt88 <kl1467@gmail.com>