### PR TITLE
FABN-1444: Better errors for missing identities

### DIFF
--- a/fabric-network/src/gateway.js
+++ b/fabric-network/src/gateway.js
@@ -211,19 +211,27 @@ class Gateway {
 		// setup an initial identity for the Gateway
 		if (options.identity) {
 			logger.debug('%s - setting identity', method);
-			const identity = await options.wallet.get(options.identity);
+			const identity = await this._getIdentity(options.identity);
 			const provider = options.wallet.getProviderRegistry().getProvider(identity.type);
 			await provider.setUserContext(this.client, identity, options.identity);
 		}
 
 		if (options.clientTlsIdentity) {
-			const tlsIdentity = await options.wallet.get(options.clientTlsIdentity);
+			const tlsIdentity = await this._getIdentity(options.clientTlsIdentity);
 			this.client.setTlsClientCertAndKey(tlsIdentity.credentials.certificate, tlsIdentity.credentials.privateKey);
 		}
 
 		if (options.tlsInfo && !options.clientTlsIdentity) {
 			this.client.setTlsClientCertAndKey(options.tlsInfo.certificate, options.tlsInfo.key);
 		}
+	}
+
+	async _getIdentity(label) {
+		const identity = await this.options.wallet.get(label);
+		if (!identity) {
+			throw new Error(`Identity not found in wallet: ${label}`);
+		}
+		return identity;
 	}
 
 	/**

--- a/fabric-network/test/gateway.js
+++ b/fabric-network/test/gateway.js
@@ -299,7 +299,6 @@ describe('Gateway', () => {
 			sinon.assert.calledWith(mockClient.setTlsClientCertAndKey, 'acert', 'akey');
 		});
 
-
 		it('should connect from an existing client object', async () => {
 			const options = {
 				wallet,
@@ -334,6 +333,25 @@ describe('Gateway', () => {
 			};
 			await gateway.connect('ccp', options);
 			should.equal(gateway.options.eventStrategy, null);
+		});
+
+		it('throws if the identity does not exist', () => {
+			const options = {
+				wallet,
+				identity: 'INVALID_IDENTITY_LABEL'
+			};
+			return gateway.connect('ccp', options)
+				.should.be.rejectedWith(options.identity);
+		});
+
+		it('throws if the TLS identity does not exist', () => {
+			const options = {
+				wallet,
+				identity: idLabel,
+				clientTlsIdentity: 'INVALID_IDENTITY_LABEL'
+			};
+			return gateway.connect('ccp', options)
+				.should.be.rejectedWith(options.clientTlsIdentity);
 		});
 	});
 


### PR DESCRIPTION
Check that identities specified on Gateway.connect() exist and
throw informative error messages if they are not found.