### PR TITLE
FABN-1479 NodeSDK fix HSM tests

### DIFF
--- a/fabric-common/lib/impl/bccsp_pkcs11.js
+++ b/fabric-common/lib/impl/bccsp_pkcs11.js
@@ -315,6 +315,8 @@ class CryptoSuite_PKCS11 extends CryptoSuite {
 			}
 			this._pkcs11Session = pkcs11.C_OpenSession(slot, flags);
 
+			logger.debug(__func() + ' after the open , %s', this._pkcs11Session);
+
 			// Getting info about Session
 			logger.debug(__func() + 'C_GetSessionInfo(' +
 				util.inspect(this._pkcs11Session, {depth: null}) + '): ' +
@@ -330,7 +332,7 @@ class CryptoSuite_PKCS11 extends CryptoSuite {
 			// pkcs11.C_Logout(session);
 			// pkcs11.C_CloseSession(session);
 		} catch (e) {
-			if (this._pkcs11Session !== null) {
+			if (this._pkcs11Session) {
 				pkcs11.C_CloseSession(this._pkcs11Session);
 			}
 			pkcs11.C_Finalize();

--- a/scripts/npm_scripts/runTape.sh
+++ b/scripts/npm_scripts/runTape.sh
@@ -22,10 +22,6 @@ runTape() {
         unset E2E_SCRIPT_SUFFIX
     fi
 
-    # force the non HSM for now
-    unset E2E_SCRIPT_SUFFIX
-
-
     # Tests have to executed in the following order
 
     # First run the ca-tests that run good/bad path member registration/enrollment scenarios

--- a/test/integration/network-e2e/idmanager.js
+++ b/test/integration/network-e2e/idmanager.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const Client = require('fabric-client');
+const Utils = require('fabric-common/lib/Utils.js');
 
 class IDManager {
 	constructor(ccp, hsmOptions) {
@@ -16,10 +17,10 @@ class IDManager {
 
 	async initialize() {
 		this.defaultClient = await Client.loadFromConfig(this.ccp);
-		this.defaultClient.setCryptoSuite(Client.newCryptoSuite());
+		this.defaultClient.setCryptoSuite(Utils.newCryptoSuite());
 
 		this.hsmClient = await Client.loadFromConfig(this.ccp);
-		const hsmCryptoSuite = Client.newCryptoSuite(this.hsmOptions);
+		const hsmCryptoSuite = Utils.newCryptoSuite(this.hsmOptions);
 		// Setting a key store triggers enrollment using this crypto suite to store the generated private key in the HSM
 		hsmCryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: '/tmp'}));
 		this.hsmClient.setCryptoSuite(hsmCryptoSuite);


### PR DESCRIPTION
HSM test were failing with the removal of fabric-client
from the packages being published and was added as a
dependent module. Upated test code to be sure is used the
same location of hsm cryptosuite.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>