### PR TITLE
Added deleteFromCA function in fabric-ca-client/lib/IdentityService.js

### DIFF
--- a/fabric-ca-client/lib/IdentityService.js
+++ b/fabric-ca-client/lib/IdentityService.js
@@ -200,6 +200,35 @@ class IdentityService {
 	}
 
 	/**
+	 * Delete an existing identity from a CA instance. The caller must have `hf.Registrar` authority.
+	 *
+	 * @param {string} enrollmentID
+	 * @param {User} registrar
+ 	 * @property {string} caname - Optional. The name of the CA to direct this request to within the server,
+	 * or the default CA if not specified	 
+	 * @param {boolean} force - Optional. With force, some identity can delete itself
+	 * @return {Promise} {@link ServiceResponse}
+	 */
+	deleteFromCA(enrollmentID, registrar, caname, force) {
+		if (!enrollmentID || typeof enrollmentID !== 'string') {
+			throw new Error('Missing required argument "enrollmentID", or argument "enrollmentID" is not a valid string');
+		}
+		checkRegistrar(registrar);
+
+		const signingIdentity = registrar.getSigningIdentity();
+
+		let url = 'identities/' + enrollmentID;
+		if (caname && force === true) {
+			url = url + '?ca='+ caname + '&&force=true';
+		} else if (caname) {
+			url = url + '?ca='+ caname;
+		} else if (force === true) {
+			url = url + '?force=true';
+		}
+		return this.client.delete(url, signingIdentity);
+	}
+
+	/**
 	 * Update an existing identity. The caller must have `hf.Registrar` authority.
 	 *
 	 * @param {string} enrollmentID

--- a/fabric-ca-client/types/index.d.ts
+++ b/fabric-ca-client/types/index.d.ts
@@ -185,6 +185,7 @@ declare namespace FabricCAServices {
         getOne(enrollmentID: string, registrar: User): Promise<IServiceResponse>;
         getAll(registrar: User): Promise<IServiceResponse>;
         delete(enrollmentID: string, registrar: User): Promise<IServiceResponse>;
+        deleteFromCA(enrollmentID: string, registrar: User): Promise<IServiceResponse>;
         update(enrollmentID: string, req: IIdentityRequest, registrar: User): Promise<IServiceResponse>;
     }
 }


### PR DESCRIPTION
Thiss which will allow redirecting delete API call to the different CA instances based on the provided caName parameter

Signed-off-by: Aditya Nalge <aditya.nalge@nutanix.com>