### PR TITLE
FABN-1481: Add Node 12 to compatibility matrix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,5 +80,5 @@ The following tables show versions of Fabric, Node and other dependencies that a
 |     | Tested | Supported |
 | --- | ------ | --------- |
 | **Fabric** | 1.4 | 1.4.x, 2.0.x |
-| **Node** | 10 | 8.9+, 10.13+ |
+| **Node** | 10, 12 | 10.13+, 12.13+ |
 | **Platform** | Ubuntu 18.04 | |


### PR DESCRIPTION
Also remove Node 8 since it out of support and we do not test with it.