### PR TITLE
FABN-1224 NodeSDK use discovery interests

### DIFF
--- a/docs/tutorials/discovery.md
+++ b/docs/tutorials/discovery.md
@@ -1,0 +1,176 @@
+
+This tutorial illustrates the use of the service discovery by the Hyperledger Fabric Node.js fabric-network SDK.
+
+For more information on:
+* [Service Discovery](https://hyperledger-fabric.readthedocs.io/en/release-2.0/discovery-overview.html#how-service-discovery-works-in-fabric)
+
+The following assumes an understanding of the Hyperledger Fabric network
+(orderers and peers),
+and of Node application development, including the use of the
+Javascript `promise` and `async await`.
+
+### Overview
+The service discovery provided by the Hyperledger Fabric helps an application
+understand the current view of the network. Service discovery also has insight
+into the endorsement policies of chaincodes and is able to provide lists of
+peers that are currently active on the network that could be used to endorse a
+proposal.
+To use the discovery service, the application will have to define just one peer.
+
+#### fabric-network APIs that can use the service discovery
+* `gateway.connect` - This method has been enhanced by adding the discovery options.
+* `gateway.getNetwork` - This method will initialize the network channel using the
+discovery options from the gateway connect.
+* `contract.setDiscoveryInterests` - This method will indicate that this contract
+is participating in a collection and that it may be calling other chaincodes.
+The peer's discovery service will use this information to build an endorsement
+plan that uses the policy information of the contract's chaincodes and collections.
+* `contract.submitTransaction` - When discovery is enabled by the gateway.connect
+options, this method will use discovery to help endorse the proposal.
+* `transaction.submit` - - When discovery is enabled by the gateway.connect
+options, this method will use discovery to help endorse the proposal.
+* `contract.evaluateTransaction` - When discovery is enabled by the gateway.connect
+options, this method will select from the peers that have been discovered during
+the network channel initialization.
+* `transaction.evaluate` - When discovery is enabled by the gateway.connect
+options, this method will select from the peers that have been discovered during
+the network channel initialization.
+
+#### fabric-network gateway.connect DiscoveryOption settings
+* `discovery.enabled` - boolean - True if discovery should be used; otherwise false.
+* `discovery.asLocalHost` - boolean - Convert discovered host addresses to be
+'localhost'. Will be needed when running a docker composed fabric network on the
+local system; otherwise should be disabled.
+
+### To use
+By default the fabric-network will not use the service discovery. To enable the
+use of discovery, set the discovery 'enabled' attribute to a value of true.
+
+```
+await gateway.connect(connectionProfile, {discovery: { enabled: true, asLocalhost: false}});
+const network = await gateway.getNetork('mychannel');
+
+```
+
+### To use with docker-compose
+When the fabric network is running in a docker-compose and the node.js application
+is running outside of the docker containers, it will be necessary to modify the
+addresses returned from the discovery service. The discovery service sees the
+addresses of the peers and orderers as host names and ports as they exist in the
+virtual systems, however the node.js
+application running outside of docker will only know the endpoints as `localhost`
+and port. In the docker-compose file, notice how Docker is mapping the port addresses,
+these must be same when using service discovery. Using `- 7061:7051` will not
+work as the application does not have visibility into the virtual system and
+the port address as seen by the peer's discovery service.
+
+Use the `asLocalhost` with true or false, the default is true.
+```
+await gateway.connect(connectionProfile, {discovery: { enabled: true, asLocalhost: true}});
+const network = await gateway.getNetork('mychannel');
+```
+
+Notice in the following definition of a peer from a docker-compose file.
+The port number is the same and has been defined along with the
+host name `peer0.org1.example.com:7051` for the peer and gossip settings.
+The node.js fabric-client application running outside of of the docker
+containers will use `localhost:7051`. There is a mapping of the host name to
+'localhost' but there is no mapping of the port address.
+```
+peer0.org1.example.com:
+  container_name: peer0.org1.example.com
+  image: hyperledger/fabric-peer
+  environment:
+	- CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+	- CORE_PEER_ID=peer0.org1.example.com
+	- CORE_PEER_ADDRESS=peer0.org1.example.com:7051
+	- CORE_PEER_LISTENADDRESS=peer0.org1.example.com:7051
+	- CORE_PEER_GOSSIP_ENDPOINT=peer0.org1.example.com:7051
+	- CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
+	- FABRIC_LOGGING_SPEC=debug
+	## the following setting redirects chaincode container logs to the peer container logs
+	- CORE_VM_DOCKER_ATTACHSTDOUT=true
+	- CORE_PEER_LOCALMSPID=Org1MSP
+	- CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer
+	##
+	- CORE_PEER_TLS_ENABLED=true
+	- CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+	- CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/msp/peer/tls/key.pem
+	- CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/msp/peer/tls/cert.pem
+	- CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/msp/peer/cacerts/org1.example.com-cert.pem
+	- CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/msp/peer/cacerts/org1.example.com-cert.pem
+	# # the following setting starts chaincode containers on the same
+	# # bridge network as the peers
+	# # https://docs.docker.com/compose/networking/
+	- CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
+  working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+  command: peer node start
+  ports:
+	- 7051:7051
+  volumes:
+	  - /var/run/:/host/var/run/
+	  - ./channel/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/msp/peer
+  depends_on:
+	- orderer.example.com
+```
+
+### using chaincode to chaincode calls and collections
+The peer's discovery service will required information
+on the channel, chaincodes, and collections that are involved in the
+smart contract to develop a valid endorsement plan.
+The contract's channel name and chaincode name will be automatically sent to
+the peer's discovery service unless the contract indicates that it requires
+other chaincodes and collections. These are known as 'discovery interests' to the
+peer's discovery service.
+
+If the endorsement will require one or more chaincode to chaincode calls and/or
+be over collections, then the application must tell the contract object
+instance of these names. This will assist the discovery service in putting
+together an endorsement plan based on all the endorsement policies of the
+chaincodes and collections involved and the active peers on the network.
+The endorsement plan will include those peers that satisfy the endorsement
+policies and the collection policies.
+The discovery interests will be used as is, therefore the contract's chaincode name
+should be included along with any collections.
+The following examples show how to setup the interests JSON object to
+provide to the contract instance when
+a chaincode to chaincode call over collections is required.
+
+
+```
+// use the following when the smart contract's chaincode will be
+// calling another chaincode
+const interest_chaincodes = [
+	{name: 'mychaincode1'},
+	{name: 'mychaincode2'}
+];
+
+// use the following when the smart contract's chaincode is in a
+// collection
+const interest_chaincode_collection = [
+	{
+		name: 'mychaincode1',
+		collection_names: ['mycollection1']
+	}
+];
+
+// use the following when the smart contract's chaincode in multiple
+// collections and is will be calling another chaincode that is in
+// multiple collections
+const interest_chaincodes_collections = [
+	{
+		name: 'mychaincode1',
+		collection_names: ['mycollection1', 'mycollection2']
+	},
+	{
+		name: 'mychaincode2',
+		collection_names: ['mycollection1', 'mycollection2']
+	}
+];
+
+const contract = network.getContract('mychaincode1');
+contract.setDiscoveryInterests(interest_chaincodes);
+```
+
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/tutorials/tutorials.json
+++ b/docs/tutorials/tutorials.json
@@ -22,5 +22,8 @@
 	},
 	"wallet": {
 		"title": "fabric-network: Using wallets to manage identities"
+	},
+	"discocery": {
+		"title": "fabric-network: Using discovery"
 	}
 }

--- a/fabric-common/lib/Proposal.js
+++ b/fabric-common/lib/Proposal.js
@@ -58,9 +58,9 @@ class Proposal extends ServiceAction {
 	}
 
 	/**
-	 * Returns a JSON object representing this proposals chaincodes
-	 * and collections as an interest for the Discovery Service.
-	 * The {@link Discovery} will use the interest to build a query
+	 * Returns an array representing this proposals chaincodes
+	 * and collections as interests for the Discovery Service.
+	 * The {@link Discovery} will use the interests to build a query
 	 * request for an endorsement plan to a Peer's Discovery service.
 	 * Use the {@link Proposal#addCollectionInterest} to add collections
 	 * for the chaincode of this proposal.
@@ -75,24 +75,24 @@ class Proposal extends ServiceAction {
 		const method = `buildProposalInterest[${this.chaincodeId}]`;
 		logger.debug('%s - start', method);
 
-		let interest = [];
+		let interests = [];
 		const chaincode = {};
-		interest.push(chaincode);
+		interests.push(chaincode);
 		chaincode.name = this.chaincodeId;
 		if (this.collectionsInterest.length > 0) {
 			chaincode.collectionNames = this.collectionsInterest;
 		}
 		if (this.chaincodesCollectionsInterest.length > 0) {
-			interest = interest.concat(this.chaincodesCollectionsInterest);
+			interests = interests.concat(this.chaincodesCollectionsInterest);
 		}
 
-		return interest;
+		return interests;
 	}
 
 	/**
 	 * Use this method to add collection names associated
 	 * with this proposal's chaincode name. These will be
-	 * used to build a Discovery interest. {@link Proposal#buildProposalInterest}
+	 * used to build a Discovery interests. {@link Proposal#buildProposalInterest}
 	 * @param {string} collectionName - collection name
 	 */
 	addCollectionInterest(collectionName) {
@@ -110,7 +110,7 @@ class Proposal extends ServiceAction {
 	/**
 	 * Use this method to add a chaincode name and collection names
 	 * that this proposal's chaincode will call. These will be used
-	 * to build a Discovery interest. {@link Proposal#buildProposalInterest}
+	 * to build a Discovery interests. {@link Proposal#buildProposalInterest}
 	 * @param {string} chaincodeId - chaincode name
 	 * @param  {...string} collectionNames - one or more collection names
 	 */

--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -207,10 +207,10 @@ describe('DiscoveryService', () => {
 				discovery.build();
 			}).should.throw('Missing idContext parameter');
 		});
-		it('should require an interest endorsement', () => {
+		it('should require interests endorsement', () => {
 			(() => {
 				discovery.build(idx, {config: false});
-			}).should.throw('No discovery interest provided');
+			}).should.throw('No discovery interests provided');
 		});
 		it('should build with default options', () => {
 			discovery.build(idx);
@@ -233,9 +233,9 @@ describe('DiscoveryService', () => {
 			should.exist(discovery._action);
 			should.exist(discovery._payload);
 		});
-		it('should build with an interest option', () => {
-			const interest = [{name: 'mychaincode'}];
-			discovery.build(idx, {local: true, interest: interest});
+		it('should build with interests option', () => {
+			const interests = [{name: 'mychaincode'}];
+			discovery.build(idx, {local: true, interests: interests});
 			should.exist(discovery._action);
 			should.exist(discovery._payload);
 		});
@@ -379,62 +379,62 @@ describe('DiscoveryService', () => {
 	});
 
 	describe('#_buildProtoChaincodeInterest', () => {
-		it('should handle no interest', () => {
+		it('should handle no interests', () => {
 			const results = discovery._buildProtoChaincodeInterest();
 			should.exist(results.chaincodes);
 		});
 		it('should handle one chaincode', () => {
-			const interest = [{name: 'chaincode1'}];
-			const results = discovery._buildProtoChaincodeInterest(interest);
+			const interests = [{name: 'chaincode1'}];
+			const results = discovery._buildProtoChaincodeInterest(interests);
 			should.exist(results.chaincodes);
 		});
 		it('should handle one chaincode one collection', () => {
-			const interest = [{name: 'chaincode1', collection_names: ['collection1']}];
-			const results = discovery._buildProtoChaincodeInterest(interest);
+			const interests = [{name: 'chaincode1', collection_names: ['collection1']}];
+			const results = discovery._buildProtoChaincodeInterest(interests);
 			should.exist(results.chaincodes);
 		});
 		it('should handle two chaincodes', () => {
-			const interest = [{name: 'chaincode1'}, {name: 'chaincode2'}];
-			const results = discovery._buildProtoChaincodeInterest(interest);
+			const interests = [{name: 'chaincode1'}, {name: 'chaincode2'}];
+			const results = discovery._buildProtoChaincodeInterest(interests);
 			should.exist(results.chaincodes);
 		});
 		it('should handle two chaincode two collection', () => {
-			const interest = [
+			const interests = [
 				{name: 'chaincode1', collection_names: ['collection1']},
 				{name: 'chaincode2', collection_names: ['collection2']}
 			];
-			const results = discovery._buildProtoChaincodeInterest(interest);
+			const results = discovery._buildProtoChaincodeInterest(interests);
 			should.exist(results.chaincodes);
 		});
 		it('should handle two chaincode four collection', () => {
-			const interest = [
+			const interests = [
 				{name: 'chaincode1', collection_names: ['collection1', 'collection3']},
 				{name: 'chaincode2', collection_names: ['collection2', 'collection4']}
 			];
-			const results = discovery._buildProtoChaincodeInterest(interest);
+			const results = discovery._buildProtoChaincodeInterest(interests);
 			should.exist(results.chaincodes);
 		});
 		it('should handle two chaincodes same name', () => {
-			const interest = [{name: 'chaincode1'}, {name: 'chaincode1'}];
-			const results = discovery._buildProtoChaincodeInterest(interest);
+			const interests = [{name: 'chaincode1'}, {name: 'chaincode1'}];
+			const results = discovery._buildProtoChaincodeInterest(interests);
 			should.exist(results.chaincodes);
 		});
 		it('should require a idContext', () => {
 			(() => {
-				const interest = [{name: {}}];
-				discovery._buildProtoChaincodeInterest(interest);
+				const interests = [{name: {}}];
+				discovery._buildProtoChaincodeInterest(interests);
 			}).should.throw('Chaincode name must be a string');
 		});
 		it('should require a idContext', () => {
 			(() => {
-				const interest = [{name: 'chaincode1', collection_names: {}}];
-				discovery._buildProtoChaincodeInterest(interest);
+				const interests = [{name: 'chaincode1', collection_names: {}}];
+				discovery._buildProtoChaincodeInterest(interests);
 			}).should.throw('Collection names must be an array of strings');
 		});
 		it('should require a idContext', () => {
 			(() => {
-				const interest = [{name: 'chaincode1', collection_names: [{}]}];
-				discovery._buildProtoChaincodeInterest(interest);
+				const interests = [{name: 'chaincode1', collection_names: [{}]}];
+				discovery._buildProtoChaincodeInterest(interests);
 			}).should.throw('The collection name must be a string');
 		});
 	});

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -76,36 +76,36 @@ describe('Proposal', () => {
 	});
 
 	describe('#buildProposalInterest', () => {
-		it('should return interest', () => {
-			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}]);
+		it('should return interests', () => {
+			const interests = proposal.buildProposalInterest();
+			interests.should.deep.equal([{name: 'chaincode'}]);
 		});
-		it('should return interest and collections', () => {
+		it('should return interests and collections', () => {
 			const collections = ['col1', 'col2'];
 			proposal.collectionsInterest = collections;
-			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
+			const interests = proposal.buildProposalInterest();
+			interests.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
 		});
-		it('should return interest and chaincode and chaincode collections ', () => {
+		it('should return interests and chaincode and chaincode collections ', () => {
 			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2']};
 			proposal.chaincodesCollectionsInterest = [chaincode_collection];
-			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			const interests = proposal.buildProposalInterest();
+			interests.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
 		});
 	});
 
 	describe('#addCollectionInterest', () => {
-		it('should save collection interest', () => {
+		it('should save collection interests', () => {
 			proposal.addCollectionInterest('col1');
 			proposal.collectionsInterest.should.deep.equal(['col1']);
 		});
-		it('should save collection interest', () => {
+		it('should save collection interests', () => {
 			const collections = ['col1', 'col2'];
 			proposal.addCollectionInterest('col1');
 			proposal.addCollectionInterest('col2');
 			proposal.collectionsInterest.should.deep.equal(collections);
-			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
+			const interests = proposal.buildProposalInterest();
+			interests.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
 		});
 		it('should require a string collection name', () => {
 			(() => {
@@ -115,19 +115,19 @@ describe('Proposal', () => {
 	});
 
 	describe('#addChaincodeCollectionsInterest', () => {
-		it('should save chaincode collection interest', () => {
+		it('should save chaincode collection interests', () => {
 			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2']};
 			proposal.addChaincodeCollectionsInterest('chain2', 'col1', 'col2');
 			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
-			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			const interests = proposal.buildProposalInterest();
+			interests.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
 		});
-		it('should save chaincode only chaincode collection interest', () => {
+		it('should save chaincode only chaincode collection interests', () => {
 			const chaincode_collection = {name: 'chain2'};
 			proposal.addChaincodeCollectionsInterest('chain2');
 			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
-			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			const interests = proposal.buildProposalInterest();
+			interests.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
 		});
 		it('should require a string chaincode name', () => {
 			(() => {

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -111,6 +111,11 @@ export class DiscoveryHandler extends ServiceHandler {
 	query(signedProposal: Buffer, request: any): Promise<any>;
 }
 
+export interface DiscoveryInterest {
+	name: string;
+	collection_names?: string[];
+}
+
 export class ServiceEndpoint {
 	public readonly name: string;
 	constructor(name: string, client: Client, mspid?: string);
@@ -458,11 +463,7 @@ export interface DiscoveryResults {
 	timestamp: number;
 }
 
-export interface DiscoveryChaincodeCall {
+export interface DiscoveryInterest {
 	name: string;
 	collection_names?: string[];
-}
-
-export interface DiscoveryChaincodeInterest {
-	chaincodes: DiscoveryChaincodeCall[];
 }

--- a/fabric-network/src/contract.js
+++ b/fabric-network/src/contract.js
@@ -176,12 +176,23 @@ class Contract {
 				const targets = this.network.discoveryService.targets;
 				const idx = this.network.gateway.identityContext;
 				const asLocalhost = this.network.gateway.getOptions().discovery.asLocalhost;
-				// this will tell discovery to build a plan based on the chaincode id
-				// and collections names of this contract that the endorsement must
-				// have been assigned.
-				const interest = endorsement.buildProposalInterest();
+				let interests;
+				if (this.discoveryInterests) {
+					// this will tell discovery to build a plan based on what the
+					// application has determined, the application must include all
+					// chaincodes this chaincode may call, including the name of
+					// this chaincode. Included with each chaincode name is the list
+					// of collections names of the chaincode.
+					interests = this.discoveryInterests;
+				} else {
+					// this will tell discovery to build a plan based on the chaincode id
+					// and collections names of this contract that the endorsement must
+					// have been assigned.
+					interests = endorsement.buildProposalInterest();
+				}
 
-				this.discoveryService.build(idx, {interest});
+
+				this.discoveryService.build(idx, {interests});
 				this.discoveryService.sign(idx);
 
 				// go get the endorsement plan from the peer's discovery service
@@ -201,6 +212,30 @@ class Contract {
 		}
 	}
 
+	/**
+	 * Provide the Discovery Interests settings to help the peer's discovery service
+	 * build an endorsement plan. This interests must include this contract's
+	 * chaincode name and any chaincode names that this chaincode may call. Must
+	 * include the collection names the chaincodes may belong.
+	 * @param {DiscoveryIntereset[]} interests - These will be used
+	 * as the interests when the {@link DiscoveryService} builds a discovery request
+	 * if the {@link module:fabric-network.Transaction#submit} is using discovery.
+	 */
+	setDiscoveryInterests(interests) {
+		this.discoveryInterests = interests;
+
+		return this;
+	}
+
+	/**
+	 * Retrieve the Discovery Interests settings that will help the peer's
+	 * discovery service build an endorsement plan.
+	 * @return {DiscoveryIntereset[]} - These will be used
+	 * as the interests when the {@link DiscoveryService} builds a discovery request.
+	 */
+	getDiscoveryInterests() {
+		return this.discoveryInterests;
+	}
 }
 
 module.exports = Contract;

--- a/fabric-network/test/contract.js
+++ b/fabric-network/test/contract.js
@@ -64,7 +64,7 @@ describe('Contract', () => {
 		transaction.evaluate.resolves('result');
 
 		endorsement = sinon.createStubInstance(Endorsement);
-		endorsement.buildProposalInterest.returns('interest');
+		endorsement.buildProposalInterest.returns('interests');
 
 		Contract.__set__('ContractEventListener', FakeListener);
 		contract = new Contract(network, chaincodeId, namespace, collections);
@@ -160,6 +160,46 @@ describe('Contract', () => {
 			network.discoveryService = discoveryService;
 			const handler = await contract.getDiscoveryHandler(endorsement);
 			expect(handler).to.equal('handler');
+		});
+		it('should use the discoveryInterests assigned', async () => {
+			network.discoveryService = discoveryService;
+			contract.discoveryInterests = 'appinterests';
+			const handler = await contract.getDiscoveryHandler(endorsement);
+			expect(handler).to.equal('handler');
+			sinon.assert.calledWith(discoveryService.build, 'idx', {interests: 'appinterests'});
+		});
+		it('should use the chaincodeid as interests', async () => {
+			network.discoveryService = discoveryService;
+			const handler = await contract.getDiscoveryHandler(endorsement);
+			expect(handler).to.equal('handler');
+			sinon.assert.calledWith(discoveryService.build, 'idx', {interests: 'interests'});
+		});
+	});
+
+	describe('#setDiscoveryInterests', () => {
+		it('set the interst object', async () => {
+			const discoveryInterests = 'interests';
+			contract.setDiscoveryInterests(discoveryInterests);
+			contract.discoveryInterests.should.equal(discoveryInterests);
+		});
+		it('unset the interst object', async () => {
+			const discoveryInterests = 'interests';
+			contract.setDiscoveryInterests(discoveryInterests);
+			contract.discoveryInterests.should.equal(discoveryInterests);
+			contract.setDiscoveryInterests(null);
+			expect(contract.discoveryInterests).to.be.null;
+		});
+	});
+	describe('#getDiscoveryInterests', () => {
+		it('get the interests object', async () => {
+			const discoveryInterests = 'interests';
+			contract.setDiscoveryInterests(discoveryInterests);
+			const result = contract.getDiscoveryInterests();
+			result.should.equal(discoveryInterests);
+		});
+		it('get and umset interests object', async () => {
+			const result = contract.getDiscoveryInterests();
+			expect(result).to.be.undefined;
 		});
 	});
 });

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -8,13 +8,12 @@
 
 import { Wallet } from '../lib/impl/wallet/wallet';
 import { CommitListener } from '../lib/impl/event/commitlistener';
-import { Identity } from '../lib/impl/wallet/identity';
-import { ChaincodeEvent, Channel, Client, Endorser, EventService, IdentityContext, ProposalResponse, User } from 'fabric-common';
+import { ChaincodeEvent, Channel, Client, DiscoveryInterest, Endorser, EventService, IdentityContext, ProposalResponse, User } from 'fabric-common';
 
 export { Wallet };
 export { Wallets } from '../lib/impl/wallet/wallets';
 export { WalletStore } from '../lib/impl/wallet/walletstore';
-export { Identity };
+export { Identity } from '../lib/impl/wallet/identity';
 export { IdentityData } from '../lib/impl/wallet/identitydata';
 export { IdentityProvider } from '../lib/impl/wallet/identityprovider';
 export { IdentityProviderRegistry } from '../lib/impl/wallet/identityproviderregistry';
@@ -107,6 +106,7 @@ export class Contract {
 	createTransaction(name: string): Transaction;
 	evaluateTransaction(name: string, ...args: string[]): Promise<Buffer>;
 	submitTransaction(name: string, ...args: string[]): Promise<Buffer>;
+	setDiscoveryInterests(interests: DiscoveryInterest[]): Contract;
 }
 
 export interface TransientMap {

--- a/test/scenario/features/lib/common_connection.js
+++ b/test/scenario/features/lib/common_connection.js
@@ -64,7 +64,7 @@ class CommonConnectionProfile {
 
 	/**
 	 * Retrieve the channel Object based on name
-	 * @param {String} channelName the channel of interest
+	 * @param {String} channelName the channel of interests
 	 * @return {Object} the channel object
 	 */
 	getChannel(channelName) {
@@ -81,7 +81,7 @@ class CommonConnectionProfile {
 
 	/**
 	 * Retrieve the organization object
-	 * @param {String} orgName the organization of interest
+	 * @param {String} orgName the organization of interests
 	 * @return {Object} the organization object
 	 */
 	getOrganization(orgName) {
@@ -90,7 +90,7 @@ class CommonConnectionProfile {
 
 	/**
 	 * Retrieve the organizations included within a channel
-	 * @param {String} channelName the channel of interest
+	 * @param {String} channelName the channel of interests
 	 * @return {String[]} the organizations associated with a channel
 	 */
 	getOrganizationsForChannel(channelName) {
@@ -129,7 +129,7 @@ class CommonConnectionProfile {
 
 	/**
 	 * Retrieve all orderers from a named channel
-	 * @param {String} channelName the channel of interest
+	 * @param {String} channelName the channel of interests
 	 * @return {Object[]} orderers for the named channel
 	 */
 	getOrderersForChannel(channelName) {
@@ -190,7 +190,7 @@ class CommonConnectionProfile {
 
 	/**
 	 * Retrieve all peers for a named channel in the profile
-	 * @param {String} channelName the channel name of interest
+	 * @param {String} channelName the channel name of interests
 	 * @return {String[]} the string array of all peer for the channel
 	 */
 	getPeersForChannel(channelName) {

--- a/test/scenario/features/steps/base_steps.js
+++ b/test/scenario/features/steps/base_steps.js
@@ -308,7 +308,7 @@ module.exports = function () {
 						testUtil.logAndThrow('Discovery checkConnection test failed');
 					}
 					// pass in an endorsement, this will provide the chaincode name
-					// as an "interest" for the discovery request. The peer's discovery
+					// as an "interests" for the discovery request. The peer's discovery
 					// service will then be able to build an endorsement plan.
 					discovery.build(idx, {endorsement: endorsement});
 					discovery.sign(idx);

--- a/test/ts-scenario/steps/lib/contract.ts
+++ b/test/ts-scenario/steps/lib/contract.ts
@@ -158,7 +158,7 @@ export async function cli_lifecycle_chaincode_query_installed(orgName: string): 
 
 /**
  * Use the CLI container to retrieve a package id for lifecycle installed chaincode
- * @param {string} label the chaincode label name of interest
+ * @param {string} label the chaincode label name of interests
  * @param {string} orgName the organization to use
  */
 export async function retrievePackageIdForLabelOnOrg(label: string, orgName: string): Promise<string> {

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -16,6 +16,7 @@ import { createTransactionEventHandler as sampleTxnEventStrategy } from '../../c
 import { DefaultEventHandlerStrategies, QueryHandlerStrategies, Gateway, GatewayOptions, Wallet, Wallets, Identity, Contract, Network, TxEventHandlerFactory, QueryHandlerFactory, Transaction, TransientMap } from 'fabric-network';
 import * as fs from 'fs';
 import * as path from 'path';
+import { DiscoveryInterest } from 'fabric-common';
 
 const stateStore: StateStore = StateStore.getInstance();
 const txnTypes: string[] = ['evaluate', 'submit'];
@@ -398,6 +399,13 @@ export async function performTransientGatewayTransaction(gatewayName: string, cc
 	const gateway: Gateway = gatewayObj.gateway;
 	const network: Network = await gateway.getNetwork(channelName);
 	const contract: Contract = network.getContract(ccName);
+	const options = gateway.getOptions();
+	if (options.discovery && options.discovery.enabled) {
+		const interests: DiscoveryInterest[] = [
+			{name: ccName}
+		];
+		contract.setDiscoveryInterests(interests);
+	}
 
 	// Build a transaction
 	const transaction: Transaction = contract.createTransaction(func);


### PR DESCRIPTION
Add discovery interests to the fabric-network. This will
allow for endorsement plans to be provided from the peer's
discovery service that consider chaincode to chaincode
calls and collections.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>