### PR TITLE
FABN-1386: Import npm credentials in build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ pool:
 
 variables:
 - group: credentials
+- group: npm
 - name: SOFTHSM2_CONF
   value: "$(Build.Repository.LocalPath)/test/fixtures/hsm/softhsm2.conf"
 


### PR DESCRIPTION
npm credentials must be imported to allow publishing to npm as part
of the merge builds.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>