### PR TITLE
[FABN-1522] load the value of config.orderers

### DIFF
--- a/fabric-network/src/impl/ccp/networkconfig.js
+++ b/fabric-network/src/impl/ccp/networkconfig.js
@@ -30,7 +30,7 @@ class NetworkConfig {
 			}
 		}
 		// create orderers
-		if (config.peers) {
+		if (config.orderers) {
 			for (const orderer_name in config.orderers) {
 				await buildOrderer(client, orderer_name, config.orderers[orderer_name]);
 			}


### PR DESCRIPTION
The function called loadFromConfig, load the value of config.peers instead of config.orderers. I fixed it to get the value of config.orderers

Signed-off-by: KIM GEONWOO <kgw8919@gmail.com>