### PR TITLE
FABN-1451 add peer responses to error

### DIFF
--- a/fabric-network/test/transaction.js
+++ b/fabric-network/test/transaction.js
@@ -225,6 +225,13 @@ describe('Transaction', () => {
 			return expect(promise).to.be.rejectedWith(status);
 		});
 
+		it('throws with peer responses if the orderer returns an unsuccessful response', () => {
+			const status = 'FAILURE';
+			channel.sendTransaction.resolves({status});
+			const promise = transaction.submit();
+			return expect(promise).to.be.eventually.rejectedWith(status).and.have.deep.property('responses', [validProposalResponse]);
+		});
+
 		it('sends only valid proposal responses to orderer', async () => {
 			channel.sendTransactionProposal.resolves(mixedProposalResponses);
 			await transaction.submit();

--- a/test/typescript/integration/network-e2e/invoke.ts
+++ b/test/typescript/integration/network-e2e/invoke.ts
@@ -93,7 +93,10 @@ async function testErrorResponse(t: any, contract: Contract): Promise<void> {
 		const response = await contract.submitTransaction('returnError', errorMessage);
 		t.fail('Transaction "returnError" should have thrown an error.  Got response: ' + response.toString());
 	} catch (expectedErr) {
-		if (expectedErr.message.includes(errorMessage)) {
+		if (expectedErr.message.includes(errorMessage) &&
+			expectedErr.responses.length === 2 &&
+			expectedErr.responses[0].status === 500 &&
+			expectedErr.responses[0].message.includes(errorMessage)) {
 			t.pass('Successfully handled invocation errors');
 		} else {
 			t.fail('Unexpected exception: ' + expectedErr);


### PR DESCRIPTION
In submitTransaction(), if there are no valid responses from peers, an error is thrown back to the client.
This PR adds the array of responses to the error object.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>