### PR TITLE
FABN-1540 NodeSDK remove ccp roles

### DIFF
--- a/docs/tutorials/commonconnectionprofile.md
+++ b/docs/tutorials/commonconnectionprofile.md
@@ -1,0 +1,286 @@
+
+This tutorial illustrates the common connection profile. A common connection
+profile describes the Hyperledger Fabric network to the Hyperledger
+Fabric Node.js client.
+
+### Overview
+A connection profile contain entries that describe the Hyperledger Fabric network.
+The application will load a configuration file and then it will be used by
+fabric-network to simplify the steps needed to setup and use the network.
+The connection profile has specific addresses and settings of the network endpoints.
+
+### Loading connection profile configurations
+The application may build a Javascript object from a yaml or a json
+formatted file.
+The applicatioin will then pass this to the `Gateway.connect`
+which provides the network configuration.
+
+The following examples will create a new instance of the `Gateway` using a
+common connection profile. The common connection profile object may be created
+by reading a json or a yaml formatted file.
+
+#### YAML
+```
+// read a common connection profile in yaml format
+const data = fs.readFileSync(path);
+const yaml = require('js-yaml');
+const connectionProfile = yaml.safeLoad(data);
+
+// use the loaded connection profile
+const gateway = new Gateway();
+await gateway.connect(connectionProfile, gatewayOptions);
+
+const network = await gateway.getNetwork('mychannel');
+```
+
+#### JSON
+```
+// read a common connection profile in json format
+const data = fs.readFileSync(path);
+const connectionProfile = JSON.parse(data);
+
+// or
+const connectionProfile = require(path);
+
+// use the loaded connection profile
+const gateway = new Gateway();
+await gateway.connect(connectionProfile, gatewayOptions);
+
+const network = await gateway.getNetwork('mychannel');
+```
+### A common connection profile in YAML
+```
+name: "Network"
+version: "1.1"
+
+channels:
+  mychannel:
+    orderers:
+      - orderer.example.com
+    peers:
+      - peer0.org1.example.com
+      - peer0.org2.example.com
+
+organizations:
+  Org1:
+    mspid: Org1MSP
+    peers:
+      - peer0.org1.example.com
+
+  Org2:
+    mspid: Org2MSP
+    peers:
+      - peer0.org2.example.com
+
+orderers:
+  orderer.example.com:
+    url: grpcs://localhost:7050
+    grpcOptions:
+      ssl-target-name-override: orderer.example.com
+    tlsCACerts:
+      path: test/ordererOrganizations/example.com/orderers/orderer.example.com/tlscacerts/example.com-cert.pem
+
+peers:
+  peer0.org1.example.com:
+    url: grpcs://localhost:7051
+    grpcOptions:
+      ssl-target-name-override: peer0.org1.example.com
+    tlsCACerts:
+      path: test/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tlscacerts/org1.example.com-cert.pem
+
+  peer0.org2.example.com:
+    url: grpcs://localhost:8051
+    grpcOptions:
+      ssl-target-name-override: peer0.org2.example.com
+    tlsCACerts:
+      path: test/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tlscacerts/org2.example.com-cert.pem
+```
+
+### A common connection profile in JSON
+
+```
+{
+  "name": "Network",
+  "version": "1.1",
+  "channels": {
+    "mychannel": {
+      "orderers": [
+        "orderer.example.com"
+      ],
+      "peers": [
+        "peer0.org1.example.com",
+        "peer0.org2.example.com"
+      ]
+    }
+  },
+  "organizations": {
+    "Org1": {
+      "mspid": "Org1MSP",
+      "peers": [
+        "peer0.org1.example.com"
+      ]
+    },
+    "Org2": {
+      "mspid": "Org2MSP",
+      "peers": [
+        "peer0.org2.example.com"
+      ]
+    }
+  },
+  "orderers": {
+    "orderer.example.com": {
+      "url": "grpcs://localhost:7050",
+      "grpcOptions": {
+        "ssl-target-name-override": "orderer.example.com"
+      },
+      "tlsCACerts": {
+        "path": "test/ordererOrganizations/example.com/orderers/orderer.example.com/tlscacerts/example.com-cert.pem"
+      }
+    }
+  },
+  "peers": {
+    "peer0.org1.example.com": {
+      "url": "grpcs://localhost:7051",
+      "grpcOptions": {
+        "ssl-target-name-override": "peer0.org1.example.com"
+      },
+      "tlsCACerts": {
+        "path": "test/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tlscacerts/org1.example.com-cert.pem"
+      }
+    },
+    "peer0.org2.example.com": {
+      "url": "grpcs://localhost:8051",
+      "grpcOptions": {
+        "ssl-target-name-override": "peer0.org2.example.com"
+      },
+      "tlsCACerts": {
+        "path": "test/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tlscacerts/org2.example.com-cert.pem"
+      }
+    }
+  }
+}
+```
+
+
+## Common Connection Profile
+The common connection profile has the following format:
+
+```
+#
+# How a channel is defined and the peers and orderers on that channel.
+#
+channels:
+  # name of the channel
+  mychannel:
+    # List of orderers designated by the application to use for transactions on this channel.
+    # The values must be orderer names defined under "orderers" section
+    orderers:
+      - orderer.example.com
+
+    # List of peers from participating organizations
+    peers:
+      # The values must be peer names defined under "peers" section
+      - peer0.org1.example.com
+
+#
+# list of participating organizations in this network
+#
+organizations:
+  Org1:
+    mspid: Org1MSP
+
+    # The peers that are known to be in this organization
+    peers:
+      - peer0.org1.example.com
+
+    # The following section is only for Fabric-CA servers.
+    certificateAuthorities:
+      - ca-org1
+
+    # If the application is going to make requests that are reserved to organization
+    # administrators, including creating/updating channels, installing/instantiating chaincodes, it
+    # must have access to the admin identity represented by the private key and signing certificate.
+    # Both properties can be the PEM string or local path to the PEM file.
+    #   path: <the path to a file containing the byte string>
+    #    or
+    #   pem: <the byte string>
+    # Note that this is mainly for convenience in development mode, production systems
+    # should not expose sensitive information this way.
+    # The SDK should allow applications to set the org admin identity via APIs, and only use
+    # this route as an alternative when it exists.
+    adminPrivateKey:
+      path: <path to file>
+       or
+      pem: <byte string>
+    signedCert:
+      path: <path to file>
+       or
+      pem: <byte string>
+
+  # the profile will contain public information about organizations other than the one it belongs to.
+  # These are necessary information to make transaction lifecycles work, including MSP IDs and
+  # peers with a public URL to send transaction proposals. The file will not contain private
+  # information reserved for members of the organization, such as admin key and certificate,
+  # fabric-ca registrar enroll ID and secret, etc.
+  Org2:
+    mspid: Org2MSP
+    peers:
+      - peer0.org2.example.com
+    certificateAuthorities:
+      - ca-org2
+    adminPrivateKey:
+      path: <path to file>
+       or
+      pem: <byte string>
+    signedCert:
+      path: <path to file>
+       or
+      pem: <byte string>
+
+#
+# List of orderers to send transaction and channel create/update requests.
+#
+orderers:
+  orderer.example.com:
+    url: grpcs://localhost:7050
+
+    # these are standard properties defined by the gRPC library
+    # they will be passed in as-is to gRPC client constructor
+    grpcOptions:
+      ssl-target-name-override: orderer.example.com
+
+    tlsCACerts:
+      path: <path to file>
+       or
+      pem: <byte string>
+
+#
+# List of peers to send various requests to, including endorsement, query
+# and event listener registration.
+#
+peers:
+  peer0.org1.example.com:
+    # this URL is used to send endorsement and query requests
+    url: grpcs://localhost:7051
+
+    grpcOptions:
+      ssl-target-name-override: peer0.org1.example.com
+      request-timeout: 120001
+
+    tlsCACerts:
+      path: <path to file>
+       or
+      pem: <byte string>
+
+  peer0.org2.example.com:
+    url: grpcs://localhost:8051
+    grpcOptions:
+      ssl-target-name-override: peer0.org2.example.com
+    tlsCACerts:
+      path: <path to file>
+       or
+      pem: <byte string>
+```
+
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/fabric-network/src/impl/ccp/networkconfig.js
+++ b/fabric-network/src/impl/ccp/networkconfig.js
@@ -53,12 +53,22 @@ async function buildChannel(client, channel_name, channel_config, config) {
 	// this will add the channel to the client instance
 	const channel = client.getChannel(channel_name);
 	if (channel_config.peers) {
-		// using 'in' as peers is an object
-		for (const peer_name in channel_config.peers) {
-			const peer = client.getEndorser(peer_name);
-			channel.addEndorser(peer);
-			logger.debug('%s - added endorsing peer :: %s', method, peer.name);
+		if (Array.isArray(channel_config.peers)) {
+			// using 'of' as peers is an array
+			for (const peer_name of channel_config.peers) {
+				const peer = client.getEndorser(peer_name);
+				channel.addEndorser(peer);
+				logger.debug('%s - added endorsing peer as array :: %s', method, peer.name);
+			}
+		} else {
+			// using 'in' as peers is an object
+			for (const peer_name in channel_config.peers) {
+				const peer = client.getEndorser(peer_name);
+				channel.addEndorser(peer);
+				logger.debug('%s - added endorsing peer as object :: %s', method, peer.name);
+			}
 		}
+
 	} else {
 		logger.debug('%s - no peers in config', method);
 	}

--- a/fabric-network/test/impl/ccp/networkconfig.js
+++ b/fabric-network/test/impl/ccp/networkconfig.js
@@ -94,7 +94,16 @@ describe('NetworkConfig', () => {
 					'peer0.org1.example.com': {},
 					'peer0.org2.example.com': {}
 				}
-			}
+			},
+			mychannel2: {
+				orderers: [
+					'orderer.example.com'
+				],
+				peers: [
+					'peer0.org1.example.com',
+					'peer0.org2.example.com'
+				]
+			},
 		},
 		organizations: {
 			Org1: {
@@ -156,7 +165,7 @@ describe('NetworkConfig', () => {
 		});
 	});
 
-	describe('#buildChannel', () => {
+	describe('#buildChannel - peer as object', () => {
 		it('should run with params', async () => {
 			const channel = sinon.stub();
 			client.getChannel = sinon.stub().returns(channel);
@@ -181,6 +190,34 @@ describe('NetworkConfig', () => {
 			const channel = sinon.stub();
 			client.getChannel = sinon.stub().returns(channel);
 			await buildChannel(client, 'name', {mychannel: {chaincodes: []}});
+		});
+	});
+
+	describe('#buildChannel - peer as array', () => {
+		it('should run with params', async () => {
+			const channel = sinon.stub();
+			client.getChannel = sinon.stub().returns(channel);
+			client.getEndorser = sinon.stub().returns('peer');
+			client.getCommitter = sinon.stub().returns('orderer');
+			channel.addEndorser = sinon.stub();
+			channel.addCommitter = sinon.stub();
+			await buildChannel(client, 'name', config.channels.mychannel2);
+			sinon.assert.calledWith(client.getEndorser, 'peer0.org1.example.com');
+			sinon.assert.calledWith(client.getEndorser, 'peer0.org2.example.com');
+			sinon.assert.calledWith(client.getCommitter, 'orderer.example.com');
+			sinon.assert.calledWith(client.getChannel, 'name');
+			sinon.assert.calledWith(channel.addEndorser, 'peer');
+			sinon.assert.calledWith(channel.addCommitter, 'orderer');
+		});
+		it('should run with only channel defined', async () => {
+			const channel = sinon.stub();
+			client.getChannel = sinon.stub().returns(channel);
+			await buildChannel(client, 'name', {mychannel2: {}});
+		});
+		it('should run with only chaincodes defined', async () => {
+			const channel = sinon.stub();
+			client.getChannel = sinon.stub().returns(channel);
+			await buildChannel(client, 'name', {mychannel2: {chaincodes: []}});
 		});
 	});
 

--- a/test/ts-scenario/config/Org1.json
+++ b/test/ts-scenario/config/Org1.json
@@ -17,20 +17,10 @@
 		"orderers":[
 		  "orderer.example.com"
 		],
-		"peers":{
-		  "peer0.org1.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":true,
-			"ledgerQuery":true,
-			"eventSource":true
-		  },
-		  "peer0.org2.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":false,
-			"ledgerQuery":true,
-			"eventSource":false
-		  }
-		},
+		"peers":[
+		  "peer0.org1.example.com",
+		  "peer0.org2.example.com"
+		],
 		"chaincodes":[
 		]
 	  },

--- a/test/ts-scenario/config/Org2.json
+++ b/test/ts-scenario/config/Org2.json
@@ -17,20 +17,10 @@
 		"orderers":[
 		  "orderer.example.com"
 		],
-		"peers":{
-		  "peer0.org1.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":true,
-			"ledgerQuery":true,
-			"eventSource":true
-		  },
-		  "peer0.org2.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":false,
-			"ledgerQuery":true,
-			"eventSource":false
-		  }
-		},
+		"peers":[
+		  "peer0.org1.example.com",
+		  "peer0.org2.example.com"
+		],
 		"chaincodes":[
 		]
 	  },

--- a/test/ts-scenario/config/ccp-lifecycle-tls.json
+++ b/test/ts-scenario/config/ccp-lifecycle-tls.json
@@ -7,20 +7,10 @@
       "orderers":[
         "orderer.example.com"
       ],
-      "peers":{
-        "peer0.org1.example.com":{
-          "endorsingPeer":true,
-          "chaincodeQuery":true,
-          "ledgerQuery":true,
-          "eventSource":true
-        },
-        "peer0.org2.example.com":{
-          "endorsingPeer":true,
-          "chaincodeQuery":false,
-          "ledgerQuery":true,
-          "eventSource":false
-        }
-      },
+      "peers":[
+        "peer0.org1.example.com",
+        "peer0.org2.example.com"
+		],
       "chaincodes":[
       ]
 	}

--- a/test/ts-scenario/config/ccp-lifecycle.json
+++ b/test/ts-scenario/config/ccp-lifecycle.json
@@ -7,20 +7,10 @@
       "orderers":[
         "orderer.example.com"
       ],
-      "peers":{
-        "peer0.org1.example.com":{
-          "endorsingPeer":true,
-          "chaincodeQuery":true,
-          "ledgerQuery":true,
-          "eventSource":true
-        },
-        "peer0.org2.example.com":{
-          "endorsingPeer":true,
-          "chaincodeQuery":false,
-          "ledgerQuery":true,
-          "eventSource":false
-        }
-      },
+      "peers":[
+        "peer0.org1.example.com",
+        "peer0.org2.example.com"
+		],
       "chaincodes":[
       ]
 	}

--- a/test/ts-scenario/config/ccp-tls.json
+++ b/test/ts-scenario/config/ccp-tls.json
@@ -17,20 +17,10 @@
 		"orderers":[
 		  "orderer.example.com"
 		],
-		"peers":{
-		  "peer0.org1.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":true,
-			"ledgerQuery":true,
-			"eventSource":true
-		  },
-		  "peer0.org2.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":false,
-			"ledgerQuery":true,
-			"eventSource":false
-		  }
-		},
+		"peers":[
+		  "peer0.org1.example.com",
+		  "peer0.org2.example.com"
+		],
 		"chaincodes":[
 		]
 	  },

--- a/test/ts-scenario/config/ccp.json
+++ b/test/ts-scenario/config/ccp.json
@@ -17,20 +17,10 @@
 		"orderers":[
 		  "orderer.example.com"
 		],
-		"peers":{
-		  "peer0.org1.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":true,
-			"ledgerQuery":true,
-			"eventSource":true
-		  },
-		  "peer0.org2.example.com":{
-			"endorsingPeer":true,
-			"chaincodeQuery":false,
-			"ledgerQuery":true,
-			"eventSource":false
-		  }
-		},
+		"peers":[
+		  "peer0.org1.example.com",
+		  "peer0.org2.example.com"
+		],
 		"chaincodes":[
 		]
 	  },


### PR DESCRIPTION
When defining a channel the peer roles will no longer
be required as they are not used.
This will simplify the defined peer from a named attribute
objects to a list of strings. This will also provide
consistency with how the orderers are defined on the
channel and how the peers are defined on an organization.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>