### PR TITLE
[FABN-1481] Fix api docs publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,8 @@ stages:
           displayName: Install Node.js
         - script: npm install
           displayName: npm install
+        - script: npm run compile
+          displayName: Compile
         - script: scripts/ci_scripts/azurePublishApiDocs.sh
           displayName: Publish API docs
           env:


### PR DESCRIPTION
- Add compile step in publishDocs job so fabric-network/lib is populated

Signed-off-by: heatherlp <heatherpollard0@gmail.com>