### PR TITLE
[FABN-1422] not to get property from getter

### DIFF
--- a/fabric-client/lib/utils/ChannelHelper.js
+++ b/fabric-client/lib/utils/ChannelHelper.js
@@ -27,7 +27,7 @@ const _proposalProto = ProtoLoader.load(path.resolve(__dirname, '../protos/peer/
  */
 function buildTransactionProposal(chaincodeProposal, endorsements, proposalResponse) {
 
-	const header = _commonProto.Header.decode(chaincodeProposal.getHeader());
+	const header = _commonProto.Header.decode(chaincodeProposal.header);
 
 	const chaincodeEndorsedAction = new _transProto.ChaincodeEndorsedAction();
 	chaincodeEndorsedAction.setProposalResponsePayload(proposalResponse.payload);


### PR DESCRIPTION
If chaincode proposal is recovered from deserialized,
the getter function will not be available.

Signed-off-by: david <david-khala@hotmail.com>