### PR TITLE
FABN-1386: Don't pull Docker images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,6 @@ steps:
 - script: npm install
   displayName: 'npm install'
 
-- script: npm run retrieve-images
-  displayName: 'Pull Docker images'
-
-- script: npx gulp install-and-generate-certs
-  displayName: 'Generate credentials'
-
 - script: npx gulp run-test-all
   displayName: 'Run tests'
 


### PR DESCRIPTION
Release 1.4 uses release versions of Fabric Docker images. It does
not need to pull development snapshots.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>