### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Fabric SDK Node maintainers
-*	@andrew-coleman @christo4ferris @JonathanLevi @harrisob @mastersingh24 @smithbk @zhaochy1990 @bestbeforetoday
+*	@hyperledger/fabric-sdk-node-maintainers


### PR DESCRIPTION
Point to the GitHub group instead of directly
to people.

Signed-off-by: Ry Jones <ry@linux.com>