### PR TITLE
FABN-1463 NodeSDK make waitForReady optional

### DIFF
--- a/fabric-client/lib/Remote.js
+++ b/fabric-client/lib/Remote.js
@@ -26,6 +26,8 @@ const MAX_RECEIVE = 'grpc.max_receive_message_length';
 const MAX_SEND_V10 = 'grpc-max-send-message-length';
 const MAX_RECEIVE_V10 = 'grpc-max-receive-message-length';
 
+const USE_WAIT_FOR_READY = 'useWaitForReady';
+
 // the logger available during construction of instances
 const super_logger = utils.getLogger('Remote.js');
 
@@ -59,8 +61,19 @@ class Remote {
 	 */
 	constructor(url, opts = {}) {
 		this._options = {};
+
+		// default
+		this.useWaitForReady = false;
+
 		for (const key in opts) {
 			const value = opts[key];
+			if (key === USE_WAIT_FOR_READY) {
+				if (typeof value === 'boolean') {
+					this.useWaitForReady = value;
+				}
+				// we do not want to add this to the grpc options
+				continue;
+			}
 			if (value && typeof value !== 'string' && !Number.isInteger(value)) {
 				throw new Error(`invalid grpc option value:${key}-> ${value} expected string|integer`);
 			}

--- a/fabric-client/test/Orderer.js
+++ b/fabric-client/test/Orderer.js
@@ -105,12 +105,10 @@ describe('Orderer', () => {
 				error: () => {}
 			};
 
-			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
 			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().rejects(new Error('waitForReady fail'))));
-			const obj = new OrdererRewire('grpc://host:2700');
+			const obj = new OrdererRewire('grpc://host:2700', {useWaitForReady: true});
 			await obj.sendBroadcast('broadcast').should.be.rejectedWith(/waitForReady fail/);
-			sinon.assert.calledWith(errorStub, 'Orderer %s has an error %s ');
 		});
 
 		it('should log and reject a Promise on timeout', async () => {
@@ -122,7 +120,7 @@ describe('Orderer', () => {
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
 			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
-			const obj = new OrdererRewire('grpc://host:2700');
+			const obj = new OrdererRewire('grpc://host:2700', {useWaitForReady: true});
 
 			const broadcastStub = sinon.stub();
 
@@ -145,7 +143,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -169,7 +166,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -203,7 +199,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -239,7 +234,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -274,7 +268,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -309,7 +302,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -338,7 +330,6 @@ describe('Orderer', () => {
 
 		it('should resolve if there is a valid response', async () => {
 
-			OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves());
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const broadcastStub = sinon.stub();
@@ -378,7 +369,7 @@ describe('Orderer', () => {
 
 		it('should reject on error during `waitForReady`', async () => {
 			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().rejects(new Error('waitForReady fail'))));
-			const obj = new OrdererRewire('grpc://host:2700');
+			const obj = new OrdererRewire('grpc://host:2700', {useWaitForReady: true});
 			await obj.sendDeliver('deliver').should.be.rejectedWith(/waitForReady fail/);
 		});
 
@@ -391,7 +382,7 @@ describe('Orderer', () => {
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
 			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
-			const obj = new OrdererRewire('grpc://host:2700');
+			const obj = new OrdererRewire('grpc://host:2700', {useWaitForReady: true});
 			obj._request_timeout = 0;
 
 			const deliverStub = sinon.stub();
@@ -404,7 +395,7 @@ describe('Orderer', () => {
 
 		it('should reject a Promise on timeout', async () => {
 			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
-			const obj = new OrdererRewire('grpc://host:2700');
+			const obj = new OrdererRewire('grpc://host:2700', {useWaitForReady: true});
 			obj._request_timeout = 0;
 
 			const deliverStub = sinon.stub();
@@ -427,7 +418,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -451,7 +441,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -469,7 +458,6 @@ describe('Orderer', () => {
 
 		it('should reject if there is an error in the response with a non-matched error code', async () => {
 
-			OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves());
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -497,7 +485,6 @@ describe('Orderer', () => {
 		});
 
 		it('should reject if there is an error in the response with a no error code and disconnect', async () => {
-			OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves());
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -524,7 +511,6 @@ describe('Orderer', () => {
 		});
 
 		it('should reject if there is an error in the response with a non-matched error code and disconnect', async () => {
-			OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves());
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -558,7 +544,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -592,7 +577,6 @@ describe('Orderer', () => {
 
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -627,7 +611,6 @@ describe('Orderer', () => {
 			};
 			const errorStub = sinon.stub(FakeLogger, 'error');
 			revert.push(OrdererRewire.__set__('logger', FakeLogger));
-			revert.push(OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves()));
 			const obj = new OrdererRewire('grpc://host:2700');
 			obj._ordererClient.deliver = () => {
 				throw 'Fake Error';
@@ -647,7 +630,6 @@ describe('Orderer', () => {
 
 			OrdererRewire.__set__('logger', FakeLogger);
 
-			OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves());
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();
@@ -678,7 +660,6 @@ describe('Orderer', () => {
 		});
 
 		it('should deal with `block` and `status` response types ', async () => {
-			OrdererRewire.__set__('Orderer.prototype.waitForReady', sinon.stub().resolves());
 			const obj = new OrdererRewire('grpc://host:2700');
 
 			const deliverStub = sinon.stub();

--- a/fabric-client/test/Peer.js
+++ b/fabric-client/test/Peer.js
@@ -114,6 +114,12 @@ describe('Peer', () => {
 			await obj.sendProposal().should.be.rejectedWith(/Missing proposal to send to peer/);
 		});
 
+		it('should reject on error during `waitForReady`', async () => {
+			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().rejects(new Error('waitForReady fail')));
+			const obj = new PeerRewire('grpc://host:2700', {useWaitForReady: true});
+			await obj.sendProposal('deliver').should.be.rejectedWith(/waitForReady fail/);
+		});
+
 		it('should reject on timeout', async () => {
 			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 
@@ -126,7 +132,7 @@ describe('Peer', () => {
 			const endorserClient = sinon.stub();
 			endorserClient.processProposal = sinon.stub().callsFake(Fake);
 
-			const obj = new PeerRewire('grpc://host:2700');
+			const obj = new PeerRewire('grpc://host:2700', {useWaitForReady: true});
 			obj._endorserClient = endorserClient;
 
 			await obj.sendProposal('deliver', 0).should.be.rejectedWith(/REQUEST_TIMEOUT/);
@@ -142,8 +148,6 @@ describe('Peer', () => {
 			const debugStub = sandbox.stub(FakeLogger, 'debug');
 
 			PeerRewire.__set__('logger', FakeLogger);
-
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 
 			const endorserClient = sinon.stub();
 
@@ -170,8 +174,6 @@ describe('Peer', () => {
 
 			PeerRewire.__set__('logger', FakeLogger);
 
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
-
 			const endorserClient = sinon.stub();
 
 			function Fake(params, callback) {
@@ -196,8 +198,6 @@ describe('Peer', () => {
 			const errorStub = sandbox.stub(FakeLogger, 'error');
 
 			PeerRewire.__set__('logger', FakeLogger);
-
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 
 			const endorserClient = sinon.stub();
 
@@ -225,8 +225,6 @@ describe('Peer', () => {
 
 			PeerRewire.__set__('logger', FakeLogger);
 
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
-
 			const endorserClient = sinon.stub();
 
 			function Fake(params, callback) {
@@ -253,8 +251,6 @@ describe('Peer', () => {
 
 			PeerRewire.__set__('logger', FakeLogger);
 
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
-
 			const endorserClient = sinon.stub();
 
 			function Fake(params, callback) {
@@ -279,8 +275,6 @@ describe('Peer', () => {
 			const debugStub = sandbox.stub(FakeLogger, 'debug');
 
 			PeerRewire.__set__('logger', FakeLogger);
-
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 
 			const endorserClient = sinon.stub();
 
@@ -308,7 +302,6 @@ describe('Peer', () => {
 			};
 
 			PeerRewire.__set__('logger', FakeLogger);
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 			const endorserClient = sinon.stub();
 
 			const myResponse = {response: {status: 500, message: 'some error'}};
@@ -334,8 +327,6 @@ describe('Peer', () => {
 		});
 
 		it('should not mark errors as proposal response if not a proposal response', async () => {
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
-
 			function Fake(params, callback) {
 				setTimeout(() => {
 					callback.call(null, 'timeout not honoured');
@@ -377,7 +368,7 @@ describe('Peer', () => {
 
 			PeerRewire.__set__('logger', FakeLogger);
 
-			const obj = new PeerRewire('grpc://host:2700');
+			const obj = new PeerRewire('grpc://host:2700', {useWaitForReady: true});
 
 			// this will throw, but we can still check method entry
 			obj.sendDiscovery()
@@ -393,6 +384,12 @@ describe('Peer', () => {
 		it('should reject if no request to send', async () => {
 			const obj = new Peer('grpc://host:2700');
 			await obj.sendDiscovery().should.be.rejectedWith(/Missing request to send to peer discovery service/);
+		});
+
+		it('should reject on error during `waitForReady`', async () => {
+			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().rejects(new Error('waitForReady fail')));
+			const obj = new PeerRewire('grpc://host:2700', {useWaitForReady: true});
+			await obj.sendDiscovery('deliver').should.be.rejectedWith(/waitForReady fail/);
 		});
 
 		it('should log and reject on timeout', async () => {
@@ -416,7 +413,7 @@ describe('Peer', () => {
 			const discoveryClient = sinon.stub();
 			discoveryClient.discover = sinon.stub().callsFake(Fake);
 
-			const obj = new PeerRewire('grpc://host:2700');
+			const obj = new PeerRewire('grpc://host:2700', {useWaitForReady: true});
 			obj._discoveryClient = discoveryClient;
 
 			await obj.sendDiscovery('deliver', 0).should.be.rejectedWith(/REQUEST_TIMEOUT/);
@@ -433,8 +430,6 @@ describe('Peer', () => {
 			const debugStub = sandbox.stub(FakeLogger, 'debug');
 
 			PeerRewire.__set__('logger', FakeLogger);
-
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 
 			function Fake(params, callback) {
 				callback.call(null, 'i_am_an_error');
@@ -461,8 +456,6 @@ describe('Peer', () => {
 
 			PeerRewire.__set__('logger', FakeLogger);
 
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
-
 			function Fake(params, callback) {
 				callback.call(null, new Error('FORCED_ERROR'));
 			}
@@ -488,8 +481,6 @@ describe('Peer', () => {
 
 			PeerRewire.__set__('logger', FakeLogger);
 
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
-
 			function Fake(params, callback) {
 				callback.call(null, null, null);
 			}
@@ -514,7 +505,6 @@ describe('Peer', () => {
 			const debugStub = sandbox.stub(FakeLogger, 'debug');
 
 			PeerRewire.__set__('logger', FakeLogger);
-			PeerRewire.__set__('Peer.prototype.waitForReady', sinon.stub().resolves());
 
 			const myResponse = {me: 'valid'};
 			function Fake(params, callback) {

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1076,7 +1076,7 @@ test('\n\n ** Channel Discovery tests **\n\n', async (t) => {
 	);
 
 
-	const peer = new Peer('grpc://localhost:9999');
+	const peer = new Peer('grpc://localhost:9999', {useWaitForReady: true});
 
 	channel.addPeer(peer);
 
@@ -1159,7 +1159,7 @@ test('\n\n ** Channel Discovery tests **\n\n', async (t) => {
 	try {
 		await channel.initialize({
 			target: peer,
-			endorsementHandler: 'fabric-client/lib/impl/BasicCommitHandler.js',
+			commitHandler: 'fabric-client/lib/impl/BasicCommitHandler.js',
 			discover: false
 		});
 		t.fail('able to initialize channel with a good commit handler path');

--- a/test/unit/commit-handler.js
+++ b/test/unit/commit-handler.js
@@ -68,16 +68,16 @@ test('\n\n ** BasicCommitHandler - test **\n\n', async (t) => {
 	parameters.request = {};
 	await errorChecker(t, handler, parameters, 'Missing "signed_envolope"');
 
-	const orderer = client.newOrderer('grpc://somehost.com:7777');
+	const orderer = client.newOrderer('grpc://somehost.com:7777', {useWaitForReady: true});
 	try {
 		await handler.commit({request: {orderer}, signed_envelope: {}}, 1000);
 		t.fail('Should not be here - looking for orderers in request');
 	} catch (error) {
 		if (error instanceof Error) {
 			if (error.toString().indexOf('Failed to connect before the deadline') > -1) {
-				t.pass('This should fail with ' + error.toString());
+				t.pass('Successfull - got failed with ' + error.toString());
 			} else {
-				t.fail('Did not get Failed to connect before the deadline - got ' + error.toString());
+				t.fail('Failed - Did not get Failed to connect before the deadline - got ' + error.toString());
 			}
 		} else {
 			t.fail('Unknown commit results returned');
@@ -104,12 +104,12 @@ test('\n\n ** BasicCommitHandler - test **\n\n', async (t) => {
 		}
 	}
 
-	channel.addOrderer(client.newOrderer('grpc://somehost.com:1111'));
-	channel.addOrderer(client.newOrderer('grpc://somehost.com:2222'));
-	channel.addOrderer(client.newOrderer('grpc://somehost.com:3333'));
-	channel.addOrderer(client.newOrderer('grpc://somehost.com:4444'));
-	channel.addOrderer(client.newOrderer('grpc://somehost.com:5555'));
-	channel.addOrderer(client.newOrderer('grpc://somehost.com:6666'));
+	channel.addOrderer(client.newOrderer('grpc://somehost.com:1111', {useWaitForReady: true}));
+	channel.addOrderer(client.newOrderer('grpc://somehost.com:2222', {useWaitForReady: true}));
+	channel.addOrderer(client.newOrderer('grpc://somehost.com:3333', {useWaitForReady: true}));
+	channel.addOrderer(client.newOrderer('grpc://somehost.com:4444', {useWaitForReady: true}));
+	channel.addOrderer(client.newOrderer('grpc://somehost.com:5555', {useWaitForReady: true}));
+	channel.addOrderer(client.newOrderer('grpc://somehost.com:6666', {useWaitForReady: true}));
 
 	try {
 		await handler._commit(request, envelope, 5000);

--- a/test/unit/remote.js
+++ b/test/unit/remote.js
@@ -150,7 +150,7 @@ test('\n\n ** Remote node tests **\n\n', async (t) => {
 		'Check not passing any GRPC options.'
 	);
 
-	peer = new Peer(url, {pem: aPem, clientKey: aPem, clientCert: aPem});
+	peer = new Peer(url, {pem: aPem, clientKey: aPem, clientCert: aPem, useWaitForReady: true});
 	try {
 		await peer.sendProposal({}, 100);
 	} catch (error) {


### PR DESCRIPTION
The gRPC setup 'waitForReady' on services is an optional setup
step on a service connection that could be bypassed when not
required by the application.

Allow for a connection option to skip and move straight to
sending the outbound request.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>