### PR TITLE
Import ByteBuffer and Long types to prevent TypeScript errors

### DIFF
--- a/fabric-client/types/index.d.ts
+++ b/fabric-client/types/index.d.ts
@@ -6,7 +6,9 @@
 
 /* tslint:disable:max-classes-per-file */
 
+import * as ByteBuffer from 'bytebuffer';
 import FabricCAServices = require('fabric-ca-client');
+import * as Long from 'long';
 import { BaseClient } from './base';
 
 interface ProtoBufObject {


### PR DESCRIPTION
When excluding `node_modules` in tsconfig.json typescript will throw errors when building a project 
using the fabric client.

```
node_modules/fabric-client/types/index.d.ts:635:21 - error TS2304: Cannot find name 'ByteBuffer'.
635  	signature_header: ByteBuffer;

node_modules/fabric-client/types/index.d.ts:711:18 - error TS2304: Cannot find name 'Long'.
711  	ledger_height: Long;
```

I found references to other users experiencing the same problem in the Hyperledger JIRA:
https://jira.hyperledger.org/browse/FAB-5581
