### PR TITLE
[FABN-1422] not to get property from getter

### DIFF
--- a/fabric-client/lib/utils/ChannelHelper.js
+++ b/fabric-client/lib/utils/ChannelHelper.js
@@ -20,7 +20,7 @@ const fabprotos = require('fabric-protos');
  */
 function buildTransactionProposal(chaincodeProposal, endorsements, proposalResponse) {
 
-	const header = fabprotos.common.Header.decode(chaincodeProposal.getHeader());
+	const header = fabprotos.common.Header.decode(chaincodeProposal.header);
 
 	const chaincodeEndorsedAction = new fabprotos.protos.ChaincodeEndorsedAction();
 	chaincodeEndorsedAction.setProposalResponsePayload(proposalResponse.payload);


### PR DESCRIPTION
If chaincode proposal is recovered from deserialized,
the getter function will not be available.

Signed-off-by: david <david-khala@hotmail.com>