### PR TITLE
FABN-1483 NodeSDK set self signed cert

### DIFF
--- a/fabric-common/lib/Client.js
+++ b/fabric-common/lib/Client.js
@@ -9,7 +9,8 @@ const TYPE = 'Client';
 const path = require('path');
 const crypto = require('crypto');
 
-const {checkParameter, getLogger, pemToDER, getConfig, setConfigSetting, getConfigSetting} = require('./Utils.js');
+const {checkParameter, getLogger, pemToDER, getConfig, setConfigSetting,
+	getConfigSetting, newCryptoSuite} = require('./Utils.js');
 const Channel = require('./Channel');
 const Endpoint = require('./Endpoint');
 const Committer = require('./Committer');
@@ -405,7 +406,7 @@ const Client = class {
 			// generate X509 cert pair
 			// use the default software cryptosuite, not the client assigned cryptosuite, which may be
 			// HSM, or the default has been set to HSM. FABN-830
-			const key = Client.newCryptoSuite({software: true}).generateEphemeralKey();
+			const key = newCryptoSuite({software: true}).generateEphemeralKey();
 			this._tls_mutual.clientKey = key.toBytes();
 			this._tls_mutual.clientCert = key.generateX509Certificate('fabric-common');
 			this._tls_mutual.selfGenerated = true;

--- a/fabric-common/test/Client.js
+++ b/fabric-common/test/Client.js
@@ -355,7 +355,7 @@ describe('Client', () => {
 				generateX509Certificate: generateX509CertificateStub
 			});
 			const newCryptoSuiteStub = sinon.stub().returns({generateEphemeralKey: generateEphemeralKeyStub});
-			Client.__set__('Client.newCryptoSuite', newCryptoSuiteStub);
+			Client.__set__('newCryptoSuite', newCryptoSuiteStub);
 			const myClient = new Client('client');
 
 			myClient.setTlsClientCertAndKey();

--- a/fabric-network/src/gateway.js
+++ b/fabric-network/src/gateway.js
@@ -209,7 +209,8 @@ class Gateway {
 			logger.debug('%s - setting tlsInfo', method);
 			this.client.setTlsClientCertAndKey(options.tlsInfo.certificate, options.tlsInfo.key);
 		} else {
-			logger.debug('%s - not setting tls', method);
+			logger.debug('%s - using self signed setting for tls', method);
+			this.client.setTlsClientCertAndKey();
 		}
 
 		if (load_ccp) {


### PR DESCRIPTION
When not using client TLS settings (mutual TLS) set the
self signed cert into the low level automatically.
Fixed missing function referrence in fabric-common/Client

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>