### PR TITLE
FABN-1518: Update JSDoc for event listening

### DIFF
--- a/fabric-network/index.js
+++ b/fabric-network/index.js
@@ -276,6 +276,7 @@
  * @interface BlockEvent
  * @memberof module:fabric-network
  * @see module:fabric-network.FilteredBlockEvent
+ * @see module:fabric-network.FullBlockEvent
  * @property {module:fabric-network.EventType} type The type of this block event.
  * @property {Long} blockNumber The number of the block this event represents.
  */
@@ -306,10 +307,28 @@
 
 
 /**
+ * The type for BlockEvent objects with a type of <code>full</code>.
+ * @interface FullBlockEvent
+ * @implements {module:fabric-network.BlockEvent}
+ * @memberof module:fabric-network
+ * @property {'full'} type The type of this block event.
+ * @property {Block} blockData The raw block event protobuf.
+ */
+
+/**
+ * Get the transactions included in this block.
+ * @method FilteredBlockEvent#getTransactionEvents
+ * @memberof module:fabric-network
+ * @returns {module:fabric-network.FullTransactionEvent[]} Transaction events.
+ */
+
+
+/**
  * Event representing a transaction processed within a block.
  * @interface TransactionEvent
  * @memberof module:fabric-network
  * @see module:fabric-network.FilteredTransactionEvent
+ * @see module:fabric-network.FullTransactionEvent
  * @property {module:fabric-network.EventType} type The type of this transaction event.
  * @property {string} transactionId The ID of the transaction this event represents.
  * @property {string} status The status of this transaction.
@@ -334,6 +353,7 @@
 
 
 /**
+ * The type for TransactionEvent objects with a type of <code>filtered</code>.
  * @interface FilteredTransactionEvent
  * @implements {module:fabric-network.TransactionEvent}
  * @memberof module:fabric-network
@@ -350,9 +370,33 @@
 
 /**
  * Get the contract events emitted by this transaction.
- * @method TransactionEvent#getContractEvents
+ * @method FilteredTransactionEvent#getContractEvents
  * @memberof module:fabric-network
  * @returns {module:fabric-network.FilteredContractEvent[]} Contract events.
+ */
+
+
+/**
+ * The type for TransactionEvent objects with a type of <code>full</code>.
+ * @interface FullTransactionEvent
+ * @implements {module:fabric-network.TransactionEvent}
+ * @memberof module:fabric-network
+ * @property {'full'} type The type of this transaction event.
+ * @property {any} transactionData The raw transaction event protobuf.
+ */
+
+/**
+ * Get the parent block event for this event.
+ * @method FullTransactionEvent#getBlockEvent
+ * @memberof module:fabric-network
+ * @returns {module:fabric-network.FullBlockEvent} Transaction event protobuf.
+ */
+
+/**
+ * Get the contract events emitted by this transaction.
+ * @method FullTransactionEvent#getContractEvents
+ * @memberof module:fabric-network
+ * @returns {module:fabric-network.FullContractEvent[]} Contract events.
  */
 
 
@@ -361,9 +405,12 @@
  * @interface ContractEvent
  * @memberof module:fabric-network
  * @see module:fabric-network.FilteredContractEvent
+ * @see module:fabric-network.FullContractEvent
  * @property {module:fabric-network.EventType} type The type of this contract event.
  * @property {string} chaincodeId The chaincode ID of the smart contract that emitted this event.
  * @property {string} eventName The name of the emitted event.
+ * @property {Buffer} [payload] The data associated with this event by the smart contract. Note that filtered events
+ * do not include any payload data.
  */
 
 /**
@@ -375,18 +422,36 @@
 
 
 /**
- * Event representing a contract event emitted by a smart contract.
+ * The type for ContractEvent objects with a type of <code>filtered</code>.
  * @interface FilteredContractEvent
  * @implements {module:fabric-network.ContractEvent}
  * @memberof module:fabric-network
  * @property {'filtered'} type The type of this contract event.
+ * @property {undefined} payload Filtered events do not incude any payload data.
  */
 
 /**
  * Get the parent transaction event of this event.
- * @method ContractEvent#getTransactionEvent
+ * @method FilteredContractEvent#getTransactionEvent
  * @memberof module:fabric-network
  * @returns {module:fabric-network.FilteredTransactionEvent} A transaction event.
+ */
+
+
+/**
+ * The type for TransactionEvent objects with a type of <code>full</code>.
+ * @interface FullContractEvent
+ * @implements {module:fabric-network.ContractEvent}
+ * @memberof module:fabric-network
+ * @property {'full'} type The type of this contract event.
+ * @property {Buffer} payload The data associated with this event by the smart contract.
+ */
+
+/**
+ * Get the parent transaction event of this event.
+ * @method FullContractEvent#getTransactionEvent
+ * @memberof module:fabric-network
+ * @returns {module:fabric-network.FullTransactionEvent} A transaction event.
  */
 
 

--- a/fabric-network/src/contract.js
+++ b/fabric-network/src/contract.js
@@ -128,14 +128,14 @@ class Contract {
 	}
 
 	/**
-	 * Add a listener to receive all contract events emitted by the smart contract.
-     * The default is to listen for full contract events from the current block position.
+	 * Add a listener to receive all contract events emitted by the smart contract as part of successfully committed
+	 * transactions. The default is to listen for full contract events from the current block position.
 	 * @param {module:fabric-network.ContractListener} listener A contract listener callback function.
 	 * @param {module:fabric-network.ListenerOptions} [options] Listener options.
 	 * @returns {Promise<module:fabric-network.ContractListener>} The added listener.
 	 * @example
 	 * const listener: ContractListener = async (event) => {
-	 *     if (event.eventName ===  'newOrder') {
+	 *     if (event.eventName === 'newOrder') {
 	 *         const details = event.payload.toString('utf8');
 	 *         // Run business process to handle orders
 	 *     }

--- a/fabric-network/src/events.ts
+++ b/fabric-network/src/events.ts
@@ -54,11 +54,13 @@ export interface ContractEvent {
 	readonly type: EventType;
 	readonly chaincodeId: string;
 	readonly eventName: string;
+	readonly payload?: Buffer;
 	getTransactionEvent(): TransactionEvent;
 }
 
 export interface FilteredContractEvent extends ContractEvent {
 	readonly type: 'filtered';
+	readonly payload: undefined;
 	getTransactionEvent(): FilteredTransactionEvent;
 }
 

--- a/fabric-network/src/impl/event/filteredeventfactory.ts
+++ b/fabric-network/src/impl/event/filteredeventfactory.ts
@@ -69,6 +69,7 @@ function newFilteredContractEvent(transactionEvent: FilteredTransactionEvent, ch
 		type: 'filtered',
 		chaincodeId: chaincodeEvent.chaincode_id,
 		eventName: chaincodeEvent.event_name,
+		payload: undefined,
 		getTransactionEvent: () => transactionEvent
 	};
 	return Object.freeze(contractEvent);


### PR DESCRIPTION
- Update JSDoc to include full block events
- Add optional 'payload' property to ContactEvent to make listener code easier to write
- Process transactions within a block in parallel when notifying contract event listeners