### PR TITLE
FABN-1464 NodeSDK update queryHandling

### DIFF
--- a/docs/tutorials/query-peers.md
+++ b/docs/tutorials/query-peers.md
@@ -1,11 +1,11 @@
-This tutorial describes how peers are selected to evaluate transactions
-that will not then be written to the ledger, which may also be considered
-as queries.
+This tutorial describes how peers are selected when a transaction is evaluated
+and the results are not written to the ledger. The is considered to be a
+query.
 
 ### Query handling strategies
 
-The SDK provides several selectable strategies for how it should evaluate
-transactions on peers in the network. The available strategies are defined
+The SDK provides two strategies to evaluate transactions.
+The available strategies are defined
 in `QueryHandlerStrategies`. The desired strategy is (optionally)
 specified as an argument to `connect()` on the `Gateway`, and is used for
 all transaction evaluations on Contracts obtained from that Gateway
@@ -13,15 +13,25 @@ instance.
 
 If no query handling strategy is specified, `MSPID_SCOPE_SINGLE` is used
 by default. This will evaluate all transactions on the first peer from
-which is can obtain a response, and only switch to another peer if this
-peer fails.
+which it can obtain a response, and only switch to another peer if this
+peer fails. The list of peers will be all peers in the contract's `Network`
+that belong to the gateway's organization.
+
+There is another query handling strategy provided called `MSPID_SCOPE_ROUND_ROBIN`.
+This will evaluate a transaction starting with the first peer on the list.
+It will try the peers in order until a response is received or all peers
+have been tried. On the next call the second peer will be tried first and then
+continue on in the list until a response is received. The starting point within
+the list is incremented on each call, this will distribute the work load among all
+responding peers. The list of peers will be all peers in the contract's `Network`
+that belong to the gateway's organization.
 
 ```javascript
 const { Gateway, QueryHandlerStrategies } = require('fabric-network');
 
 const connectOptions = {
     query: {
-        timeout: 3,
+        timeout: 3, // timeout in seconds
         strategy: QueryHandlerStrategies.MSPID_SCOPE_SINGLE
     }
 }
@@ -37,20 +47,28 @@ strategies, it is possible to implement your own query handling. This is
 achieved by specifying your own factory function as the query handling
 strategy. The factory function should return a *query handler*
 object and take one parameter:
-1. Blockchain network: `Network`
+1. Blockchain network: `Network` - {@link fabric-network.Network}
 
-The Network provides access to peers on which transactions should be
+The Network instance provides access to peers on which transactions should be
 evaluated.
 
 ```javascript
+// factory function will return the handler
 function createQueryHandler(network) {
-    /* Your implementation here */
+    // use the network to get all endorsing peers
+    // of all organizations
+    const peers = network.getEndorsers();
+    // use the network to get endorsing peers
+    // of my organization (MSPID of the organization)
+    const peers = network.getEndorsers('mymspid');
+
+    // build and return the query handler
     return new MyQueryHandler(peers);
 }
 
 const connectOptions = {
     query: {
-        timeout: 3,
+        timeout: 3, // timeout in seconds (optional will default to 3)
         strategy: createQueryHandler
     }
  }
@@ -65,12 +83,52 @@ The *query handler* object returned must implement the following functions.
 class MyQueryHandler {
 	/**
 	 * Evaluate the supplied query on appropriate peers.
-	 * @param {Query} query A query object that provides an evaluate()
-	 * function to invoke itself on specified peers.
+	 * @param {Query} query - A query object that will send the
+	 * query proposal to the peers and format the responses for this query handler
 	 * @returns {Buffer} Query result.
 	 */
     async evaluate(query) { /* Your implementation here */ }
 }
 ```
 
-For a complete sample plug-in query handler implementation, see [sample-query-handler.ts](https://github.com/hyperledger/fabric-sdk-node/blob/master/test/typescript/integration/network-e2e/sample-query-handler.ts).
+Use the `query` instance provided to the `evaluate` method to make the query call
+to the peer or peers of your Fabric network. The query instance will process
+the peer responses of the endorsement and provide your handler with the results.
+The results will be keyed by peer name and may contain either a `QueryResult`
+or an `Error`.
+
+The QueryResult:
+```
+export interface QueryResponse {
+	isEndorsed: boolean; // indicates a good endorsement, required to have query results
+	payload: Buffer; // The query results
+	status: number; // status of the query, 200 successful, 500 failed
+	message: string; // failed reason message
+}
+```
+
+The following sample code is in TypeScript to show the object types involved.
+```javascript
+	public async evaluate(query: Query): Promise<Buffer> {
+		const errorMessages: string[] = [];
+
+		for (const peer of this.peers) {
+			const results: QueryResults = await query.evaluate([peer]);
+			const result = results[peer.name];
+			if (result instanceof Error) {
+				errorMessages.push(result.toString());
+			} else {
+				if (result.isEndorsed) {
+					return result.payload;
+				}
+				errorMessages.push(result.message);
+			}
+		}
+
+		const message = util.format('Query failed. Errors: %j', errorMessages);
+		const error = new Error(message);
+		throw error;
+	}
+```
+
+For a complete sample plug-in query handler implementation, see [sample-query-handler.ts](https://github.com/hyperledger/fabric-sdk-node/blob/master/test/ts-scenario/config/handlers/sample-query-handler.ts).

--- a/fabric-common/lib/Proposal.js
+++ b/fabric-common/lib/Proposal.js
@@ -330,6 +330,7 @@ message Endorsement {
 		const signedEnvelope = this.getSignedProposal();
 		this._proposalResponses = [];
 		this._proposalErrors = [];
+		this._queryResults = [];
 
 		if (handler) {
 			logger.debug('%s - endorsing with a handler', method);
@@ -389,13 +390,12 @@ message Endorsement {
 		};
 
 		if (this.type === 'Query') {
-			this._queryResults = [];
 			this._proposalResponses.forEach((response) => {
-				if (response.response && response.response.payload && response.response.payload.length > 0) {
+				if (response.endorsement && response.response && response.response.payload) {
 					logger.debug('%s - have payload', method);
 					this._queryResults.push(response.response.payload);
 				} else {
-					logger.error('%s - unknown or missing results in query', method);
+					logger.debug('%s - no payload in query', method);
 				}
 			});
 			return_results.queryResults = this._queryResults;

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -112,6 +112,7 @@ export class DiscoveryHandler extends ServiceHandler {
 }
 
 export class ServiceEndpoint {
+	public readonly name: string;
 	constructor(name: string, client: Client, mspid?: string);
 	public connect(endpoint: Endpoint, options: ConnectOptions): Promise<void>;
 	public disconnect(): void;

--- a/fabric-network/src/impl/query/query.js
+++ b/fabric-network/src/impl/query/query.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2020 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+const logger = require('fabric-network/lib/logger').getLogger('Query');
+
+/**
+ * @typedef {Object} Query~QueryResponse
+ * @memberof module:fabric-network
+ * @property {number} status - The status value from the endorsement. This attriibute
+ * will be set by the chaincode.
+ * @property {Buffer} payload - The payload value from the endorsement. This attribute
+ * may be considered the query value if the status code is exceptable.
+ * @property {Buffer} payload - The message value from the endorsement. This attribute
+ * will have a value when there is not a payload and status value indicates an issue
+ * with determining the payload (the query value).
+ */
+/**
+ * Used by query handler implementations to evaluate transactions on peers of their choosing.
+ * @memberof module:fabric-network
+ */
+class Query {
+	/**
+	 * Builds a Query instance to send and then work with the results returned
+	 * by the fabric-common/Query.
+	 * @param {module:fabric-common.Query} query - The query instance of the proposal
+	 * @returns {Object} options - options to be used when sending the request to
+	 * fabric-common service endpoint {Endorser} peer.
+	 */
+	constructor(query, options = {}) {
+		this.query = query;
+		this.requestTimeout = 3000; // default 3 seconds
+		if (Number.isInteger(options.timeout)) {
+			this.requestTimeout = options.timeout * 1000; // need ms;
+		}
+	}
+
+	/**
+	 * Sends a signed proposal to the specified peers. The peer endorsment
+	 * responses are
+	 * @param {Endorser[]} peers - The peers to query
+	 * @returns {Object.<String, (QueryResponse | Error)>} Object with peer name keys and associated values that are either
+	 * QueryResponse objects or Error objects.
+	 */
+	async evaluate(peers) {
+		const method = 'evaluate';
+		logger.debug('%s - start', method);
+
+		const results = {};
+		try {
+			const responses = await this.query.send({targets: peers, requestTimeout: this.requestTimeout});
+			if (responses) {
+				if (responses.errors) {
+					for (const resultError of responses.errors) {
+						results[resultError.connection.name] = resultError;
+						logger.debug('%s - problem with query to peer %s error:%s', method, resultError.connection.name, resultError);
+					}
+				}
+				if (responses.responses) {
+					for (const peer_response of responses.responses) {
+						if (peer_response.response) {
+							const response = {};
+							response.status = peer_response.response.status;
+							response.payload = peer_response.response.payload;
+							response.message = peer_response.response.message;
+							response.isEndorsed = peer_response.endorsement ? true : false;
+							results[peer_response.connection.name] = response;
+							logger.debug('%s - have results - peer: %s with status:%s',
+								method,
+								peer_response.connection.name,
+								response.status);
+						}
+					}
+				}
+
+				// check to be sure we got results for each peer requested
+				for (const peer of peers) {
+					if (!results[peer.name]) {
+						logger.error('%s - no results for peer: %s', method, peer.name);
+						results[peer.name] = new Error('Missing response from peer');
+					}
+				}
+			} else {
+				throw Error('No responses returned for query');
+			}
+		} catch (error) {
+			// if we get an error, return this error for each peer
+			for (const peer of peers) {
+				results[peer.name] = error;
+				logger.error('%s - problem with query to peer %s error:%s', method, peer.name, error);
+			}
+		}
+
+		logger.debug('%s - end', method);
+		return results;
+	}
+}
+
+module.exports = Query;

--- a/fabric-network/src/impl/query/queryhandlerstrategies.js
+++ b/fabric-network/src/impl/query/queryhandlerstrategies.js
@@ -13,23 +13,14 @@ function getOrganizationPeers(network) {
 	return network.channel.getEndorsers(network.mspid);
 }
 
-function getTimeout(network) {
-	const queryOptions = network.gateway.getOptions().query;
-	let timeout = 3000; // default 3 seconds
-	if (Number.isInteger(queryOptions.timeout)) {
-		timeout = queryOptions.timeout * 1000; // need ms;
-	}
-	return {timeout};
-}
-
 function MSPID_SCOPE_SINGLE(network) {
 	const peers = getOrganizationPeers(network);
-	return new SingleQueryHandler(peers, getTimeout(network));
+	return new SingleQueryHandler(peers);
 }
 
 function MSPID_SCOPE_ROUND_ROBIN(network) {
 	const peers = getOrganizationPeers(network);
-	return new RoundRobinQueryHandler(peers, getTimeout(network));
+	return new RoundRobinQueryHandler(peers);
 }
 
 /**

--- a/fabric-network/src/impl/query/roundrobinqueryhandler.js
+++ b/fabric-network/src/impl/query/roundrobinqueryhandler.js
@@ -13,11 +13,10 @@ const util = require('util');
 const logger = require('fabric-network/lib/logger').getLogger('RoundRobinQueryHandler');
 
 class RoundRobinQueryHandler {
-	constructor(peers, options = {}) {
+	constructor(peers) {
 		logger.debug('constructor: peers=%j', peers.map((peer) => peer.name));
 		this._peers = peers;
 		this._currentPeerIndex = 0;
-		this._options = options;
 	}
 
 	async evaluate(query) {
@@ -25,40 +24,30 @@ class RoundRobinQueryHandler {
 		logger.debug('%s - start', method);
 
 		const startPeerIndex = this._currentPeerIndex;
+
+		this._currentPeerIndex = (this._currentPeerIndex + 1) % this._peers.length;
+
 		const errorMessages = [];
-		const options = {requestTimeout: 3000};
-		// use the timeout as the requestTimeout or let default
-		if (Number.isInteger(this._options.timeout)) {
-			options.requestTimeout = this._options.timeout * 1000; // in ms;
-		}
 
 		for (let i = 0; i < this._peers.length; i++) {
 			const peerIndex = (startPeerIndex + i) % this._peers.length;
-			this._currentPeerIndex = peerIndex;
+
 			const peer = this._peers[peerIndex];
+			logger.debug('%s - sending to peer %s', method, peer.name);
 
-			logger.debug('%s - query sending to peer %s', method, peer.name);
-			const results = await query.send({targets:[peer]}, options);
-
-			if (results.errors.length > 0) {
-				logger.error('%s - problem with query to peer %s error:%s', method, peer.name, results.errors[0]);
-				// since only one peer, only one error
-				errorMessages.push(results.errors[0].message);
-				continue;
+			const results = await query.evaluate([peer]);
+			const result = results[peer.name];
+			if (result instanceof Error) {
+				errorMessages.push(result.toString());
+			} else {
+				if (result.isEndorsed) {
+					logger.debug('%s - return peer response status: %s', method, result.status);
+					return result.payload;
+				} else {
+					logger.debug('%s - throw peer response status: %s message: %s', method, result.status, result.message);
+					throw Error(result.message);
+				}
 			}
-
-			const endorsementResponse = results.responses[0];
-
-			if (!endorsementResponse.endorsement) {
-				logger.debug('%s - peer response status: %s message: %s',
-					method,
-					endorsementResponse.response.status,
-					endorsementResponse.response.message);
-				throw new Error(endorsementResponse.response.message);
-			}
-
-			logger.debug('%s - peer response status %s', method, endorsementResponse.response.status);
-			return endorsementResponse.response.payload;
 		}
 
 		const message = util.format('Query failed. Errors: %j', errorMessages);

--- a/fabric-network/src/impl/query/singlequeryhandler.js
+++ b/fabric-network/src/impl/query/singlequeryhandler.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, 2019 IBM All Rights Reserved.
+ * Copyright 2018, 2020 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,11 +13,10 @@ const util = require('util');
 const logger = require('fabric-network/lib/logger').getLogger('SingleQueryHandler');
 
 class SingleQueryHandler {
-	constructor(peers, options = {}) {
+	constructor(peers) {
 		logger.debug('constructor: peers=%j', peers.map((peer) => peer.name));
 		this._peers = peers;
 		this._currentPeerIndex = 0;
-		this._options = options;
 	}
 
 	async evaluate(query) {
@@ -26,39 +25,27 @@ class SingleQueryHandler {
 
 		const startPeerIndex = this._currentPeerIndex;
 		const errorMessages = [];
-		const options = {requestTimeout: 3000};
-		// use the timeout as the requestTimeout or let default
-		if (Number.isInteger(this._options.timeout)) {
-			options.requestTimeout = this._options.timeout * 1000; // in ms;
-		}
 
 		for (let i = 0; i < this._peers.length; i++) {
 			const peerIndex = (startPeerIndex + i) % this._peers.length;
 			this._currentPeerIndex = peerIndex;
+
 			const peer = this._peers[peerIndex];
+			logger.debug('%s - sending to peer %s', method, peer.name);
 
-			logger.debug('%s - query sending to peer %s', method, peer.name);
-			const results = await query.send({targets:[peer]}, options);
-
-			if (results.errors.length > 0) {
-				logger.error('%s - problem with query to peer %s error:%s', method, peer.name, results.errors[0]);
-				// since only one peer, only one error
-				errorMessages.push(results.errors[0].message);
-				continue;
+			const results = await query.evaluate([peer]);
+			const result = results[peer.name];
+			if (result instanceof Error) {
+				errorMessages.push(result.toString());
+			} else {
+				if (result.isEndorsed) {
+					logger.debug('%s - return peer response status: %s', method, result.status);
+					return result.payload;
+				} else {
+					logger.debug('%s - throw peer response status: %s message: %s', method, result.status, result.message);
+					throw Error(result.message);
+				}
 			}
-
-			const endorsementResponse = results.responses[0];
-
-			if (!endorsementResponse.endorsement) {
-				logger.debug('%s - peer response status: %s message: %s',
-					method,
-					endorsementResponse.response.status,
-					endorsementResponse.response.message);
-				throw new Error(endorsementResponse.response.message);
-			}
-
-			logger.debug('%s - peer response status %s', method, endorsementResponse.response.status);
-			return endorsementResponse.response.payload;
 		}
 
 		const message = util.format('Query failed. Errors: %j', errorMessages);

--- a/fabric-network/test/impl/query/query.js
+++ b/fabric-network/test/impl/query/query.js
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2020 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+const QueryProposal = require('fabric-common/lib/Query');
+const Query = require('fabric-network/lib/impl/query/query');
+
+describe('Query', () => {
+	let queryProposal;
+	const peer1 = {name: 'peer1'};
+	const peer2 = {name: 'peer2'};
+
+	const error1 = new Error('peer1-error');
+	const error2 = new Error('peer2-error');
+	error1.connection = {name: 'peer1'};
+	error2.connection = {name: 'peer2'};
+	const noresulterror = new Error('No responses returned for query');
+	const missingerror = new Error('Missing response from peer');
+	const response200 = {status: 200, payload: Buffer.from('good'), message: undefined};
+	const result200 = {status: 200, payload: Buffer.from('good'), message: undefined, isEndorsed: true};
+	const response200_peer1 = {
+		response: response200,
+		connection: {name: 'peer1'},
+		endorsement: {}
+	};
+	const response200_peer2 = {
+		response: response200,
+		connection: {name: 'peer2'},
+		endorsement: {}
+	};
+	const response500 = {status: 500, message: 'problem500', payload: undefined};
+	const result500 = {status: 500, message: 'problem500', payload: undefined, isEndorsed: false};
+	const response500_peer1 = {
+		response: response500,
+		connection: {name: 'peer1'}
+	};
+	const response500_peer2 = {
+		response: response500,
+		connection: {name: 'peer2'}
+	};
+
+	const valid200Resonse = {responses: [response200_peer1]};
+	const valid200Resonses = {responses: [response200_peer1, response200_peer2]};
+	const valid500Resonse = {responses: [response500_peer1]};
+	const valid500Resonses = {responses: [response500_peer1, response500_peer2]};
+	const errorResonse = {errors: [error1]};
+	const errorResonses = {errors: [error1, error2]};
+	const validMixResonse = {responses: [response200_peer1, response500_peer2]};
+	const vallidMixError = {responses: [response200_peer1], errors: [error2]};
+	const validMissingResponse = {responses: [response200_peer1, {}]};
+
+
+	beforeEach(() => {
+		queryProposal = sinon.createStubInstance(QueryProposal);
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe('#constructor', () => {
+
+		it('no options', async () => {
+			const query = new Query({});
+			expect(query).to.exist;
+		});
+		it('with options', async () => {
+			const query = new Query({}, {something: 33});
+			expect(query).to.exist;
+		});
+		it('with timeout options', async () => {
+			const query = new Query({}, {timeout: 3});
+			expect(query.requestTimeout).to.equal(3000);
+		});
+		it('check timeout passed to low level', async () => {
+			const query = new Query(queryProposal, {timeout: 5});
+
+			await query.evaluate([peer1]);
+
+			const expected = {
+				targets: [peer1],
+				requestTimeout: 5000
+			};
+			sinon.assert.calledWithMatch(queryProposal.send, expected);
+		});
+	});
+
+	describe('#evaluate', () => {
+		let query;
+
+		beforeEach(() => {
+			query = new Query(queryProposal);
+		});
+
+		// check calls to low level
+		it('calls low level with a single peer', async () => {
+			await query.evaluate([peer1]);
+
+			const expected = {
+				targets: [peer1],
+				requestTimeout: 3000
+			};
+			sinon.assert.calledWithMatch(queryProposal.send, expected);
+		});
+
+		it('calls low level with multiple peers', async () => {
+			const peers = [peer1, peer2];
+
+			await query.evaluate(peers);
+
+			const expected = {
+				targets: peers,
+				requestTimeout: 3000
+			};
+			sinon.assert.calledWithMatch(queryProposal.send, expected);
+		});
+
+		// single peer
+		it('returns query results from one peer status 200', async () => {
+			queryProposal.send.resolves(valid200Resonse);
+
+			const result = await query.evaluate([peer1]);
+
+			const expected = {
+				peer1: result200
+			};
+			expect(result).to.own.deep.equal(expected);
+		});
+		it('returns query results from one peer status 500', async () => {
+			queryProposal.send.resolves(valid500Resonse);
+
+			const result = await query.evaluate([peer1]);
+			const expected = {
+				peer1: result500
+			};
+			expect(result).to.own.deep.equal(expected);
+		});
+		it('returns query error result from one peer', async () => {
+			queryProposal.send.resolves(errorResonse);
+
+			const result = await query.evaluate([peer1]);
+
+			const expected = {
+				peer1: error1
+			};
+			expect(result).to.own.deep.equal(expected);
+		});
+		it('returns missing error result from one peer', async () => {
+			queryProposal.send.resolves();
+
+			const result = await query.evaluate([peer1]);
+
+			expect(result.peer1.message).to.own.deep.equal(noresulterror.message);
+		});
+
+		// multiple peers same results
+		it('returns query results from two peers status 200', async () => {
+			queryProposal.send.resolves(valid200Resonses);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			const expected = {
+				peer1: result200,
+				peer2: result200
+			};
+			expect(result).to.own.deep.equal(expected);
+		});
+		it('returns query results from two peers status 500', async () => {
+			queryProposal.send.resolves(valid500Resonses);
+
+			const result = await query.evaluate([peer1, peer2]);
+			const expected = {
+				peer1: result500,
+				peer2: result500
+			};
+
+			expect(result).to.own.deep.equal(expected);
+
+		});
+		it('returns query error result from two peers', async () => {
+			queryProposal.send.resolves(errorResonses);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			const expected = {
+				peer1: error1,
+				peer2: error2
+			};
+			expect(result).to.own.deep.equal(expected);
+		});
+		it('returns no result error result from two peers', async () => {
+			queryProposal.send.resolves();
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			expect(result.peer1.message).to.own.deep.equal(noresulterror.message);
+			expect(result.peer2.message).to.own.deep.equal(noresulterror.message);
+		});
+
+		// multiple peers missing results
+		it('returns no result error result from one peer', async () => {
+			queryProposal.send.resolves(valid200Resonse);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			expect(result.peer1).to.own.deep.equal(result200);
+			expect(result.peer2.message).to.own.deep.equal(missingerror.message);
+		});
+		it('returns empty result and valid result', async () => {
+			queryProposal.send.resolves(validMissingResponse);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			expect(result.peer1).to.own.deep.equal(result200);
+			expect(result.peer2.message).to.own.deep.equal(missingerror.message);
+		});
+		it('returns no result error result from one peer and error from the other', async () => {
+			queryProposal.send.resolves(errorResonse);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			expect(result.peer1.message).to.own.deep.equal(error1.message);
+			expect(result.peer2.message).to.own.deep.equal(missingerror.message);
+		});
+
+		// multiple peers mixed results
+		it('returns mixed valid from two peers status 200 and 500', async () => {
+			queryProposal.send.resolves(validMixResonse);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			expect(result.peer1).to.own.deep.equal(result200);
+			expect(result.peer2).to.own.deep.equal(result500);
+		});
+		it('returns mixed valid and error result from two peers', async () => {
+			queryProposal.send.resolves(vallidMixError);
+
+			const result = await query.evaluate([peer1, peer2]);
+
+			expect(result.peer1).to.own.deep.equal(result200);
+			expect(result.peer2.message).to.own.deep.equal(error2.message);
+		});
+	});
+});

--- a/fabric-network/test/impl/query/queryhandlers.js
+++ b/fabric-network/test/impl/query/queryhandlers.js
@@ -1,13 +1,26 @@
 /**
- * Copyright 2018 IBM All Rights Reserved.
+ * Copyright 2018, 2020 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
 
-const Query = require('fabric-common/lib/Query');
+/*
+		it('should handle a successful sign by the crypto suite', async () => {
+			mockCryptoSuite.sign.withArgs(mockPrivateKey, digest, opts).resolves();
+			await signer.sign(digest, opts);
+			mockCryptoSuite.sign.should.have.been.calledOnceWithExactly(mockPrivateKey, digest, opts);
+		});
+
+		it('should handle an unsuccessful sign by the crypto suite', async () => {
+			mockCryptoSuite.sign.withArgs(mockPrivateKey, digest, opts).rejects(new Error('such error'));
+			await signer.sign(digest, opts).should.be.rejectedWith(/such error/);
+		});
+		*/
+
 const Endorser = require('fabric-common/lib/Endorser');
+const Query = require('fabric-network/lib/impl/query/query');
 const SingleQueryHandler = require('fabric-network/lib/impl/query/singlequeryhandler');
 const RoundRobinQueryHandler = require('fabric-network/lib/impl/query/roundrobinqueryhandler');
 
@@ -17,29 +30,30 @@ const expect = chai.expect;
 chai.use(require('chai-as-promised'));
 
 describe('QueryHandlers', () => {
-	const querySuccessResult = Buffer.from('SUCCESS_QUERY_RESULT');
-	const queryErrorResult = new Error('ERROR_QUERY_RESULT');
-	const queryFailMessage = 'QUERY_FAILED';
-	const peerInfo = {name: 'peer1', url: 'grpc://fakehost:9999'};
-	const validProposalResponse = {
-		endorsement: {},
-		response: {
-			status: 200,
-			payload: querySuccessResult
-		},
-		connection: peerInfo
+	const s200ProposalResponse1 = {
+		'peer1': {status: 200, payload: 'peer1-200', isEndorsed: true}
 	};
-	const invalidProposalResponse = {
-		response: {
-			status: 500,
-			message: queryFailMessage
-		},
-		connection: peerInfo
+	const s400ProposalResponse1 = {
+		'peer1': {status: 400, message: 'peer1-400', isEndorsed: false}
 	};
-
-	const validProposalResponses = {responses: [validProposalResponse], errors: [], queryResponses: [querySuccessResult]};
-	const invalidProposalResponses = {responses: [invalidProposalResponse], errors: []};
-	const errorProposalResponses = {responses: [], errors: [queryErrorResult]};
+	const s500ProposalResponse1 = {
+		'peer1': {status: 500, message: 'peer1-500', isEndorsed: false}
+	};
+	const errorProposalResponse1 = {
+		'peer1': new Error('peer1-error')
+	};
+	const s200ProposalResponse2 = {
+		'peer2': {status: 200, payload: 'peer2-200', isEndorsed: true}
+	};
+	const s400ProposalResponse2 = {
+		'peer2': {status: 400, message: 'peer2-400', isEndorsed: false}
+	};
+	const s500ProposalResponse2 = {
+		'peer2': {status: 500, message: 'peer2-500', isEndorsed: false}
+	};
+	const errorProposalResponse2 = {
+		'peer2': new Error('peer2-error')
+	};
 
 	let endorser1;
 	let endorser2;
@@ -57,43 +71,48 @@ describe('QueryHandlers', () => {
 		sinon.restore();
 	});
 
-	describe('SingleQueryHandler', () => {
+	describe('SingleQueryHandler with one peer', () => {
 		let handler;
 
 		beforeEach(() => {
-			handler = new SingleQueryHandler([endorser1, endorser2]);
+			handler = new SingleQueryHandler([endorser1]);
 		});
 
-		it('returns peer valid results', async () => {
-			query.send.resolves(validProposalResponses);
-			handler._options = {timeout: 1};
+		it('returns valid results - all good', async () => {
+			query.evaluate.resolves(s200ProposalResponse1);
 
 			const result = await handler.evaluate(query);
-			expect(result).to.be.equal(querySuccessResult);
+			expect(result).to.be.equal('peer1-200');
 		});
-
-		it('returns an error with the peer invalid results', async () => {
-			query.send.resolves(invalidProposalResponses);
+		it('returns an error with the peer status 400 results', async () => {
+			query.evaluate.resolves(s400ProposalResponse1);
 
 			try {
 				await handler.evaluate(query);
 			} catch (error) {
-				expect(error.message).to.contain(queryFailMessage);
+				expect(error.message).to.contain('peer1-400');
 			}
 		});
+		it('returns an error with the peer status 500 results', async () => {
+			query.evaluate.resolves(s500ProposalResponse1);
 
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-500');
+			}
+		});
 		it('returns an error with the grpc sending error', async () => {
-			query.send.resolves(errorProposalResponses);
+			query.evaluate.resolves(errorProposalResponse1);
 
 			try {
 				await handler.evaluate(query);
 			} catch (error) {
-				expect(error.message).to.contain('ERROR_QUERY_RESULT');
+				expect(error.message).to.contain('peer1-error');
 			}
 		});
-
-		it('returns an error with internal sending error', async () => {
-			query.send.rejects(new Error('Send failed'));
+		it('returns an error with internal error', async () => {
+			query.evaluate.rejects(new Error('Send failed'));
 
 			try {
 				await handler.evaluate(query);
@@ -103,43 +122,324 @@ describe('QueryHandlers', () => {
 		});
 	});
 
-	describe('RoundRobinQueryHandler', () => {
+	describe('SingleQueryHandler with two peers', () => {
+		let handler;
+
+		beforeEach(() => {
+			handler = new SingleQueryHandler([endorser1, endorser2]);
+		});
+
+		it('returns valid results - all 200', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+
+			const result = await handler.evaluate(query);
+			expect(result).to.be.equal('peer1-200');
+		});
+		it('returns error results - with 400 first', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(s400ProposalResponse1);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-400');
+			}
+		});
+		it('returns valid results - with 500 first', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(s500ProposalResponse1);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-500');
+			}
+		});
+		it('returns valid results - with error', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+
+			const result = await handler.evaluate(query);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('continues to use first peer with 400 return second peer', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s400ProposalResponse2);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer1-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer1-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer1-200');
+		});
+		it('continues to use second peer', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('switches to second peer after error', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer1-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer1-200');
+
+
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('returns an error with the both peers 500 results', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s500ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s500ProposalResponse2);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-500');
+			}
+		});
+		it('returns an error with the grpc sending error', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(errorProposalResponse2);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-error');
+				expect(error.message).to.contain('peer2-error');
+			}
+		});
+		it('returns an error with internal error', async () => {
+			query.evaluate.rejects(new Error('Send failed'));
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('Send failed');
+			}
+		});
+	});
+
+	describe('RoundRobinQueryHandler with one peer', () => {
+		let handler;
+
+		beforeEach(() => {
+			handler = new RoundRobinQueryHandler([endorser1]);
+		});
+
+		it('returns  valid results - all good', async () => {
+			query.evaluate.resolves(s200ProposalResponse1);
+
+			const result = await handler.evaluate(query);
+			expect(result).to.be.equal('peer1-200');
+		});
+		it('returns an error with the peer status 400 results', async () => {
+			query.evaluate.resolves(s400ProposalResponse1);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-400');
+			}
+		});
+		it('returns an error with the peer status 500 results', async () => {
+			query.evaluate.resolves(s500ProposalResponse1);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-500');
+			}
+		});
+		it('returns an error with the grpc sending error', async () => {
+			query.evaluate.resolves(errorProposalResponse1);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-error');
+			}
+		});
+		it('returns an error with internal sending error', async () => {
+			query.evaluate.rejects(new Error('Send failed'));
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('Send failed');
+			}
+		});
+	});
+
+	describe('RoundRobinQueryHandler with two peers', () => {
 		let handler;
 
 		beforeEach(() => {
 			handler = new RoundRobinQueryHandler([endorser1, endorser2]);
 		});
 
-		it('returns peer valid results', async () => {
-			query.send.resolves(validProposalResponses);
-			handler._options = {timeout: 1};
+		it('returns valid results - all 200', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
 
 			const result = await handler.evaluate(query);
-			expect(result).to.be.equal(querySuccessResult);
+			expect(result).to.be.equal('peer1-200');
 		});
-
-		it('returns an error with the peer invalid results', async () => {
-			query.send.resolves(invalidProposalResponses);
+		it('returns error results - with 400 first', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(s400ProposalResponse1);
 
 			try {
 				await handler.evaluate(query);
 			} catch (error) {
-				expect(error.message).to.contain(queryFailMessage);
+				expect(error.message).to.contain('peer1-400');
 			}
 		});
+		it('returns valid results - with 500 first', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(s500ProposalResponse1);
 
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-500');
+			}
+		});
+		it('returns valid results - with error first', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+
+			const result = await handler.evaluate(query);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('switches from peer1 to peer2 with 400 and 200', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s400ProposalResponse2);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer1-200');
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer2-400');
+			}
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer1-200');
+		});
+		it('switches between peers', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer1-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer1-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('continues to use second peer', async () => {
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('stays with second peer after error', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s200ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s200ProposalResponse2);
+
+			let result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer1-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer2-200');
+
+
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(1);
+			expect(result).to.be.equal('peer2-200');
+
+			result = await handler.evaluate(query);
+			expect(handler._currentPeerIndex).to.be.equal(0);
+			expect(result).to.be.equal('peer2-200');
+		});
+		it('returns an error with the both peers 500 results', async () => {
+			query.evaluate.withArgs([endorser1]).resolves(s500ProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(s500ProposalResponse2);
+
+			try {
+				await handler.evaluate(query);
+			} catch (error) {
+				expect(error.message).to.contain('peer1-500');
+			}
+		});
 		it('returns an error with the grpc sending error', async () => {
-			query.send.resolves(errorProposalResponses);
+			query.evaluate.withArgs([endorser1]).resolves(errorProposalResponse1);
+			query.evaluate.withArgs([endorser2]).resolves(errorProposalResponse2);
 
 			try {
 				await handler.evaluate(query);
 			} catch (error) {
-				expect(error.message).to.contain('ERROR_QUERY_RESULT');
+				expect(error.message).to.contain('peer1-error');
+				expect(error.message).to.contain('peer2-error');
 			}
 		});
-
-		it('returns an error with internal sending error', async () => {
-			query.send.rejects(new Error('Send failed'));
+		it('returns an error with internal error', async () => {
+			query.evaluate.rejects(new Error('Send failed'));
 
 			try {
 				await handler.evaluate(query);

--- a/fabric-network/test/transaction.js
+++ b/fabric-network/test/transaction.js
@@ -14,8 +14,8 @@ chai.use(require('chai-as-promised'));
 const Client = require('fabric-common/lib/Client');
 const Channel = require('fabric-common/lib/Channel');
 const Endorsement = require('fabric-common/lib/Endorsement');
-const Query = require('fabric-common/lib/Query');
 const Endorser = require('fabric-common/lib/Endorser');
+const QueryProposal = require('fabric-common/lib/Query');
 const Commit = require('fabric-common/lib/Commit');
 const IdentityContext = require('fabric-common/lib/IdentityContext');
 const DiscoveryHandler = require('fabric-common/lib/DiscoveryHandler');
@@ -26,6 +26,7 @@ const Network = require('fabric-network/lib/network');
 const Gateway = require('fabric-network/lib/gateway');
 const Transaction = require('fabric-network/lib/transaction');
 const TransactionEventHandler = require('fabric-network/lib/impl/event/transactioneventhandler');
+const Query = require('fabric-network/lib/impl/query/query');
 const QueryStrategies = require('fabric-network/lib/impl/query/queryhandlerstrategies');
 
 describe('Transaction', () => {
@@ -81,7 +82,7 @@ describe('Transaction', () => {
 	let channel;
 	let endorsement;
 	let endorser;
-	let query;
+	let queryProposal;
 	let commit;
 	let queryHandler;
 	let network;
@@ -93,14 +94,13 @@ describe('Transaction', () => {
 
 	beforeEach(() => {
 		contract = sinon.createStubInstance(Contract);
-
 		network = sinon.createStubInstance(Network);
 		network.queryHandler = queryHandler;
 		contract.network = network;
 
 		idx = sinon.createStubInstance(IdentityContext);
 		endorser = sinon.createStubInstance(Endorser);
-		query = sinon.createStubInstance(Query);
+		queryProposal = sinon.createStubInstance(QueryProposal);
 		endorsement = sinon.createStubInstance(Endorsement);
 		endorsement.send.resolves(newProposalResponse([validEnsorsementResponse]));
 		commit = sinon.createStubInstance(Commit);
@@ -108,7 +108,7 @@ describe('Transaction', () => {
 		endorsement.newCommit.returns(commit);
 		channel = sinon.createStubInstance(Channel);
 		channel.newEndorsement.returns(endorsement);
-		channel.newQuery.withArgs(chaincodeId).returns(query);
+		channel.newQuery.withArgs(chaincodeId).returns(queryProposal);
 		channel.getEndorsers.returns([endorser]);
 		network.channel = channel;
 		queryHandler = {
@@ -423,7 +423,7 @@ describe('Transaction', () => {
 		it('builds correct request for no-args invocation', async () => {
 			await transaction.evaluate();
 
-			sinon.assert.calledWith(query.build, idx, sinon.match({
+			sinon.assert.calledWith(queryProposal.build, idx, sinon.match({
 				fcn: transactionName,
 				args: []
 			}));
@@ -434,7 +434,7 @@ describe('Transaction', () => {
 
 			await transaction.evaluate(...args);
 
-			sinon.assert.calledWith(query.build, idx, sinon.match({
+			sinon.assert.calledWith(queryProposal.build, idx, sinon.match({
 				fcn: transactionName,
 				args
 			}));
@@ -446,7 +446,7 @@ describe('Transaction', () => {
 
 			await transaction.evaluate();
 
-			sinon.assert.calledWith(query.build, idx, sinon.match({transientMap}));
+			sinon.assert.calledWith(queryProposal.build, idx, sinon.match({transientMap}));
 		});
 
 		it('returns empty string response', async () => {
@@ -462,7 +462,7 @@ describe('Transaction', () => {
 
 			await transaction.evaluate();
 
-			sinon.assert.calledWith(query.build, idx, sinon.match({requestTimeout: 55000}));
+			sinon.assert.calledWith(queryProposal.build, idx, sinon.match({requestTimeout: 55000}));
 		});
 	});
 });

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -7,7 +7,7 @@
 /* tslint:disable:max-classes-per-file */
 
 import { Wallet } from '../lib/impl/wallet/wallet';
-import { ChaincodeEvent, Channel, Client, Endorser, EventService, IdentityContext, ProposalResponse, Query, User } from 'fabric-common';
+import { ChaincodeEvent, Channel, Client, Endorser, EventService, IdentityContext, ProposalResponse, User } from 'fabric-common';
 
 export { Wallet };
 export { Wallets } from '../lib/impl/wallet/wallets';
@@ -77,14 +77,25 @@ export class QueryHandlerStrategies {
 	public static MSPID_SCOPE_SINGLE: QueryHandlerFactory;
 }
 
-export type QueryHandlerFactory = (network: Network, options: object) => QueryHandler;
+export type QueryHandlerFactory = (network: Network) => QueryHandler;
 
 export interface QueryHandler {
 	evaluate(query: Query): Promise<Buffer>;
 }
 
+export interface Query {
+	evaluate(targets: Endorser[]): Promise<QueryResults>;
+}
+
 export interface QueryResults {
-	[peerName: string]: Buffer | ProposalResponse;
+	[peerName: string]: Error | QueryResponse;
+}
+
+export interface QueryResponse {
+	isEndorsed: boolean;
+	payload: Buffer;
+	status: number;
+	message: string;
 }
 
 export class Gateway {


### PR DESCRIPTION
Update queryHandler's to use a highlevel wrapper on the
low level query sending. This will sheild the users that
wish to create their own handlers from the sending and
handling of the responses. The handlers will focus on peer
selection. Update the sample and doc.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>