### PR TITLE
[FABN-1430] Fix type for IServiceResponse

### DIFF
--- a/fabric-ca-client/types/index.d.ts
+++ b/fabric-ca-client/types/index.d.ts
@@ -133,10 +133,10 @@ declare namespace FabricCAServices {
     }
 
     export interface IServiceResponse {
-        Success: boolean;
-        Result: any;
-        Errors: IServiceResponseMessage[];
-        Messages: IServiceResponseMessage[];
+        success: boolean;
+        result: any;
+        errors: IServiceResponseMessage[];
+        messages: IServiceResponseMessage[];
     }
 
     export interface IAffiliationRequest {


### PR DESCRIPTION
JIRA: https://jira.hyperledger.org/browse/FABN-1430

The names of the members of IServiceResponse should start with small
letters as per lib/serverendpoint.go in fabric-ca.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>
