### PR TITLE
Added caname parameter to delete function in fabric-ca-client/lib/IdentityService.js

### DIFF
--- a/fabric-ca-client/lib/IdentityService.js
+++ b/fabric-ca-client/lib/IdentityService.js
@@ -182,9 +182,11 @@ class IdentityService {
 	 * @param {string} enrollmentID
 	 * @param {User} registrar
 	 * @param {boolean} force - Optional. With force, some identity can delete itself
+	 * @param {string}	caname - Optional. The name of the CA to direct this request to within the server,
+	 * or the default CA if not specified
 	 * @return {Promise} {@link ServiceResponse}
 	 */
-	delete(enrollmentID, registrar, force) {
+	delete(enrollmentID, registrar, force, caname) {
 		if (!enrollmentID || typeof enrollmentID !== 'string') {
 			throw new Error('Missing required argument "enrollmentID", or argument "enrollmentID" is not a valid string');
 		}
@@ -193,7 +195,9 @@ class IdentityService {
 		const signingIdentity = registrar.getSigningIdentity();
 
 		let url = 'identities/' + enrollmentID;
-		if (force === true) {
+		if (caname && force === true) {
+			url = url + '?ca='+ caname + '&&force=true';
+		} else if (force === true) {
 			url = url + '?force=true';
 		}
 		return this.client.delete(url, signingIdentity);


### PR DESCRIPTION
This will allow rerouting the delete request to different CA instances in the same server. If no CA Name is provided, the request is routed to default CA server.