### PR TITLE
FABN-1386: Publish correct doc release directory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,7 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_style = space
 indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/build/tasks/doc.js
+++ b/build/tasks/doc.js
@@ -19,17 +19,9 @@ const jsdoc = require('gulp-jsdoc3');
 const fs = require('fs-extra');
 const path = require('path');
 const replace = require('gulp-replace');
-let currentBranch = process.env.GERRIT_BRANCH;
 
-if (!currentBranch) {
-	currentBranch = 'master';
-}
-let docsRoot;
-if (process.env.DOCS_ROOT) {
-	docsRoot = process.env.DOCS_ROOT;
-} else {
-	docsRoot = './docs/gen';
-}
+const currentBranch = process.env.BUILD_BRANCH || 'master';
+const docsRoot = process.env.DOCS_ROOT || './docs/gen';
 
 gulp.task('clean', () => {
 	return fs.removeSync(path.join(docsRoot, currentBranch));

--- a/scripts/ci_scripts/azurePublishApiDocs.sh
+++ b/scripts/ci_scripts/azurePublishApiDocs.sh
@@ -12,6 +12,7 @@
 : "${PROJECT_DIR:?}" # Root directory for the Git project
 : "${STAGING_DIR:?}" # Directory used to store content to publish to GitHub Pages
 
+readonly CURRENT_BRANCH=$(git branch --show-current)
 readonly COMMIT_HASH=$(git rev-parse HEAD)
 readonly BUILD_DIR="${PROJECT_DIR}/docs/gen"
 readonly DOCS_BRANCH='gh-pages'
@@ -19,7 +20,7 @@ readonly DOCS_BRANCH='gh-pages'
 prepareStaging() {
     echo "Preparing staging directory: ${STAGING_DIR}"
     rm -rf "${STAGING_DIR}"
-	rsync -r --exclude-from=${PROJECT_DIR}/.gitignore "${PROJECT_DIR}/" "${STAGING_DIR}"
+	rsync -r --exclude-from="${PROJECT_DIR}/.gitignore" "${PROJECT_DIR}/" "${STAGING_DIR}"
     (cd "${STAGING_DIR}" && _stagingGitSetUp)
 }
 
@@ -36,13 +37,13 @@ _stagingGitSetUp() {
 buildDocs() {
     echo 'Building documentation'
     rm -rf "${BUILD_DIR}"
-    npx gulp docs
+	BUILD_BRANCH="${CURRENT_BRANCH}" DOCS_ROOT="${BUILD_DIR}" npx gulp docs
 }
 
 copyToStaging() {
     echo "Copying built documentation from ${BUILD_DIR} to ${STAGING_DIR}"
     cleanStaging
-    cp -r "${BUILD_DIR}"/* "${STAGING_DIR}"
+    rsync -r "${BUILD_DIR}/" "${STAGING_DIR}"
 }
 
 cleanStaging() {


### PR DESCRIPTION
Invoke documentation generation with the correct branch name so
that built documentation is published under the correct
sub-directory for the current branch. Previously, all branches
published their documentation as master.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>