### PR TITLE
Import ByteBuffer type to prevent TypeScript errors

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -7,6 +7,7 @@
 
 import { lstatSync } from 'fs';
 import * as Long from 'long';
+import * as ByteBuffer from 'bytebuffer';
 
 export class Utils {
 	public static getLogger(name: string): any;


### PR DESCRIPTION
When excluding `node_modules` in tsconfig.json typescript will throw errors when building a project 
using the fabric client.

```
node_modules/fabric-common/types/index.d.ts:421:18 - error TS2304: Cannot find name 'ByteBuffer'.

421  channel_header: ByteBuffer;
```

I found references to other users experiencing the same problem in the Hyperledger JIRA:
https://jira.hyperledger.org/browse/FAB-5581
