### PR TITLE
Match fabric-network API to v1.4 as closely as possible

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,9 @@
 trigger:
 - master
 
+pr:
+  - master
+
 pool:
   vmImage: 'ubuntu-18.04'
 

--- a/fabric-network/src/gateway.js
+++ b/fabric-network/src/gateway.js
@@ -97,11 +97,11 @@ class Gateway {
 
 		// initial options - override with the connect()
 		this.options = {
-			query: {
+			queryHandlerOptions: {
 				timeout: 30, // 30 seconds
 				strategy: QueryStrategies.MSPID_SCOPE_SINGLE
 			},
-			transaction: {
+			eventHandlerOptions: {
 				endorseTimeout: 30, // 30 seconds
 				commitTimeout: 300, // 5 minutes
 				strategy: EventStrategies.MSPID_SCOPE_ALLFORTX

--- a/fabric-network/src/impl/event/filteredevents.ts
+++ b/fabric-network/src/impl/event/filteredevents.ts
@@ -36,7 +36,7 @@ export function newFilteredBlockEvent(eventInfo: EventInfo): FilteredBlockEvent 
 		getTransactionEvents: () => getTransactionEvents(blockEvent)
 	};
 
-	return blockEvent;
+	return Object.freeze(blockEvent);
 }
 
 export function newCommitEvent(peer: Endorser, eventInfo: EventInfo): CommitEvent {
@@ -58,7 +58,7 @@ export function newCommitEvent(peer: Endorser, eventInfo: EventInfo): CommitEven
 		return transactionEvent;
 	}
 
-	return {
+	const commitEvent: CommitEvent = {
 		peer: peer,
 		transactionId: transactionId,
 		status: eventInfo.status!,
@@ -69,6 +69,8 @@ export function newCommitEvent(peer: Endorser, eventInfo: EventInfo): CommitEven
 		getBlockEvent: () => getBlockEvent(),
 		getContractEvents: () => getTransactionEvent().getContractEvents()
 	};
+
+	return Object.freeze(commitEvent);
 }
 
 function newFilteredTransactionEvents(blockEvent: FilteredBlockEvent): FilteredTransactionEvent[] {

--- a/fabric-network/src/impl/event/transactioneventhandler.ts
+++ b/fabric-network/src/impl/event/transactioneventhandler.ts
@@ -66,7 +66,7 @@ export class TransactionEventHandler implements TxEventHandler {
 		const defaultOptions: any = {
 			commitTimeout: 30
 		};
-		this.options = Object.assign(defaultOptions, network.getGateway().getOptions().transaction);
+		this.options = Object.assign(defaultOptions, network.getGateway().getOptions().eventHandlerOptions);
 
 		logger.debug('%s: transactionId = %s, options = %j', method, this.transactionId, this.options);
 

--- a/fabric-network/src/network.ts
+++ b/fabric-network/src/network.ts
@@ -171,8 +171,8 @@ export class NetworkImpl implements Network {
 		this.initialized = true;
 
 		// Must be created after channel initialization to ensure discovery has located the peers
-		const queryOptions = this.gateway.getOptions().query;
-		this.queryHandler = queryOptions.strategy(this, queryOptions);
+		const queryOptions = this.gateway.getOptions().queryHandlerOptions;
+		this.queryHandler = queryOptions.strategy(this);
 		logger.debug('%s - end', method);
 	}
 

--- a/fabric-network/src/transaction.js
+++ b/fabric-network/src/transaction.js
@@ -91,7 +91,7 @@ class Transaction {
 		this._name = name;
 		this._transientMap = null;
 		this._options = contract.gateway.getOptions();
-		this._eventHandlerStrategyFactory = this._options.transaction.strategy || noOpEventHandlerStrategyFactory;
+		this._eventHandlerStrategyFactory = this._options.eventHandlerOptions.strategy || noOpEventHandlerStrategyFactory;
 		this._isInvoked = false;
 		this.queryHandler = contract.network.queryHandler;
 		this._endorsingPeers = null; // for user assigned endorsements
@@ -180,9 +180,11 @@ class Transaction {
 		logger.debug('%s - start', method);
 
 		const channel = this.contract.network.channel;
+		const transactionOptions = this._options.eventHandlerOptions;
+
 		const endorsementOptions = this._buildEndorsementOptions(args);
-		if (Number.isInteger(this._options.transaction.endorseTimeout)) {
-			endorsementOptions.requestTimeout = this._options.transaction.endorseTimeout * 1000; // in ms;
+		if (Number.isInteger(transactionOptions.endorseTimeout)) {
+			endorsementOptions.requestTimeout = transactionOptions.endorseTimeout * 1000; // in ms;
 		}
 
 		// This is the object that will centralize this endorsement activities
@@ -237,8 +239,8 @@ class Transaction {
 			await eventHandler.startListening();
 
 			const commitOptions = {};
-			if (Number.isInteger(this._options.transaction.commitTimeout)) {
-				commitOptions.requestTimeout = this._options.transaction.commitTimeout * 1000; // in ms;
+			if (Number.isInteger(transactionOptions.commitTimeout)) {
+				commitOptions.requestTimeout = transactionOptions.commitTimeout * 1000; // in ms;
 			}
 			if (endorsementOptions.handler) {
 				logger.debug('%s - use discovery to commit', method);
@@ -306,9 +308,11 @@ class Transaction {
 		const method = `evaluate[${this._name}]`;
 		logger.debug('%s - start', method);
 
+		const queryOptions = this._options.queryHandlerOptions;
+
 		const request = this._buildEndorsementOptions(args);
-		if (Number.isInteger(this._options.query.timeout)) {
-			request.requestTimeout = this._options.query.timeout * 1000; // in ms;
+		if (Number.isInteger(queryOptions.timeout)) {
+			request.requestTimeout = queryOptions.timeout * 1000; // in ms;
 		}
 
 		const queryProposal = this.contract.network.channel.newQuery(this.contract.chaincodeId);
@@ -317,7 +321,6 @@ class Transaction {
 		queryProposal.build(this.identityContext, request);
 		queryProposal.sign(this.identityContext);
 
-		const queryOptions = this.contract.gateway.getOptions().query;
 		const query = new Query(queryProposal, queryOptions);
 
 		logger.debug('%s - handler will send', method);

--- a/fabric-network/test/contract.js
+++ b/fabric-network/test/contract.js
@@ -45,7 +45,7 @@ describe('Contract', () => {
 		gateway = sinon.createStubInstance(Gateway);
 		gateway.identityContext = 'idx';
 		gateway.getOptions.returns({
-			transaction: 'options',
+			eventHandlerOptions: 'options',
 			discovery: {
 				asLocalhost: true
 			}

--- a/fabric-network/test/gateway.js
+++ b/fabric-network/test/gateway.js
@@ -368,28 +368,30 @@ describe('Gateway', () => {
 				wallet
 			};
 			await gateway.connect('ccp', options);
-			gateway.options.transaction.strategy.should.be.a('Function');
+			gateway.getOptions().eventHandlerOptions.strategy.should.be.a('Function');
 		});
 
 		it('allows transaction event handling strategy to be specified', async () => {
 			const stubStrategyFn = function stubStrategyFn() { };
 			const options = {
 				wallet,
-				eventStrategy: stubStrategyFn
+				eventHandlerOptions: {
+					strategy: stubStrategyFn
+				}
 			};
 			await gateway.connect('ccp', options);
-			gateway.options.eventStrategy.should.equal(stubStrategyFn);
+			gateway.getOptions().eventHandlerOptions.strategy.should.equal(stubStrategyFn);
 		});
 
 		it('allows null transaction event handling strategy to be set', async () => {
 			const options = {
 				wallet,
-				transaction: {
+				eventHandlerOptions: {
 					strategy: null
 				}
 			};
 			await gateway.connect('ccp', options);
-			should.equal(gateway.options.transaction.strategy, null);
+			should.equal(gateway.getOptions().eventHandlerOptions.strategy, null);
 		});
 
 		it('should assign connection options to the client', async () => {
@@ -437,13 +439,13 @@ describe('Gateway', () => {
 			it('should return the options', () => {
 				const expectedOptions = {
 					wallet: 'something',
-					query: {
+					queryHandlerOptions: {
 						timeout: 30,
 						strategy: QueryStrategies.MSPID_SCOPE_SINGLE
 					}
 				};
 				gateway.getOptions().should.deep.include(expectedOptions);
-				gateway.getOptions().transaction.should.include({
+				gateway.getOptions().eventHandlerOptions.should.include({
 					commitTimeout: 300
 				});
 			});

--- a/fabric-network/test/impl/event/transactioneventhandler.ts
+++ b/fabric-network/test/impl/event/transactioneventhandler.ts
@@ -86,7 +86,7 @@ describe('TransactionEventHandler', () => {
 
 	describe('#constructor', () => {
 		it('has a default timeout', () => {
-			options.transaction = {};
+			options.eventHandlerOptions = {};
 			const test: any = new TransactionEventHandler(transactionId, network, strategy);
 			expect(test.options.commitTimeout).to.equal(30);
 		});
@@ -243,7 +243,7 @@ describe('TransactionEventHandler', () => {
 		});
 
 		it('fails on timeout if timeout set', async () => {
-			options.transaction = {commitTimeout: 418};
+			options.eventHandlerOptions = {commitTimeout: 418};
 			handler = new TransactionEventHandler(transactionId, network, strategy);
 
 			await handler.startListening();
@@ -255,7 +255,7 @@ describe('TransactionEventHandler', () => {
 
 		it('does not timeout if timeout set to zero', async () => {
 			stubStrategy.eventReceived.callsArg(0);
-			options.transaction = {commitTimeout: 0};
+			options.eventHandlerOptions = {commitTimeout: 0};
 			handler = new TransactionEventHandler(transactionId, network, strategy);
 
 			await handler.startListening();
@@ -266,7 +266,7 @@ describe('TransactionEventHandler', () => {
 		});
 
 		it('timeout failure message includes peers that have not responded', async () => {
-			options.transaction = {commitTimeout: 418};
+			options.eventHandlerOptions = {commitTimeout: 418};
 			handler = new TransactionEventHandler(transactionId, network, strategy);
 
 			await handler.startListening();
@@ -278,7 +278,7 @@ describe('TransactionEventHandler', () => {
 
 		it('does not timeout if no peers', async () => {
 			stubStrategy.getPeers.returns([]);
-			options.transaction = {commitTimeout: 418};
+			options.eventHandlerOptions = {commitTimeout: 418};
 			handler = new TransactionEventHandler(transactionId, network, strategy);
 
 			await handler.startListening();
@@ -288,7 +288,7 @@ describe('TransactionEventHandler', () => {
 		});
 
 		it('timeout failure error has transaction ID property', async () => {
-			options.transaction = {commitTimeout: 418};
+			options.eventHandlerOptions = {commitTimeout: 418};
 			handler = new TransactionEventHandler(transactionId, network, strategy);
 
 			await handler.startListening();

--- a/fabric-network/test/network.js
+++ b/fabric-network/test/network.js
@@ -74,12 +74,12 @@ describe('Network', () => {
 		gateway.identityContext = identityContext;
 		gateway.getOptions.returns({
 			useDiscovery: false,
-			transaction: {
+			eventHandlerOptions: {
 				endorseTimeout: 30,
 				commitTimeout: 300,
 				strategy: EventStrategies.MSPID_SCOPE_ALLFORTX
 			},
-			query: {
+			queryHandlerOptions: {
 				timeout: 3,
 				strategy: (theNetwork) => {
 					queryHandler.network = theNetwork;

--- a/fabric-network/test/transaction.js
+++ b/fabric-network/test/transaction.js
@@ -136,10 +136,10 @@ describe('Transaction', () => {
 		mockGateway.identityContext = idx;
 
 		gatewayOptions = {
-			query: {
+			queryHandlerOptions: {
 				strategy: QueryStrategies.MSPID_SCOPE_SINGLE
 			},
-			transaction: {
+			eventHandlerOptions: {
 				strategy: null
 			},
 			discovery: {
@@ -272,7 +272,7 @@ describe('Transaction', () => {
 		it('uses event handler strategy from gateway options', async () => {
 			const stubEventHandler = sinon.createStubInstance(TransactionEventHandler);
 			const stubEventHandlerFactoryFn = sinon.stub().withArgs(transactionId, network).returns(stubEventHandler);
-			gatewayOptions.transaction.strategy = stubEventHandlerFactoryFn;
+			gatewayOptions.eventHandlerOptions.strategy = stubEventHandlerFactoryFn;
 			transaction = new Transaction(contract, transactionName);
 
 			await transaction.submit();
@@ -296,7 +296,7 @@ describe('Transaction', () => {
 		});
 
 		it('sends proposal using endorsement timeout from gateway options', async () => {
-			gatewayOptions.transaction.endorseTimeout = 55;
+			gatewayOptions.eventHandlerOptions.endorseTimeout = 55;
 
 			await transaction.submit();
 
@@ -361,7 +361,7 @@ describe('Transaction', () => {
 		});
 
 		it('commits using timeout from gateway options', async () => {
-			gatewayOptions.transaction.commitTimeout = 55;
+			gatewayOptions.eventHandlerOptions.commitTimeout = 55;
 
 			await transaction.submit();
 
@@ -436,7 +436,7 @@ describe('Transaction', () => {
 		});
 
 		it('builds correct request with timeout from gateway options', async () => {
-			gatewayOptions.query.timeout = 55;
+			gatewayOptions.queryHandlerOptions.timeout = 55;
 
 			await transaction.evaluate();
 

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -46,30 +46,27 @@ export interface GatewayOptions {
 	identity: string;
 	clientTlsIdentity?: string;
 	discovery?: DiscoveryOptions;
-	transaction?: TransactionOptions;
-	query?: QueryOptions;
+	eventHandlerOptions?: DefaultEventHandlerOptions;
+	queryHandlerOptions?: DefaultQueryHandlerOptions;
 }
 
 export interface DiscoveryOptions {
 	asLocalhost?: boolean;
 	enabled?: boolean;
-	maxAge?: number;
 }
 
-export interface TransactionOptions {
+export interface DefaultEventHandlerOptions {
 	commitTimeout?: number;
 	endorseTimeout?: number;
 	strategy?: TxEventHandlerFactory | null;
 }
 
-export interface QueryOptions {
+export interface DefaultQueryHandlerOptions {
 	strategy?: QueryHandlerFactory;
 	timeout?: number;
 }
 
 export class Gateway {
-	public client: Client;
-	public identityContext: IdentityContext;
 	constructor();
 	public connect(config: Client | string | object, options: GatewayOptions): Promise<void>;
 	public disconnect(): void;

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -218,22 +218,22 @@ export async function performGatewayTransaction(gatewayName: string, contractNam
 		if (submit) {
 			// add event handler options
 			if (handlerOption.localeCompare('custom') === 0) {
-				currentOptions.transaction = {
+				currentOptions.eventHandlerOptions = {
 					strategy: sampleTxnEventStrategy as TxEventHandlerFactory
 				};
 			} else {
-				currentOptions.transaction = {
+				currentOptions.eventHandlerOptions = {
 					strategy: EventStrategies[handlerOption]
 				};
 			}
 		} else {
 			// Add queryHandlerOptions
 			if (handlerOption.localeCompare('custom') === 0) {
-				currentOptions.query = {
+				currentOptions.queryHandlerOptions = {
 					strategy: sampleQueryStrategy as QueryHandlerFactory
 				};
 			} else {
-				currentOptions.query = {
+				currentOptions.queryHandlerOptions = {
 					strategy: QueryStrategies[handlerOption]
 				};
 			}


### PR DESCRIPTION
- Remove Gateway.client
- Remove Gateway.identityContext
- Rename TransactionOptions to DefaultEventHandlerOptions
- Rename transaction option to eventHandlerOptions
- Rename QueryOptions to DefaultQueryHandlerOptions
- Rename query option to queryHandlerOptions
- Remove 'maxAge' from DiscoveryOptions (not used)