### PR TITLE
FABN-1512: Port changes from FABN-1257 to 1.4 stream

### DIFF
--- a/fabric-client/lib/ChannelEventHub.js
+++ b/fabric-client/lib/ChannelEventHub.js
@@ -556,27 +556,27 @@ class ChannelEventHub {
 		});
 
 		this._stream.on('end', () => {
-			self._connect_running = false;
-			clearTimeout(connection_setup_timeout);
 			logger.debug('on.end - event stream:%s _current_stream:%s peer:%s', stream_id, self._current_stream, self.getPeerAddr());
 			if (stream_id !== self._current_stream) {
 				logger.debug('on.end - incoming message was from a canceled stream');
 				return;
 			}
+			self._connect_running = false;
+			clearTimeout(connection_setup_timeout);
 
 			logger.debug('on.end - grpc stream is ready :%s', isStreamReady(self));
 			self._disconnect(new Error('fabric peer service has disconnected due to an "end" event'));
 		});
 
 		this._stream.on('error', (err) => {
-			self._connect_running = false;
-			clearTimeout(connection_setup_timeout);
 			logger.debug('on.error - block stream:%s _current_stream:%s  peer:%s', stream_id, self._current_stream, self.getPeerAddr());
 			if (stream_id !== self._current_stream) {
 				logger.debug('on.error - incoming message was from a cancelled stream');
 				logger.debug('on.error - %s %s', new Date(), err);
 				return;
 			}
+			self._connect_running = false;
+			clearTimeout(connection_setup_timeout);
 
 			logger.debug('on.error - grpc stream is ready :%s', isStreamReady(self));
 			if (err instanceof Error) {


### PR DESCRIPTION
Fix timeout error that occurs when we immediately
reconnect EventHub. The cause of this problem is
inappropreate handling of incomming reset message
for the disconnected stream.

Change-Id: Ifa9802b7c5e71124ea6ec3ed3c4afd73102bce26
Signed-off-by: Yohei Ueda <yohei@jp.ibm.com>
(cherry picked from commit 60d160dbdf098acd99ec3d3f636fd4987fe2ee60)