### PR TITLE
FABN-1536 NodeSDK allow application txid

### DIFF
--- a/fabric-common/lib/Proposal.js
+++ b/fabric-common/lib/Proposal.js
@@ -143,6 +143,8 @@ class Proposal extends ServiceAction {
 	 * @property {boolean} [init] - Optional. If this proposal should be an
 	 * chaincode initialization request. This will set the init setting in the
 	 * protobuf object sent to the peer.
+	 * @property {string} [transactionId] - Optional. Application has provided
+	 * transaction ID to use.
 	 */
 
 	/**
@@ -178,7 +180,11 @@ class Proposal extends ServiceAction {
 			this._action.init = init;
 		}
 
-		this._action.transactionId = idContext.calculateTransactionId().transactionId;
+		if (request.transactionId) {
+			this._action.transactionId = request.transactionId;
+		} else {
+			this._action.transactionId = idContext.calculateTransactionId().transactionId;
+		}
 
 		this._action.args = [];
 		if (fcn) {


### PR DESCRIPTION
Alllow an application to create and set a new transaction ID
on the fabric-network.transaction prior to submission.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>