### PR TITLE
FABN-1424: Fix lifecycle scenario tests

### DIFF
--- a/test/ts-scenario/steps/channel_operations.ts
+++ b/test/ts-scenario/steps/channel_operations.ts
@@ -30,7 +30,7 @@ When(/^I perform a (.+?) operation on channel (.+?) with (.+?) the response (inc
 	const response: any = await AdminUtils.performChannelQueryOperation(queryOperation, channelName, orgName, ccp, undefined);
 
 	// check response
-	BaseUtils.logMsg(`Recursively checking response object from ${queryOperation}`, undefined);
+	BaseUtils.logMsg(`Recursively checking response object from ${queryOperation}`);
 	validateObjectKeyMatch(JSON.parse(expectedResponse), response, compareType);
 
 });
@@ -47,7 +47,7 @@ When(/^I perform a (.+?) operation with arguments (.+?) on channel (.+?) with (.
 	const response: any = await AdminUtils.performChannelQueryOperation(queryOperation, channelName, orgName, ccp, JSON.parse(args));
 
 	// check response
-	BaseUtils.logMsg(`Recursively checking response object from ${queryOperation}`, undefined);
+	BaseUtils.logMsg(`Recursively checking response object from ${queryOperation}`);
 	validateObjectKeyMatch(JSON.parse(expectedResponse), response, compareType);
 });
 
@@ -85,7 +85,7 @@ function validateObjectKeyMatch(expected: any, actual: any, compareType: 'includ
 			for (const key of Object.keys(expected)) {
 				if (actual.hasOwnProperty(key)) {
 					// recursive call to scan property
-					BaseUtils.logMsg(`->Recursively checking response key ${key}`, undefined);
+					BaseUtils.logMsg(`->Recursively checking response key ${key}`);
 					return validateObjectKeyMatch(expected[key], actual[key], compareType);
 				} else {
 					BaseUtils.logAndThrow(`-->Missing key in response expected field ${key} to be present in ${{actual}}`);
@@ -99,18 +99,18 @@ function validateObjectKeyMatch(expected: any, actual: any, compareType: 'includ
 				if (expected !== actual) {
 					BaseUtils.logAndThrow(`-->Mismatched items expected ${expected} but found ${actual}`);
 				} else {
-					BaseUtils.logMsg(`-->Confirmed match of expected key value ${actual}`, undefined);
+					BaseUtils.logMsg(`-->Confirmed match of expected key value ${actual}`);
 				}
 				break;
 			case 'includes':
 				if (expected !== actual) {
 					return false;
 				} else {
-					BaseUtils.logMsg(`-->Confirmed existence of required 'include' key with value ${actual}`, undefined);
+					BaseUtils.logMsg(`-->Confirmed existence of required 'include' key with value ${actual}`);
 					return true;
 				}
 			case 'mirrors':
-				BaseUtils.logMsg(`-->Confirmed existence of required 'mirror' key name and presence of a value`, undefined);
+				BaseUtils.logMsg(`-->Confirmed existence of required 'mirror' key name and presence of a value`);
 				break;
 			default:
 				throw new Error(`Unconditioned switch type ${compareType} passed to validate match`);

--- a/test/ts-scenario/steps/cli.ts
+++ b/test/ts-scenario/steps/cli.ts
@@ -38,7 +38,7 @@ Given(/^I use the cli to create and join the channel named (.+?) on the deployed
 		for (const orgName of orgNames) {
 			const alreadyJoined: boolean = await AdminUtils.isOrgChannelJoined(orgName, ccp, channelName);
 			if (alreadyJoined) {
-				BaseUtils.logMsg(`Organization ${orgName} has already joined channel ${channelName}, skipping ... `, undefined);
+				BaseUtils.logMsg(`Organization ${orgName} has already joined channel ${channelName}, skipping ... `);
 			} else {
 				await Channel.cli_join_org_to_channel(orgName.toLowerCase(), channelName, (fabricState.type.localeCompare('tls') === 0));
 			}
@@ -80,7 +80,7 @@ Given(/^I use the cli to deploy a (.+?) smart contract named (.+?) at version (.
 		for (const orgName of orgNames) {
 			const isInstalled: boolean = await AdminUtils.isOrgChaincodeInstalled(orgName, ccp, ccName, ccVersion);
 			if (isInstalled) {
-				BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been installed on the peers for organization ${orgName}`, undefined);
+				BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been installed on the peers for organization ${orgName}`);
 			} else {
 				await Contract.cli_chaincode_install_for_org(ccType, ccName, ccVersion, orgName.toLowerCase());
 			}
@@ -89,7 +89,7 @@ Given(/^I use the cli to deploy a (.+?) smart contract named (.+?) at version (.
 		// Instantiate
 		const isInstantiated: boolean = await AdminUtils.isChaincodeInstantiatedOnChannel(Object.keys(ccp.getOrganizations())[0], ccp, channelName, ccName, ccVersion);
 		if (isInstantiated) {
-			BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been instantiated on channel ${channelName} `, undefined);
+			BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been instantiated on channel ${channelName} `);
 		} else {
 			await Contract.cli_chaincode_instantiate(ccType, ccName, ccVersion, initArgs, channelName, policy, (fabricState.type.localeCompare('tls') === 0));
 		}
@@ -111,7 +111,7 @@ Given(/^I use the cli to lifecycle deploy a (.+?) smart contract named (.+?) at 
 		// Skip if already committed on channel
 		const isCommitted: boolean = await AdminUtils.isOrgChaincodeLifecycleCommittedOnChannel(Object.keys(ccp.getOrganizations())[0], ccp, ccName, ccReference, channelName);
 		if (isCommitted) {
-			BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been committed on channel ${channelName} as ${ccReference} `, undefined);
+			BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been committed on channel ${channelName} as ${ccReference} `);
 		} else {
 			// Package on each org
 			for (const orgName of orgNames) {
@@ -122,7 +122,7 @@ Given(/^I use the cli to lifecycle deploy a (.+?) smart contract named (.+?) at 
 			for (const orgName of orgNames) {
 				const isInstalled: boolean = await AdminUtils.isOrgChaincodeLifecycleInstalledOnChannel(orgName, ccp, ccName, channelName);
 				if (isInstalled) {
-					BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been lifecycle installed on the peers for organization ${orgName}`, undefined);
+					BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been lifecycle installed on the peers for organization ${orgName}`);
 				} else {
 					await Contract.cli_lifecycle_chaincode_install(ccName, orgName.toLowerCase());
 				}

--- a/test/ts-scenario/steps/deprecated.ts
+++ b/test/ts-scenario/steps/deprecated.ts
@@ -34,7 +34,7 @@ Given(/^I use the deprecated sdk to (.+?) a (.+?) smart contract named (.+?) at 
 		for (const orgName of Object.keys(ccp.getOrganizations())) {
 			const isInstalled: boolean = await AdminUtils.isOrgChaincodeInstalled(orgName, ccp, ccName, ccVersion);
 			if (isInstalled) {
-				BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been installed on the peers for organization ${orgName}`, undefined);
+				BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been installed on the peers for organization ${orgName}`);
 			} else {
 				await Deprecated.sdk_chaincode_install_for_org(ccType, ccName, ccVersion, ccId, tls, ccp, orgName, channelName);
 			}
@@ -43,7 +43,7 @@ Given(/^I use the deprecated sdk to (.+?) a (.+?) smart contract named (.+?) at 
 		// Instantiate
 		const isInstantiated: boolean = await AdminUtils.isChaincodeInstantiatedOnChannel(Object.keys(ccp.getOrganizations())[0], ccp, channelName, ccName, ccVersion);
 		if (isInstantiated) {
-			BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been instantiated on channel ${channelName} `, undefined);
+			BaseUtils.logMsg(`Smart contract ${ccName} at version ${ccVersion} has already been instantiated on channel ${channelName} `);
 		} else {
 			await Deprecated.sdk_chaincode_instantiate(ccName, ccType, ccVersion, ccId, initArgs, isUpgrade, tls, ccp, Constants.DEFAULT_ORG, channelName, policy);
 		}

--- a/test/ts-scenario/steps/lib/channel.ts
+++ b/test/ts-scenario/steps/lib/channel.ts
@@ -23,11 +23,11 @@ const VERBOSE_CLI: boolean = JSON.parse(Constants.CLI_VERBOSITY);
 export async function cli_channel_create(channelName: string, tls: boolean): Promise<void> {
 	try {
 		// Use CLI container to create a channel
-		BaseUtils.logMsg(`Attempting to create channel ${channelName} of type ${tls ? 'tls' : 'non-tls'}`, undefined);
+		BaseUtils.logMsg(`Attempting to create channel ${channelName} of type ${tls ? 'tls' : 'non-tls'}`);
 
 		// Do not create already existing channels
 		if (AdminUtils.isChannelCreated(channelName)) {
-			BaseUtils.logMsg(`Channel ${channelName} already exists, skipping creation`, undefined);
+			BaseUtils.logMsg(`Channel ${channelName} already exists, skipping creation`);
 			return;
 		}
 
@@ -51,7 +51,7 @@ export async function cli_channel_create(channelName: string, tls: boolean): Pro
 		await commandRunner.runShellCommand(true, createChannelCommand.join(' '), VERBOSE_CLI);
 		await BaseUtils.sleep(Constants.INC_SHORT);
 
-		BaseUtils.logMsg(`Channel ${channelName} has been created`, undefined);
+		BaseUtils.logMsg(`Channel ${channelName} has been created`);
 		AdminUtils.addToCreatedChannels(channelName);
 	} catch (err) {
 		BaseUtils.logError(`Failed to create channel ${channelName}`, err);
@@ -70,7 +70,7 @@ export async function cli_join_org_to_channel(orgName: string, channelName: stri
 
 	try {
 		// Use CLI container to join org to channel
-		BaseUtils.logMsg(`Attempting to join organization ${orgName} to channel ${channelName} of type ${tls ? 'tls' : 'non-tls'}`, undefined);
+		BaseUtils.logMsg(`Attempting to join organization ${orgName} to channel ${channelName} of type ${tls ? 'tls' : 'non-tls'}`);
 
 		let tlsOptions: string[];
 		if (tls) {
@@ -88,7 +88,7 @@ export async function cli_join_org_to_channel(orgName: string, channelName: stri
 		await commandRunner.runShellCommand(true, joinChannelCommand.join(' '), VERBOSE_CLI);
 
 		await BaseUtils.sleep(Constants.INC_SHORT);
-		BaseUtils.logMsg(`Channel ${channelName} has been joined by organization ${orgName}`, undefined);
+		BaseUtils.logMsg(`Channel ${channelName} has been joined by organization ${orgName}`);
 	} catch (err) {
 		BaseUtils.logError('Join Channel failure: ', err);
 		return Promise.reject(err);
@@ -106,10 +106,10 @@ export async function cli_channel_update(channelName: string, updateTx: string, 
 	try {
 
 		if (AdminUtils.channelHasBeenUpdated(channelName, updateTx)) {
-			BaseUtils.logMsg(`Channel ${channelName} has already been updated, skipping ...`, undefined);
+			BaseUtils.logMsg(`Channel ${channelName} has already been updated, skipping ...`);
 		} else {
 			// Use CLI container to update channel
-			BaseUtils.logMsg(`Using default CLI container ${Constants.DEFAULT_CLI_CONTAINER} to update channel ${channelName} of type ${tls ? 'tls' : 'non-tls'} with updateTx ${updateTx}`, undefined);
+			BaseUtils.logMsg(`Using default CLI container ${Constants.DEFAULT_CLI_CONTAINER} to update channel ${channelName} of type ${tls ? 'tls' : 'non-tls'} with updateTx ${updateTx}`);
 
 			let tlsOptions: string[];
 			if (tls) {
@@ -130,7 +130,7 @@ export async function cli_channel_update(channelName: string, updateTx: string, 
 			await BaseUtils.sleep(Constants.INC_SHORT);
 
 			AdminUtils.addToUpdatedChannel(channelName, updateTx);
-			BaseUtils.logMsg(`Channel ${channelName} has been updated`, undefined);
+			BaseUtils.logMsg(`Channel ${channelName} has been updated`);
 		}
 	} catch (err) {
 		BaseUtils.logError('Failed to update channels: ', (err.stack ? err.stack : err));

--- a/test/ts-scenario/steps/lib/contract.ts
+++ b/test/ts-scenario/steps/lib/contract.ts
@@ -29,7 +29,7 @@ export async function cli_chaincode_install_for_org(ccType: string, ccName: stri
 
 	try {
 		// Use CLI container to install smart contract (no TLS options required)
-		BaseUtils.logMsg(`Attempting to install smart contract ${persistName} for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Attempting to install smart contract ${persistName} for organization ${orgName} using the CLI`);
 
 		const ccPath: string = path.join('/', 'opt', 'gopath', 'src', 'github.com', 'chaincode', ccType, ccName);
 		let installCommand: string[];
@@ -44,7 +44,7 @@ export async function cli_chaincode_install_for_org(ccType: string, ccName: stri
 
 		await commandRunner.runShellCommand(true, installCommand.join(' '), VERBOSE_CLI);
 		await BaseUtils.sleep(Constants.INC_SHORT);
-		BaseUtils.logMsg(`Smart contract ${persistName} has been installed for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Smart contract ${persistName} has been installed for organization ${orgName} using the CLI`);
 	} catch (err) {
 		BaseUtils.logError(`Failed to install smart contract ${ccName} using the CLI`, err);
 		return Promise.reject(err);
@@ -65,7 +65,7 @@ export async function cli_chaincode_instantiate(ccType: string, ccName: string, 
 	try {
 		// Use CLI container to instantiate smart contract
 		const persistName: string = `${ccName}@${ccVersion}`;
-		BaseUtils.logMsg(`Attempting to instantiate smart contract ${persistName} on channel ${channelName} with args ${initArgs} using default container ${Constants.DEFAULT_CLI_CONTAINER}`, undefined);
+		BaseUtils.logMsg(`Attempting to instantiate smart contract ${persistName} on channel ${channelName} with args ${initArgs} using default container ${Constants.DEFAULT_CLI_CONTAINER}`);
 
 		let tlsOptions: string[];
 		if (tls) {
@@ -115,12 +115,12 @@ export async function cli_chaincode_instantiate(ccType: string, ccName: string, 
 			if (response.includes(`Name: ${ccName}, Version: ${ccVersion}`)) {
 				deployed = true;
 			} else {
-				BaseUtils.logMsg('Awaiting smart contract instantiation ...', undefined);
+				BaseUtils.logMsg('Awaiting smart contract instantiation ...');
 				await BaseUtils.sleep(Constants.INC_SHORT);
 			}
 		}
 		clearTimeout(timeoutId);
-		BaseUtils.logMsg(`Smart contract ${ccName} has been instantiated on channel ${channelName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Smart contract ${ccName} has been instantiated on channel ${channelName} using the CLI`);
 	} catch (err) {
 		BaseUtils.logError(`Failed to instantiate smart contract ${ccName} on channel ${channelName} using the CLI`, err);
 		return Promise.reject(err);
@@ -177,7 +177,7 @@ export async function retrievePackageIdForLabelOnOrg(label: string, orgName: str
 
 	// if it is not found in the above, throw
 	const msg: string = `Unable to find packageId for contract label ${label}`;
-	BaseUtils.logMsg(msg, undefined);
+	BaseUtils.logMsg(msg);
 	throw new Error(msg);
 }
 
@@ -191,7 +191,7 @@ export async function cli_lifecycle_chaincode_package(ccType: string, ccName: st
 
 	try {
 		// Use CLI container to package smart contract (no TLS options required)
-		BaseUtils.logMsg(`Attempting lifecyle package of smart contract ${ccName} for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Attempting lifecyle package of smart contract ${ccName} for organization ${orgName} using the CLI`);
 
 		const ccPath: string = path.join('/', 'opt', 'gopath', 'src', 'github.com', 'chaincode', ccType, ccName);
 		let packageCommand: string[];
@@ -205,7 +205,7 @@ export async function cli_lifecycle_chaincode_package(ccType: string, ccName: st
 
 		await commandRunner.runShellCommand(true, packageCommand.join(' '), VERBOSE_CLI);
 		await BaseUtils.sleep(Constants.INC_SHORT);
-		BaseUtils.logMsg(`Smart contract ${ccName} has been packaged for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Smart contract ${ccName} has been packaged for organization ${orgName} using the CLI`);
 	} catch (err) {
 		BaseUtils.logError(`Failed to package smart contract ${ccName} using the CLI`, err);
 		return Promise.reject(err);
@@ -220,7 +220,7 @@ export async function cli_lifecycle_chaincode_package(ccType: string, ccName: st
 export async function cli_lifecycle_chaincode_install(packageName: string, orgName: string): Promise<void> {
 	try {
 		// Use CLI container to package smart contract (no TLS options required)
-		BaseUtils.logMsg(`Attempting lifecycle install of smart contract package ${packageName} for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Attempting lifecycle install of smart contract package ${packageName} for organization ${orgName} using the CLI`);
 
 		let installCommand: string[];
 		installCommand = [
@@ -231,7 +231,7 @@ export async function cli_lifecycle_chaincode_install(packageName: string, orgNa
 
 		await commandRunner.runShellCommand(true, installCommand.join(' '), VERBOSE_CLI);
 		await BaseUtils.sleep(Constants.INC_SHORT);
-		BaseUtils.logMsg(`Smart contract package ${packageName} has been installed for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Smart contract package ${packageName} has been installed for organization ${orgName} using the CLI`);
 	} catch (err) {
 		BaseUtils.logError(`Failed to install smart contract package ${packageName} using the CLI`, err);
 		return Promise.reject(err);
@@ -251,7 +251,7 @@ export async function cli_lifecycle_chaincode_install(packageName: string, orgNa
 export async function cli_lifecycle_chaincode_approve(ccReference: string, ccVersion: string, orgName: string, channelName: string, packageId: string, sequence: string, tls: boolean): Promise<void> {
 	try {
 		// Use CLI container to package smart contract
-		BaseUtils.logMsg(`Attempting lifecycle approve of smart contract with reference ${ccReference} for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Attempting lifecycle approve of smart contract with reference ${ccReference} for organization ${orgName} using the CLI`);
 
 		let approveCommand: string[];
 		approveCommand = [
@@ -270,7 +270,7 @@ export async function cli_lifecycle_chaincode_approve(ccReference: string, ccVer
 
 		await commandRunner.runShellCommand(true, approveCommand.join(' '), VERBOSE_CLI);
 		await BaseUtils.sleep(Constants.INC_SHORT);
-		BaseUtils.logMsg(`Smart contract with reference ${ccReference} has been approved for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Smart contract with reference ${ccReference} has been approved for organization ${orgName} using the CLI`);
 	} catch (err) {
 		BaseUtils.logError(`Failed to approve smart contract with reference ${ccReference} using the CLI`, err);
 		return Promise.reject(err);
@@ -290,7 +290,7 @@ export async function cli_lifecycle_chaincode_approve(ccReference: string, ccVer
 export async function cli_lifecycle_chaincode_commit(ccReference: string, ccVersion: string, orgName: string, channelName: string, ccp: CommonConnectionProfileHelper, sequence: string, tls: boolean): Promise<void> {
 	try {
 		// Use CLI container to commit smart contract
-		BaseUtils.logMsg(`Attempting lifecycle commit of smart contract with reference ${ccReference} for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Attempting lifecycle commit of smart contract with reference ${ccReference} for organization ${orgName} using the CLI`);
 
 		const ordererName: string = ccp.getOrderersForChannel(channelName)[0];
 		const ordererUrl: string = ccp.getOrderer(ordererName).url;
@@ -318,7 +318,7 @@ export async function cli_lifecycle_chaincode_commit(ccReference: string, ccVers
 
 		await commandRunner.runShellCommand(true, commitCommand.join(' '), VERBOSE_CLI);
 		await BaseUtils.sleep(Constants.INC_SHORT);
-		BaseUtils.logMsg(`Smart contract with reference ${ccReference} has been committed for organization ${orgName} using the CLI`, undefined);
+		BaseUtils.logMsg(`Smart contract with reference ${ccReference} has been committed for organization ${orgName} using the CLI`);
 	} catch (err) {
 		BaseUtils.logError(`Failed to commit smart contract with reference ${ccReference} using the CLI`, err);
 		return Promise.reject(err);

--- a/test/ts-scenario/steps/lib/deprecatedSDK.ts
+++ b/test/ts-scenario/steps/lib/deprecatedSDK.ts
@@ -85,7 +85,7 @@ export async function sdk_chaincode_install_for_org(ccType: 'golang' | 'car' | '
 			targets,
 		};
 
-		BaseUtils.logMsg(`Using deprecated API to install chaincode with ID ${chaincodeId}@${ccVersion} on organization ${orgName} peers [${ccp.getPeersForOrganization(orgName).toString()}] ...`, undefined);
+		BaseUtils.logMsg(`Using deprecated API to install chaincode with ID ${chaincodeId}@${ccVersion} on organization ${orgName} peers [${ccp.getPeersForOrganization(orgName).toString()}] ...`);
 
 		const results: Client.ProposalResponseObject = await client.installChaincode(request as any);
 
@@ -108,7 +108,7 @@ export async function sdk_chaincode_install_for_org(ccType: 'golang' | 'car' | '
 		if (!proposalResponsesValid) {
 			throw new Error(`Failed to send install Proposal or receive valid response when using deprecated API: ${JSON.stringify(errors)}`);
 		} else {
-			BaseUtils.logMsg(`Successfully installed chaincode with ID ${chaincodeId}@${ccVersion} using deprecated API`, undefined);
+			BaseUtils.logMsg(`Successfully installed chaincode with ID ${chaincodeId}@${ccVersion} using deprecated API`);
 			return await BaseUtils.sleep(Constants.INC_SHORT);
 		}
 	} catch (err) {
@@ -173,7 +173,7 @@ export async function sdk_chaincode_instantiate(ccName: string, ccType: 'golang'
 	);
 
 	try {
-		BaseUtils.logMsg(`Using deprecated API to perform ${type} transaction on chaincode with ID ${chaincodeId}@${ccVersion} as organization ${orgName} ...`, undefined);
+		BaseUtils.logMsg(`Using deprecated API to perform ${type} transaction on chaincode with ID ${chaincodeId}@${ccVersion} as organization ${orgName} ...`);
 		// set user to send install chaincode requests
 		await AdminUtils.getSubmitter(client, true /* get peer org admin */, orgName, ccp);
 
@@ -234,7 +234,7 @@ export async function sdk_chaincode_instantiate(ccName: string, ccType: 'golang'
 					clearTimeout(handle);
 					if (code !== 'VALID') {
 						const msg: string = `The chaincode ${type} transaction was invalid, code = ${code}`;
-						BaseUtils.logError(msg, undefined);
+						BaseUtils.logError(msg);
 						reject(msg);
 					} else {
 						resolve();
@@ -242,7 +242,7 @@ export async function sdk_chaincode_instantiate(ccName: string, ccType: 'golang'
 				}, (err: Error) => {
 					clearTimeout(handle);
 					const msg: string = `There was a problem with the ${type} transaction event: ${JSON.stringify(err)}`;
-					BaseUtils.logError(msg, undefined);
+					BaseUtils.logError(msg);
 					reject(msg);
 				}, {
 					disconnect: true,
@@ -254,11 +254,11 @@ export async function sdk_chaincode_instantiate(ccName: string, ccType: 'golang'
 
 		const eventResults: any[] = await Promise.all(eventPromises) ;
 		if (eventResults && !(eventResults[0] instanceof Error) && (eventResults[0].status === 'SUCCESS')) {
-			BaseUtils.logMsg(`Successfully performed ${type} transaction on chaincode with ID ${chaincodeId}@${ccVersion} using deprecated API`, undefined);
+			BaseUtils.logMsg(`Successfully performed ${type} transaction on chaincode with ID ${chaincodeId}@${ccVersion} using deprecated API`);
 			return await BaseUtils.sleep(Constants.INC_SHORT);
 		} else {
 			const msg: string = `Failed to order the ${type} transaction using deprecated API. Error code: ${eventResults[0].status}`;
-			BaseUtils.logError(msg, undefined);
+			BaseUtils.logError(msg);
 			throw new Error(msg);
 		}
 	} catch (err) {

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -57,7 +57,7 @@ export async function createGateway(ccp: CommonConnectionProfileHelper, tls: boo
 	const myWalletReference: string = `${Constants.WALLET}_walletType`;
 	let wallet: Wallet = stateStore.get(myWalletReference);
 	if (!wallet) {
-		BaseUtils.logMsg(`Creating wallet of type ${walletType}`, undefined);
+		BaseUtils.logMsg(`Creating wallet of type ${walletType}`);
 		switch (walletType) {
 			case Constants.MEMORY_WALLET:
 				wallet = await Wallets.newInMemoryWallet();
@@ -87,7 +87,7 @@ export async function createGateway(ccp: CommonConnectionProfileHelper, tls: boo
 
 	if (userIdentity) {
 		// We have an identity to use
-		BaseUtils.logMsg(`Identity ${userId} already exists in wallet and will be used`, undefined);
+		BaseUtils.logMsg(`Identity ${userId} already exists in wallet and will be used`);
 	} else {
 		await identitySetup(wallet, ccp, orgName, userName);
 
@@ -125,7 +125,7 @@ export async function createGateway(ccp: CommonConnectionProfileHelper, tls: boo
 		gateway,
 	};
 	addGatewayObjectToStateStore(gatewayName, gatewayObj);
-	BaseUtils.logMsg(`Gateway ${gatewayName} connected`, undefined);
+	BaseUtils.logMsg(`Gateway ${gatewayName} connected`);
 }
 
 function addGatewayObjectToStateStore(gatewayName: string, gateway: any): void {
@@ -189,7 +189,7 @@ async function identitySetup(wallet: Wallet, ccp: CommonConnectionProfileHelper,
 		type: 'X.509',
 	};
 
-	BaseUtils.logMsg(`Adding identity for ${identityName} to wallet`, undefined);
+	BaseUtils.logMsg(`Adding identity for ${identityName} to wallet`);
 	await wallet.put(identityName, identity);
 }
 
@@ -226,20 +226,20 @@ export async function performGatewayTransaction(gatewayName: string, contractNam
 	const funcArgs: string[] = argArray.slice(1);
 	try {
 		if (submit) {
-			BaseUtils.logMsg('Submitting transaction [' + func + '] with arguments ' + args, undefined);
+			BaseUtils.logMsg('Submitting transaction [' + func + '] with arguments ' + args);
 			const result: Buffer = await contract.submitTransaction(func, ...funcArgs);
 			gatewayObj.result = {type: 'submit', response: result.toString()};
-			BaseUtils.logMsg('Successfully submitted transaction [' + func + ']', undefined);
+			BaseUtils.logMsg('Successfully submitted transaction [' + func + ']');
 		} else {
-			BaseUtils.logMsg('Evaluating transaction [' + func + '] with arguments ' + args, undefined);
+			BaseUtils.logMsg('Evaluating transaction [' + func + '] with arguments ' + args);
 			const result: Buffer = await contract.evaluateTransaction(func, ...funcArgs);
-			BaseUtils.logMsg('Successfully evaluated transaction [' + func  + '] with result [' + result.toString() + ']', undefined);
+			BaseUtils.logMsg('Successfully evaluated transaction [' + func  + '] with result [' + result.toString() + ']');
 			gatewayObj.result = {type: 'evaluate', response: JSON.parse(result.toString())};
 		}
 	} catch (err) {
 		gatewayObj.result = {type: 'error', response: err.toString()};
 		// Don't log the full error, since we might be forcing the error
-		BaseUtils.logError(err.toString(), undefined);
+		BaseUtils.logError(err.toString());
 	}
 }
 
@@ -336,10 +336,10 @@ export async function performHandledGatewayTransaction(gatewayName: string, ccNa
 		try {
 			// Split args, do not capture response
 			await transaction.submit(...funcArgs);
-			BaseUtils.logMsg(`Successfully submitted transaction [${func}] using handler [${EventStrategies[handlerOption]}]`, undefined);
+			BaseUtils.logMsg(`Successfully submitted transaction [${func}] using handler [${EventStrategies[handlerOption]}]`);
 		} catch (error) {
 			gatewayObj.result = {type: 'error', response: error.toString()};
-			BaseUtils.logError(error.toString(), undefined);
+			BaseUtils.logError(error.toString());
 		}
 
 		// Record result on gateway object
@@ -355,11 +355,11 @@ export async function performHandledGatewayTransaction(gatewayName: string, ccNa
 		try {
 			// Split args, capture response
 			const result: Buffer = await transaction.evaluate(...funcArgs);
-			BaseUtils.logMsg(`Successfully evaluated transaction [${func}] using handler [${QueryStrategies[handlerOption]}] with result [${result}]`, undefined);
+			BaseUtils.logMsg(`Successfully evaluated transaction [${func}] using handler [${QueryStrategies[handlerOption]}] with result [${result}]`);
 			gatewayObj.result = {type: 'evaluate', response: JSON.parse(result.toString())};
 		} catch (error) {
 			gatewayObj.result = {type: 'error', response: error.toString()};
-			BaseUtils.logError(error.toString(), undefined);
+			BaseUtils.logError(error.toString());
 		}
 	}
 }
@@ -407,16 +407,16 @@ export async function performTransientGatewayTransaction(gatewayName: string, cc
 		const submit: boolean = ( txnType.localeCompare('submit') === 0 );
 		if (submit) {
 			const result: Buffer = await transaction.setTransient(transientMap).submit();
-			BaseUtils.logMsg(`Successfully submitted transaction [${func}] with transient data`, undefined);
+			BaseUtils.logMsg(`Successfully submitted transaction [${func}] with transient data`);
 			gatewayObj.result = {type: 'submit', response: JSON.parse(result.toString())};
 		} else {
 			const result: Buffer = await transaction.setTransient(transientMap).evaluate();
-			BaseUtils.logMsg(`Successfully evaluated transaction [${func}] with transient data`, undefined);
+			BaseUtils.logMsg(`Successfully evaluated transaction [${func}] with transient data`);
 			gatewayObj.result = {type: 'evaluate', response: JSON.parse(result.toString())};
 		}
 	} catch (error) {
 		gatewayObj.result = {type: 'error', response: error.toString()};
-		BaseUtils.logError(error.toString(), undefined);
+		BaseUtils.logError(error.toString());
 	}
 }
 
@@ -429,7 +429,7 @@ export async function performTransientGatewayTransaction(gatewayName: string, cc
  */
 export async function retrieveContractFromGateway(gateway: Gateway, channelName: string, contractId: string): Promise<Contract> {
 	try {
-		BaseUtils.logMsg(`Retrieving contract from channel ${channelName}`, undefined);
+		BaseUtils.logMsg(`Retrieving contract from channel ${channelName}`);
 		const network: Network = await gateway.getNetwork(channelName);
 		const contract: Contract = network.getContract(contractId);
 		return contract;

--- a/test/ts-scenario/steps/lib/listeners.ts
+++ b/test/ts-scenario/steps/lib/listeners.ts
@@ -46,7 +46,7 @@ export async function createContractListener(gatewayName: string, channelName: s
 			BaseUtils.logMsg('-> Detected a contract event error', err);
 			throw err;
 		} else {
-			BaseUtils.logMsg(`-> Received a contract event for listener [${listenerName}] of type ${eventName}`, undefined);
+			BaseUtils.logMsg(`-> Received a contract event for listener [${listenerName}] of type ${eventName}`);
 		}
 
 		if (!filtered) {
@@ -222,7 +222,7 @@ export async function checkListenerCallNumber(listenerName: string, compareNumbe
 				BaseUtils.logAndThrow(msg);
 			} else {
 				const msg: string = `Verified that the listener was called exactly ${compareNumber} times`;
-				BaseUtils.logMsg(msg, undefined);
+				BaseUtils.logMsg(msg);
 			}
 			break;
 		case Constants.GREATER_THAN:
@@ -230,7 +230,7 @@ export async function checkListenerCallNumber(listenerName: string, compareNumbe
 				throw new Error(`Expected ${listenerName} to be called a minimum ${compareNumber} times, but called ${gatewayListenerCalls} times`);
 			} else {
 				const msg: string = `Verified that the listener was called at least ${compareNumber} times`;
-				BaseUtils.logMsg(msg, undefined);
+				BaseUtils.logMsg(msg);
 			}
 			break;
 		case Constants.LESS_THAN:
@@ -238,7 +238,7 @@ export async function checkListenerCallNumber(listenerName: string, compareNumbe
 					throw new Error(`Expected ${listenerName} to be called a maximum ${compareNumber} times, but called ${gatewayListenerCalls} times`);
 				} else {
 					const msg: string = `Verified that the listener was called a maximum ${compareNumber} times`;
-					BaseUtils.logMsg(msg, undefined);
+					BaseUtils.logMsg(msg);
 				}
 				break;
 		default:

--- a/test/ts-scenario/steps/lib/utility/adminUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/adminUtils.ts
@@ -194,7 +194,7 @@ export async function assignOrgAdmin(client: Client, orgName: string, ccp: Commo
  * @param chaincodeVersion the version of the contract
  */
 export async function isOrgChaincodeInstalled(orgName: string, ccp: CommonConnectionProfileHelper, chaincodeName: string, chaincodeVersion: string): Promise<boolean> {
-	BaseUtils.logMsg(`Checking if smart contract ${chaincodeName} at version ${chaincodeVersion} has been installed`, undefined);
+	BaseUtils.logMsg(`Checking if smart contract ${chaincodeName} at version ${chaincodeVersion} has been installed`);
 	const clientPath: string = path.join(__dirname, Constants.UTIL_TO_CONFIG, orgName + '.json');
 	const orgClient: Client = await Client.loadFromConfig(clientPath);
 
@@ -204,7 +204,7 @@ export async function isOrgChaincodeInstalled(orgName: string, ccp: CommonConnec
 	// Get the first target peer for our org
 	const peer: Client.Peer = orgClient.getPeersForOrg(orgName + 'MSP')[0];
 
-	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known chaincode`, undefined);
+	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known chaincode`);
 	const message: Client.ChaincodeQueryResponse = await orgClient.queryInstalledChaincodes(peer, true);
 
 	// loop over message array if present
@@ -220,7 +220,7 @@ export async function isOrgChaincodeInstalled(orgName: string, ccp: CommonConnec
 }
 
 export async function isOrgChaincodeLifecycleInstalledOnChannel(orgName: string, ccp: CommonConnectionProfileHelper, chaincodeName: string, channelName: string): Promise<boolean> {
-	BaseUtils.logMsg(`Checking if smart contract ${chaincodeName} has been installed`, undefined);
+	BaseUtils.logMsg(`Checking if smart contract ${chaincodeName} has been installed`);
 	const clientPath: string = path.join(__dirname, Constants.UTIL_TO_CONFIG, orgName + '.json');
 	const orgClient: Client = await Client.loadFromConfig(clientPath);
 
@@ -231,7 +231,7 @@ export async function isOrgChaincodeLifecycleInstalledOnChannel(orgName: string,
 	const channel: Client.Channel = orgClient.getChannel(channelName);
 	const peer: Client.Peer = orgClient.getPeersForOrg(orgName + 'MSP')[0];
 
-	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known chaincode`, undefined);
+	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known chaincode`);
 	const installedRequests: Client.QueryInstalledChaincodesRequest = {
 		target: peer,
 		txId: orgClient.newTransactionID(true),
@@ -251,7 +251,7 @@ export async function isOrgChaincodeLifecycleInstalledOnChannel(orgName: string,
 }
 
 export async function isOrgChaincodeLifecycleCommittedOnChannel(orgName: string, ccp: CommonConnectionProfileHelper, chaincodeName: string, deployedAs: string, channelName: string): Promise<boolean> {
-	BaseUtils.logMsg(`Checking if smart contract has been committed to channel ${channelName} as ${deployedAs}`, undefined);
+	BaseUtils.logMsg(`Checking if smart contract has been committed to channel ${channelName} as ${deployedAs}`);
 	const clientPath: string = path.join(__dirname, Constants.UTIL_TO_CONFIG, orgName + '.json');
 	const orgClient: Client = await Client.loadFromConfig(clientPath);
 
@@ -262,7 +262,7 @@ export async function isOrgChaincodeLifecycleCommittedOnChannel(orgName: string,
 	const channel: Client.Channel = orgClient.getChannel(channelName);
 	const peer: Client.Peer = orgClient.getPeersForOrg(orgName + 'MSP')[0];
 
-	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known chaincode`, undefined);
+	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known chaincode`);
 	const installedRequests: Client.QueryInstalledChaincodesRequest = {
 		target: peer,
 		txId: orgClient.newTransactionID(true),
@@ -296,7 +296,7 @@ export async function isOrgChaincodeLifecycleCommittedOnChannel(orgName: string,
  * @param chaincodeVersion the version of the contract
  */
 export async function isChaincodeInstantiatedOnChannel(orgName: string, ccp: CommonConnectionProfileHelper, channelName: string, chaincodeName: string, chaincodeVersion: string): Promise<boolean> {
-	BaseUtils.logMsg(`Checking if smart contract ${chaincodeName} has been instantiated on channel ${channelName}`, undefined);
+	BaseUtils.logMsg(`Checking if smart contract ${chaincodeName} has been instantiated on channel ${channelName}`);
 	const clientPath: string = path.join(__dirname, Constants.UTIL_TO_CONFIG, orgName + '.json');
 	const orgClient: Client = await Client.loadFromConfig(clientPath);
 
@@ -307,7 +307,7 @@ export async function isChaincodeInstantiatedOnChannel(orgName: string, ccp: Com
 	const channel: Client.Channel = orgClient.getChannel(channelName);
 	const peer: Client.Peer = orgClient.getPeersForOrg(orgName + 'MSP')[0];
 
-	BaseUtils.logMsg(`Querying channel ${channel.getName()} for instantiated chaincode`, undefined);
+	BaseUtils.logMsg(`Querying channel ${channel.getName()} for instantiated chaincode`);
 	const message: Client.ChaincodeQueryResponse = await channel.queryInstantiatedChaincodes(peer, true);
 
 	// loop over message array if present
@@ -333,7 +333,7 @@ export async function performChannelQueryOperation(queryOperation: string, chann
 	const channel: Client.Channel = orgClient.getChannel(channelName);
 	const peer: Client.Peer = orgClient.getPeersForOrg(orgName + 'MSP')[0];
 
-	BaseUtils.logMsg(`Performing query operation ${queryOperation} on channel ${channel.getName()}`, undefined);
+	BaseUtils.logMsg(`Performing query operation ${queryOperation} on channel ${channel.getName()}`);
 
 	switch (queryOperation) {
 		case 'queryInfo':
@@ -420,7 +420,7 @@ export async function isOrgChannelJoined(orgName: string, ccp: CommonConnectionP
 	// Get the first target peer for our org
 	const peer: Client.Peer = orgClient.getPeersForOrg(orgName + 'MSP')[0];
 
-	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known channels`, undefined);
+	BaseUtils.logMsg(`Querying peer ${peer.getName()} for known channels`);
 	const message: Client.ChannelQueryResponse = await orgClient.queryChannels(peer, true);
 
 	// loop over message array if present

--- a/test/ts-scenario/steps/lib/utility/baseUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/baseUtils.ts
@@ -19,28 +19,28 @@ export function sleep(ms: number): Promise<void> {
 	return new Promise((resolve: any): any => setTimeout(resolve, ms));
 }
 
-export function logMsg(msg: string, obj: any): void {
-	if (obj) {
-		// tslint:disable-next-line:no-console
-		console.log(msg, obj);
-	} else {
+export function logMsg(msg: string, obj?: any): void {
+	if (typeof obj === 'undefined') {
 		// tslint:disable-next-line:no-console
 		console.log(msg);
+	} else {
+		// tslint:disable-next-line:no-console
+		console.log(msg, obj);
 	}
 }
 
-export function logError(msg: string, obj: any): void {
-	if (obj) {
-		// tslint:disable-next-line:no-console
-		console.error(msg, obj);
-	} else {
+export function logError(msg: string, obj?: any): void {
+	if (typeof obj === 'undefined') {
 		// tslint:disable-next-line:no-console
 		console.error(msg);
+	} else {
+		// tslint:disable-next-line:no-console
+		console.error(msg, obj);
 	}
 }
 
 export function logAndThrow(msg: any): Error {
-	logError(msg, undefined);
+	logError(msg);
 	if (msg instanceof Error) {
 		throw msg;
 	} else {
@@ -54,7 +54,7 @@ export function checkString(actual: string, expected: string, enableThrow: boole
 		if (enableThrow) {
 			logAndThrow(msg);
 		} else {
-			logError(msg, undefined);
+			logError(msg);
 		}
 	}
 }
@@ -65,7 +65,7 @@ export function checkProperty(object: any, expectedProperty: string, enableThrow
 		if (enableThrow) {
 			logAndThrow(msg);
 		} else {
-			logError(msg, undefined);
+			logError(msg);
 		}
 	}
 }
@@ -76,7 +76,7 @@ export function checkSizeEquality(item0: number, item1: number, greaterThan: boo
 		if (enableThrow) {
 			logAndThrow(msg);
 		} else {
-			logError(msg, undefined);
+			logError(msg);
 		}
 	}
 
@@ -85,7 +85,7 @@ export function checkSizeEquality(item0: number, item1: number, greaterThan: boo
 		if (enableThrow) {
 			logAndThrow(msg);
 		} else {
-			logError(msg, undefined);
+			logError(msg);
 		}
 	}
 }
@@ -112,11 +112,11 @@ export function logScenarioStart(featureType: string): void {
 		stateStore.set(Constants.FEATURES, features);
 	}
 
-	logMsg('\n\n\n**********************************************************************************', undefined);
-	logMsg('**********************************************************************************', undefined);
-	logMsg(`****** ${featureType} Scenario ${counter} ******`, undefined);
-	logMsg('**********************************************************************************', undefined);
-	logMsg('**********************************************************************************\n\n\n', undefined);
+	logMsg('\n\n\n**********************************************************************************');
+	logMsg('**********************************************************************************');
+	logMsg(`****** ${featureType} Scenario ${counter} ******`);
+	logMsg('**********************************************************************************');
+	logMsg('**********************************************************************************\n\n\n');
 }
 
 export function recursiveDirDelete(dirPath: string): void {

--- a/test/ts-scenario/steps/lib/utility/clientUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/clientUtils.ts
@@ -22,9 +22,9 @@ export async function createAdminClient(clientName: string, ccp: CommonConnectio
 	const clientMap: Map<string, any> | undefined = stateStore.get(Constants.CLIENTS);
 
 	if (clientMap && clientMap.has(clientName)) {
-		BaseUtils.logMsg(`Client named ${clientName} already exists`, undefined);
+		BaseUtils.logMsg(`Client named ${clientName} already exists`);
 	} else {
-		BaseUtils.logMsg(`Creating client named ${clientName} for organization ${clientOrg}`, undefined);
+		BaseUtils.logMsg(`Creating client named ${clientName} for organization ${clientOrg}`);
 
 		// Get a user
 		const user: User = createAdminUserForOrg(ccp, clientOrg);
@@ -42,7 +42,7 @@ export async function createAdminClient(clientName: string, ccp: CommonConnectio
 			map.set(clientName, { client, user, ccp, clientOrg });
 			stateStore.set(Constants.CLIENTS, map);
 		}
-		BaseUtils.logMsg(`Created client named ${clientName} and persisted in state store`, undefined);
+		BaseUtils.logMsg(`Created client named ${clientName} and persisted in state store`);
 	}
 }
 
@@ -50,7 +50,7 @@ export function createChannelWithClient(clientName: string, channelName: string)
 	const clientObject: any = retrieveClientObject(clientName);
 	// Does this client have a channel associated?
 	if (clientObject.channels && clientObject.channels.has(channelName)) {
-		BaseUtils.logMsg(`Client channel named ${channelName} already exists`, undefined);
+		BaseUtils.logMsg(`Client channel named ${channelName} already exists`);
 	} else {
 		// Build channel and append to client channels map
 		const channel: Channel = (clientObject.client as Client).newChannel(channelName);
@@ -62,7 +62,7 @@ export function createChannelWithClient(clientName: string, channelName: string)
 			channelMap.set(channelName, channel);
 			clientObject.channels = channelMap;
 		}
-		BaseUtils.logMsg(`Channel ${channelName} has been persisted with client ${clientName}`, undefined);
+		BaseUtils.logMsg(`Channel ${channelName} has been persisted with client ${clientName}`);
 	}
 }
 
@@ -72,7 +72,7 @@ export function retrieveClientObject(clientName: string): any {
 		return clientMap.get(clientName);
 	} else {
 		const msg: string = `Required client named ${clientName} does not exist`;
-		BaseUtils.logMsg(msg, undefined);
+		BaseUtils.logMsg(msg);
 		throw new Error(msg);
 	}
 }
@@ -124,7 +124,7 @@ export async function buildChannelRequest(requestName: string, contractName: str
 
 			const connectionOk: boolean = await peer.checkConnection();
 			if (connectionOk) {
-				BaseUtils.logMsg('Peer checkConnection test successfully', undefined);
+				BaseUtils.logMsg('Peer checkConnection test successfully');
 			} else {
 				BaseUtils.logAndThrow('Peer checkConnection test failed');
 			}
@@ -192,7 +192,7 @@ export async function commitChannelRequest(requestName: string, clientName: stri
 			const endorsementResponse: ProposalResponse = await endorsement.send(endorsementRequest);
 			if (endorsementResponse.errors) {
 				for (const error of endorsementResponse.errors) {
-					BaseUtils.logMsg(`Failed to get endorsement : ${error.message}`, undefined);
+					BaseUtils.logMsg(`Failed to get endorsement : ${error.message}`);
 				}
 				throw Error('failed endorsement');
 			}
@@ -201,13 +201,13 @@ export async function commitChannelRequest(requestName: string, clientName: stri
 			try {
 				await eventer.connect(endpoints[0], {});
 				if (await eventer.checkConnection()) {
-					BaseUtils.logMsg('Eventer checkConnection test successfully', undefined);
+					BaseUtils.logMsg('Eventer checkConnection test successfully');
 				} else {
 					BaseUtils.logAndThrow('Eventer checkConnection test failed');
 				}
 			} catch (error) {
-				BaseUtils.logError(`Failed to connect to channel event hub ${eventer.toString()}`, undefined);
-				BaseUtils.logError(`Failed to connect ${error.stack}`, undefined);
+				BaseUtils.logError(`Failed to connect to channel event hub ${eventer.toString()}`);
+				BaseUtils.logError(`Failed to connect ${error.stack}`);
 				throw error;
 			}
 
@@ -307,7 +307,7 @@ export async function commitChannelRequest(requestName: string, clientName: stri
 			}
 			orderer.disconnect();
 			eventer.disconnect();
-			BaseUtils.logMsg(`Disconnected all endpoints for client object ${clientName} and request ${requestName}`, undefined);
+			BaseUtils.logMsg(`Disconnected all endpoints for client object ${clientName} and request ${requestName}`);
 		}
 	} else {
 		BaseUtils.logAndThrow(`Request named ${requestName} does not exits on client object for client ${clientName}`);
@@ -350,7 +350,7 @@ export async function submitChannelRequest(clientName: string, channelName: stri
 
 			const connectionOk: boolean = await peer.checkConnection();
 			if (connectionOk) {
-				BaseUtils.logMsg('Peer checkConnection test successfully', undefined);
+				BaseUtils.logMsg('Peer checkConnection test successfully');
 			} else {
 				BaseUtils.logAndThrow('Peer checkConnection test failed');
 			}
@@ -382,7 +382,7 @@ export async function submitChannelRequest(clientName: string, channelName: stri
 
 				if (queryResponse.errors) {
 					// failure
-					BaseUtils.logMsg(`Query failure detected`, undefined);
+					BaseUtils.logMsg(`Query failure detected`);
 					queryObject.results = {
 						general: JSON.stringify({
 							result: 'FAILURE'
@@ -395,7 +395,7 @@ export async function submitChannelRequest(clientName: string, channelName: stri
 					}
 				} else {
 					// Success
-					BaseUtils.logMsg(`Query success detected`, undefined);
+					BaseUtils.logMsg(`Query success detected`);
 					queryObject.results = {
 						general: JSON.stringify({
 							result: 'SUCCESS'

--- a/test/ts-scenario/steps/network-model.ts
+++ b/test/ts-scenario/steps/network-model.ts
@@ -22,12 +22,12 @@ Given(/^I have a (.+?) backed gateway named (.+?) with discovery set to (.+?) fo
 	const tls: boolean = (fabricState.type.localeCompare('tls') === 0);
 
 	if (gateways && gateways.has(gatewayName)) {
-		BaseUtils.logMsg(`Gateway named ${gatewayName} already exists`, undefined);
+		BaseUtils.logMsg(`Gateway named ${gatewayName} already exists`);
 		return;
 	} else {
 		try {
 			// Create and persist the new gateway
-			BaseUtils.logMsg(`Creating new Gateway named ${gatewayName}`, undefined);
+			BaseUtils.logMsg(`Creating new Gateway named ${gatewayName}`);
 			const profilePath: string = path.join(__dirname, '../config', ccpName);
 			const ccp: CommonConnectionProfileHelper = new CommonConnectionProfileHelper(profilePath, true);
 			return await Gateway.createGateway(ccp, tls, userName, Constants.DEFAULT_ORG, gatewayName, JSON.parse(useDiscovery), walletType);

--- a/tslint.json
+++ b/tslint.json
@@ -45,17 +45,6 @@
             "check-separator",
             "check-type"
         ],
-        "no-floating-promises": true,
-        "typedef": [
-            true,
-            "call-signature",
-            "arrow-call-signature",
-            "parameter",
-            "arrow-parameter",
-            "property-declaration",
-            "variable-declaration",
-            "member-variable-declaration",
-            "array-destructuring"
-        ]
+        "no-floating-promises": true
     }
 }


### PR DESCRIPTION
Concurrency issue in the tests where they did not wait for peers to
commit lifecycle operations, which they would later use to query
status of those lifecycle operations.

Changed test code to wait for commit events from all network peers
before proceeding when performing lifecycle operations.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>