### PR TITLE
Apply the configSetting in the channel initialize function.

### DIFF
--- a/fabric-client/lib/Channel.js
+++ b/fabric-client/lib/Channel.js
@@ -129,6 +129,7 @@ const Channel = class {
 		this._last_discover_timestamp = null;
 		this._use_discovery = sdk_utils.getConfigSetting('initialize-with-discovery', false);
 		this._as_localhost = sdk_utils.getConfigSetting('discovery-as-localhost', true);
+		this._discovery_cache_life = sdk_utils.getConfigSetting('discovery-cache-life', 300000); // default is 5 minutes
 		this._endorsement_handler = null;
 		this._commit_handler = null;
 
@@ -208,20 +209,31 @@ const Channel = class {
 
 				return true;
 			} else {
-				if (typeof request.discover !== 'undefined') {
-					if (typeof request.discover === 'boolean') {
-						logger.debug('%s - user requested discover %s', method, request.discover);
-						this._use_discovery = request.discover;
+				const use_discovery = request.discover || sdk_utils.getConfigSetting('initialize-with-discovery');
+				const as_localhost = request.asLocalhost || sdk_utils.getConfigSetting('discovery-as-localhost');
+				const cache_life_time = sdk_utils.getConfigSetting('discovery-cache-life');
+
+				if (typeof use_discovery !== 'undefined') {
+					if (typeof use_discovery === 'boolean') {
+						logger.debug('%s - user requested discover %s', method, use_discovery);
+						this._use_discovery = use_discovery;
 					} else {
-						throw new Error('Request parameter "discover" must be boolean');
+						throw new Error('Request parameter "discover" or config parameter "initialize-with-discovery" must be boolean');
 					}
 				}
-				if (typeof request.asLocalhost !== 'undefined') {
-					if (typeof request.asLocalhost === 'boolean') {
-						logger.debug('%s - user requested discovery as localhost %s', method, request.asLocalhost);
-						this._as_localhost = request.asLocalhost;
+				if (typeof as_localhost !== 'undefined') {
+					if (typeof as_localhost === 'boolean') {
+						logger.debug('%s - user requested discovery as localhost %s', method, as_localhost);
+						this._as_localhost = as_localhost;
 					} else {
-						throw new Error('Request parameter "asLocalhost" must be boolean');
+						throw new Error('Request parameter "asLocalhost" or config parameter "discovery-as-localhost" must be boolean');
+					}
+				}
+				if (typeof cache_life_time !== 'undefined') {
+					if (typeof cache_life_time === 'number') {
+						this._discovery_cache_life = cache_life_time;
+					} else {
+						throw new Error('Config parameter "discovery-cache-life" must be number');
 					}
 				}
 				if (request.endorsementHandler) {
@@ -644,7 +656,7 @@ const Channel = class {
 
 		if (this._use_discovery) {
 			const have_new_interests = this._merge_hints(endorsement_hints);
-			const allowed_age = sdk_utils.getConfigSetting('discovery-cache-life', 300000); // default is 5 minutes
+			const allowed_age = this._discovery_cache_life;
 			const now = Date.now();
 			if (have_new_interests || now - this._last_discover_timestamp > allowed_age) {
 				logger.debug('%s - need to refresh :: have_new_interests %s', method, have_new_interests);

--- a/fabric-client/lib/Channel.js
+++ b/fabric-client/lib/Channel.js
@@ -2615,8 +2615,8 @@ const Channel = class {
 			Buffer.from(this._name),
 			chaincodeDeploymentSpec.toBuffer(),
 			Buffer.from(''),
-			Buffer.from(''),
-			Buffer.from(''),
+			Buffer.from('escc'), // default
+			Buffer.from('vscc'), // default
 		];
 		if (request['endorsement-policy']) {
 			lcccSpec_args[3] = this._buildEndorsementPolicy(request['endorsement-policy']);
@@ -2624,6 +2624,14 @@ const Channel = class {
 		if (request['collections-config']) {
 			const collectionConfigPackage = CollectionConfig.buildCollectionConfigPackage(request['collections-config']);
 			lcccSpec_args[6] = collectionConfigPackage.toBuffer();
+		}
+
+		// client can specify the escc and vscc names
+		if (request.escc && typeof request.escc === 'string') {
+			lcccSpec_args[4] = Buffer.from(request.escc);
+		}
+		if (request.vscc && typeof request.vscc === 'string') {
+			lcccSpec_args[5] = Buffer.from(request.vscc);
 		}
 
 		const lcccSpec = {

--- a/fabric-client/test/Channel.js
+++ b/fabric-client/test/Channel.js
@@ -945,6 +945,39 @@ describe('Channel', () => {
 			};
 			return expect(channel.initialize(request)).to.be.fulfilled;
 		});
+
+		it('Successfully applying configSetting parameter "initialize-with-discovery"', async () => {
+			sinon.stub(channel, '_initialize');
+			sdk_utils.setConfigSetting('initialize-with-discovery', true);
+
+			const request = {
+				target: 'peer0'
+			};
+			await channel.initialize(request);
+			channel._use_discovery.should.equal(true);
+		});
+
+		it('Successfully applying configSetting parameter "initialize-with-discovery"', async () => {
+			sinon.stub(channel, '_initialize');
+			sdk_utils.setConfigSetting('discovery-as-localhost', false);
+
+			const request = {
+				target: 'peer0'
+			};
+			await channel.initialize(request);
+			channel._as_localhost.should.equal(false);
+		});
+
+		it('Successfully applying configSetting parameter "discovery-cache-life"', async () => {
+			sinon.stub(channel, '_initialize');
+			sdk_utils.setConfigSetting('discovery-cache-life', 70000);
+
+			const request = {
+				target: 'peer0'
+			};
+			await channel.initialize(request);
+			channel._discovery_cache_life.should.equal(70000);
+		});
 	});
 
 	describe('#_initialize', () => {});
@@ -987,7 +1020,7 @@ describe('Channel', () => {
 
 	describe('#addPeer', () => {});
 
-	describe('#remoePeer', () => {});
+	describe('#removePeer', () => {});
 
 	describe('#gePeer', () => {});
 

--- a/fabric-client/test/Channel.js
+++ b/fabric-client/test/Channel.js
@@ -1369,6 +1369,8 @@ describe('Channel', () => {
 			const input = proposalProto.ChaincodeInvocationSpec.decode(payload.input);
 			const args = input.chaincode_spec.input.args;
 			args.should.have.lengthOf(6);
+			args[4].toBuffer().toString().should.equal('escc');
+			args[5].toBuffer().toString().should.equal('vscc');
 			const cds = proposalProto.ChaincodeDeploymentSpec.decode(args[2]);
 			cds.chaincode_spec.chaincode_id.name.should.equal('fabcar');
 			cds.chaincode_spec.chaincode_id.version.should.equal('1.0.0');
@@ -1384,12 +1386,16 @@ describe('Channel', () => {
 				chaincodeVersion: '1.0.0',
 				fcn: 'initLedger',
 				args: ['hello', 'world'],
+				escc: 'my-escc',
+				vscc: 'my-vscc',
 				txId
 			});
 			const payload = proposalProto.ChaincodeProposalPayload.decode(proposal.payload);
 			const input = proposalProto.ChaincodeInvocationSpec.decode(payload.input);
 			const args = input.chaincode_spec.input.args;
 			args.should.have.lengthOf(6);
+			args[4].toBuffer().toString().should.equal('my-escc');
+			args[5].toBuffer().toString().should.equal('my-vscc');
 			const cds = proposalProto.ChaincodeDeploymentSpec.decode(args[2]);
 			cds.chaincode_spec.chaincode_id.name.should.equal('fabcar');
 			cds.chaincode_spec.chaincode_id.version.should.equal('1.0.0');


### PR DESCRIPTION
sdk_utils.setConfigSetting does not apply to channel.initialize when client is created and channel is automatically generated.

When channel.initialize does not have the request values discover and as_localhost, sdk_utils.getConfigSetting can be used to fetch the values and apply them.

Also, discovery-cache-life can be set at channel.initialize.