### PR TITLE
Pull Fabric Images in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,9 +47,11 @@ stages:
         - script: npm install
           displayName: npm install
         - script: npm run installAndGenerateCerts
-          displayName: 'Generate credentials'
+          displayName: Generate credentials
+        - script: npm run pullFabricImages
+          displayName: Pull Fabric Images
         - script: npm test
-          displayName: 'Run tests'
+          displayName: Run tests
 
   - stage: Publish
     displayName: Publish Packages and Docs

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "installAndGenerateCerts": "node ./scripts/npm_scripts/generateCerts.js",
+	"pullFabricImages": "./scripts/utility/fabric_images.sh",
     "test": "run-s checkLicense cleanUp dockerClean compile lint docs unitTest:all dockerReady tapeIntegration cucumberScenario",
     "testNoHSM": "run-s checkLicense cleanUp dockerClean compile lint docs unitTest:all dockerReady tapeIntegrationNoHSM cucumberScenario",
     "checkLicense": "./scripts/npm_scripts/checkLicense.sh",

--- a/scripts/utility/fabric_images.sh
+++ b/scripts/utility/fabric_images.sh
@@ -14,30 +14,21 @@ echo "======== PULL DOCKER IMAGES ========"
 echo "Fetching images from Artifactory"
 ARTIFACTORY_URL=hyperledger-fabric.jfrog.io
 
-ARCH=$1
-: ${STABLE_VERSION:=$2}
+ARCH=amd64
+STABLE_VERSION=2.1-stable
 STABLE_TAG="${ARCH}-${STABLE_VERSION}"
 VERSION_TAG="${STABLE_VERSION%%-*}"
 echo "---------> STABLE_VERSION: ${STABLE_VERSION}"
 
 dockerTag() {
-  for IMAGE in ca peer orderer ccenv baseos nodeenv javaenv tools; do
-    echo
-    echo "Pulling Image: ${ARTIFACTORY_URL}/fabric-${IMAGE}:${STABLE_TAG}"
-    echo
-	ARTIFACTORY_IMAGE="${ARTIFACTORY_URL}/fabric-${IMAGE}:${STABLE_TAG}"
-    docker pull "${ARTIFACTORY_IMAGE}"
-          if [ $? != 0 ]; then
-             echo  "FAILED: Docker Pull Failed on ${IMAGE}"
-             exit 1
-          fi
-	IMAGE_NAME="fabric-${IMAGE}"
-    docker tag "${ARTIFACTORY_IMAGE}" "hyperledger/${IMAGE_NAME}"
-    docker tag "${ARTIFACTORY_IMAGE}" "hyperledger/${IMAGE_NAME}:${VERSION_TAG}"
-    echo "${IMAGE_NAME}:${VERSION_TAG}"
-    echo "Deleting Artifactory docker images: $IMAGE"
-    docker rmi -f "${ARTIFACTORY_IMAGE}"
-  done
+    for IMAGE in ca peer orderer ccenv baseos nodeenv javaenv tools; do
+        ARTIFACTORY_IMAGE="${ARTIFACTORY_URL}/fabric-${IMAGE}:${STABLE_TAG}"
+        IMAGE_NAME="fabric-${IMAGE}"
+        docker pull "${ARTIFACTORY_IMAGE}"
+        docker tag "${ARTIFACTORY_IMAGE}" "hyperledger/${IMAGE_NAME}"
+        docker tag "${ARTIFACTORY_IMAGE}" "hyperledger/${IMAGE_NAME}:${VERSION_TAG}"
+        docker rmi -f "${ARTIFACTORY_IMAGE}"
+    done
 }
 
 dockerTag

--- a/test/ts-scenario/features/base_api.feature
+++ b/test/ts-scenario/features/base_api.feature
@@ -7,7 +7,7 @@ Feature: Use base API to perform core operations
 
 Background:
 	Given I place a scenario start message BASE API FEATURE
-	Given I deploy a tls Fabric network at 2.0 version
+	Given I deploy a tls Fabric network at 2.1 version
 	And I use the cli to create and join the channel named eventschannel on the deployed network
 	And I use the cli to update the channel with name eventschannel with config file eventschannel-anchor.tx on the deployed network
 	And I use the cli to lifecycle deploy a node smart contract named fabcar at version 1.0.0 as fabcar for all organizations on channel eventschannel with default endorsement policy and init-required true

--- a/test/ts-scenario/features/chaincode_lifecycle.feature.norun
+++ b/test/ts-scenario/features/chaincode_lifecycle.feature.norun
@@ -8,7 +8,7 @@ Feature: Use the v2.0 chaincode lifecycle process to perform lifecycle operation
 
 	Background:
 		Given I place a scenario start message LIFECYCLE SDK FEATURE
-		Given I deploy a tls Fabric network at 2.0 version
+		Given I deploy a tls Fabric network at 2.1 version
 		And I use the cli to create and join the channel named lifecyclechannel on the deployed network
 
 	Scenario: Using the SDK I can run node smart contracts through their lifecycle on a two org network

--- a/test/ts-scenario/features/channel_operations.feature.norun
+++ b/test/ts-scenario/features/channel_operations.feature.norun
@@ -8,7 +8,7 @@ Feature: Use the channel query methods
 
 	Background:
 		Given I place a scenario start message CHANNEL FEATURE
-	 	Given I deploy a tls Fabric network at 2.0 version
+	 	Given I deploy a tls Fabric network at 2.1 version
 		And I use the cli to create and join the channel named channelopschannel on the deployed network
 	 	And I use the cli to create and join the channel named channelopschannelvtwo on the deployed network
 		And I use the cli to update the channel with name channelopschannelvtwo with config file channelopschannelvtwo-anchor.tx on the deployed network

--- a/test/ts-scenario/features/deprecated_sdk.feature.norun
+++ b/test/ts-scenario/features/deprecated_sdk.feature.norun
@@ -9,7 +9,7 @@ Feature: Use the Node SDK to install/instantiate/Upgrade chaincode with the depr
 
 	Background:
 		Given I place a scenario start message DEPRECATED SDK FEATURE
-		Given I deploy a tls Fabric network at 2.0 version
+		Given I deploy a tls Fabric network at 2.1 version
 		And I use the cli to create and join the channel named deprecatedchannel on the deployed network
 
  	Scenario: Using the deprecated API I can install and instantate a smart contract that may subsequently be used through a Gateway

--- a/test/ts-scenario/features/discovery.feature
+++ b/test/ts-scenario/features/discovery.feature
@@ -9,7 +9,7 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 
 	Background:
 		Given I place a scenario start message DISCOVERY FEATURE
-		Given I deploy a tls Fabric network at 2.0 version
+		Given I deploy a tls Fabric network at 2.1 version
 		And I use the cli to create and join the channel named discoverychannel on the deployed network
 		And I use the cli to update the channel with name discoverychannel with config file discoverychannel-anchor.tx on the deployed network
 		#And I use the cli to deploy a node smart contract named fabcar at version 1.0.0 for all organizations on channel discoverychannel with endorsement policy 1of and arguments ["initLedger"]

--- a/test/ts-scenario/features/events.feature
+++ b/test/ts-scenario/features/events.feature
@@ -9,7 +9,7 @@ Feature: Node SDK Events
 
 	Background:
 		Given I place a scenario start message EVENTS FEATURE
-	 	Given I deploy a tls Fabric network at 2.0 version
+	 	Given I deploy a tls Fabric network at 2.1 version
 	 	And I use the cli to create and join the channel named eventschannel on the deployed network
 		And I use the cli to update the channel with name eventschannel with config file eventschannel-anchor.tx on the deployed network
 		And I use the cli to lifecycle deploy a node smart contract named events at version 1.0.0 as events for all organizations on channel eventschannel with default endorsement policy and init-required false

--- a/test/ts-scenario/features/gateway.feature
+++ b/test/ts-scenario/features/gateway.feature
@@ -9,7 +9,7 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 
 	Background:
 		Given I place a scenario start message GATEWAY FEATURE
-	 	Given I deploy a tls Fabric network at 2.0 version
+	 	Given I deploy a tls Fabric network at 2.1 version
 		And I use the cli to create and join the channel named gatewaychannel on the deployed network
 		And I use the cli to update the channel with name gatewaychannel with config file gatewaychannel-anchor.tx on the deployed network
 		And I use the cli to lifecycle deploy a node smart contract named fabcar at version 1.0.0 as fabcar for all organizations on channel gatewaychannel with default endorsement policy and init-required false

--- a/test/ts-scenario/features/nontls-gateway.feature
+++ b/test/ts-scenario/features/nontls-gateway.feature
@@ -9,7 +9,7 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 
 	Background:
 		Given I place a scenario start message GATEWAY NON TLS FEATURE
-		Given I deploy a non-tls Fabric network at 2.0 version
+		Given I deploy a non-tls Fabric network at 2.1 version
 		And I use the cli to create and join the channel named gatewaychannel on the deployed network
 		And I use the cli to update the channel with name gatewaychannel with config file gatewaychannel-anchor.tx on the deployed network
 		And I use the cli to lifecycle deploy a node smart contract named fabcar at version 1.0.0 as fabcar for all organizations on channel gatewaychannel with default endorsement policy and init-required false


### PR DESCRIPTION
Adds logic to pull the Fabric images from Artifactory prior to running tests instead of letting Compose pull them from DockerHub

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>