### PR TITLE
[FABN-1430] Fix type for IServiceResponse (#62)

### DIFF
--- a/fabric-ca-client/types/index.d.ts
+++ b/fabric-ca-client/types/index.d.ts
@@ -144,10 +144,10 @@ declare namespace FabricCAServices {
     }
 
     export interface IServiceResponse {
-        Success: boolean;
-        Result: any;
-        Errors: IServiceResponseMessage[];
-        Messages: IServiceResponseMessage[];
+        success: boolean;
+        result: any;
+        errors: IServiceResponseMessage[];
+        messages: IServiceResponseMessage[];
     }
 
     export interface IAffiliationRequest {


### PR DESCRIPTION
The name of the members of IServiceResponse should start with small
letters as per lib/serverendpoint.go in fabric-ca.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>