### PR TITLE
FABN-1515: consume CKS as a synchronus function

### DIFF
--- a/fabric-client/lib/utils.js
+++ b/fabric-client/lib/utils.js
@@ -410,13 +410,10 @@ const CryptoKeyStore = function (KVSImplClass, opts) {
 			if (self._store === null) {
 				self.logger.debug(util.format('This class requires a CryptoKeyStore to save keys, using the store: %j', self._storeConfig));
 
-				CKS(self._storeConfig.superClass, self._storeConfig.opts).then((ks) => {
-					self.logger.debug('_getKeyStore returning ks');
-					self._store = ks;
-					return resolve(self._store);
-				}).catch((err) => {
-					reject(err);
-				});
+				const ks = CKS(self._storeConfig.superClass, self._storeConfig.opts);
+				self.logger.debug('_getKeyStore returning ks');
+				self._store = ks;
+				resolve(self._store);
 			} else {
 				self.logger.debug('_getKeyStore resolving store');
 				return resolve(self._store);

--- a/fabric-client/lib/utils.js
+++ b/fabric-client/lib/utils.js
@@ -402,23 +402,21 @@ const CryptoKeyStore = function (KVSImplClass, opts) {
 
 	};
 
-	this._getKeyStore = function () {
+	this._getKeyStore = async function () {
 		const CKS = require('./impl/CryptoKeyStore.js');
 
 		const self = this;
-		return new Promise((resolve, reject) => {
-			if (self._store === null) {
-				self.logger.debug(util.format('This class requires a CryptoKeyStore to save keys, using the store: %j', self._storeConfig));
+		if (self._store === null) {
+			self.logger.debug(util.format('This class requires a CryptoKeyStore to save keys, using the store: %j', self._storeConfig));
 
-				const ks = CKS(self._storeConfig.superClass, self._storeConfig.opts);
-				self.logger.debug('_getKeyStore returning ks');
-				self._store = ks;
-				resolve(self._store);
-			} else {
-				self.logger.debug('_getKeyStore resolving store');
-				return resolve(self._store);
-			}
-		});
+			const ks = await CKS(self._storeConfig.superClass, self._storeConfig.opts);
+			self.logger.debug('_getKeyStore returning ks');
+			self._store = ks;
+			return self._store;
+		} else {
+			self.logger.debug('_getKeyStore resolving store');
+			return self._store;
+		}
 	};
 
 };


### PR DESCRIPTION
function calls to CKS were assuming they returned promises. however the default implementation is a synchronous call. I have updated the code to leverage async/await which will handle both the cases where CKS is meant to be sync or async.