### PR TITLE
FABN-1519: More robust private data scenario test

### DIFF
--- a/test/ts-scenario/features/events.feature
+++ b/test/ts-scenario/features/events.feature
@@ -79,8 +79,8 @@ Feature: Node SDK Events
 	Scenario: Using a gateway I can listen to private block events emitted by networks
 		When I use the gateway named event_gateway to listen for private block events with a listener named privateBlockListener on channel eventschannel
 		And I use the gateway named event_gateway to submit a transaction with args [privateValuePut] for contract events instantiated on channel eventschannel
-		Then I check event private data has myprivatedata with a listener named privateBlockListener
 		Then I receive a minimum 1 events from the listener named privateBlockListener
+		And the listener named privateBlockListener should have private data containing "myprivatedata"
 
 	Scenario: Using a gateway I can stop listening to private block events emitted by networks
 		Given I am listening for private block events with a listener named privateBlockListener

--- a/test/ts-scenario/steps/event-listeners.ts
+++ b/test/ts-scenario/steps/event-listeners.ts
@@ -26,14 +26,6 @@ Given(/^I am listening for transaction events with a listener named (.+?)$/, {ti
 	Listeners.checkTransactionListenerDetails(listenerName, Constants.TRANSACTION, isActive);
 });
 
-// private data check
-Given(/^I check event private data has (.+?) with a listener named (.+?)$/, {timeout: Constants.STEP_SHORT as number }, async (privateData: string, listenerName: string) => {
-	// wait for events to catch up
-	await BaseUtils.sleep(Constants.INC_SHORT);
-
-	Listeners.checkBlockListenerPrivatePayloads(listenerName, privateData);
-});
-
 // Contract events
 When(/^I use the gateway named (.+?) to listen for (filtered|full) contract events named (.+?) with a listener named (.+?) for the smart contract named (.+?) on channel (.+?)$/, {timeout: Constants.STEP_SHORT as number}, async (gatewayName: string, eventType: EventType, eventName: string, listenerName: string, ccName: string, channelName: string) => {
 	return await Listeners.createContractListener(gatewayName, channelName, ccName, eventName, listenerName, eventType);
@@ -59,15 +51,16 @@ When(/^I unregister the listener named (.+?)$/, {timeout: Constants.STEP_SHORT a
 
 Then(/^I receive ([0-9]+) events from the listener named (.+?)$/, {timeout: Constants.STEP_SHORT as number }, async (calls: number, listenerName: string) => {
 	await Listeners.checkListenerCallNumber(listenerName, calls, Constants.EXACT);
-	Listeners.resetListenerCalls(listenerName);
 });
 
 Then(/^I receive a minimum ([0-9]+) events from the listener named (.+?)$/, {timeout: Constants.STEP_SHORT as number }, async (calls: number, listenerName: string) => {
 	await Listeners.checkListenerCallNumber(listenerName, calls, Constants.GREATER_THAN);
-	Listeners.resetListenerCalls(listenerName);
 });
 
 Then(/^I receive a maximum ([0-9]+) events from the listener named (.+?)$/, {timeout: Constants.STEP_SHORT as number }, async (calls: number, listenerName: string) => {
 	await Listeners.checkListenerCallNumber(listenerName, calls, Constants.LESS_THAN);
-	Listeners.resetListenerCalls(listenerName);
+});
+
+Then('the listener named {word} should have private data containing {string}', {timeout: Constants.STEP_SHORT as number }, async (listenerName: string, privateData: string) => {
+	Listeners.checkBlockListenerPrivatePayloads(listenerName, privateData);
 });


### PR DESCRIPTION
The ordering of the Then assertions required waits to be introduced
to minimise timing issues causing spurious failures. Re-ordered to
ensure tests happen only when there is data available to test.