### PR TITLE
FABN-1546: Connect Gateway without a wallet

### DIFF
--- a/fabric-network/src/impl/ccp/networkconfig.js
+++ b/fabric-network/src/impl/ccp/networkconfig.js
@@ -5,7 +5,7 @@
 
 */
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const {Utils: utils} = require('fabric-common');
 
 const logger = utils.getLogger('NetworkConfig');
@@ -91,7 +91,7 @@ async function buildOrderer(client, orderer_name, orderer_config) {
 	logger.debug('%s - start - %s', method, orderer_name);
 
 	const mspid = orderer_config.mspid;
-	const options = buildOptions(orderer_config);
+	const options = await buildOptions(orderer_config);
 	const end_point = client.newEndpoint(options);
 	try {
 		logger.debug('%s - about to connect to committer %s url:%s mspid:%s', method, orderer_name, orderer_config.url, mspid);
@@ -109,7 +109,7 @@ async function buildPeer(client, peer_name, peer_config, config) {
 	logger.debug('%s - start - %s', method, peer_name);
 
 	const mspid = findPeerMspid(peer_name, config);
-	const options = buildOptions(peer_config);
+	const options = await buildOptions(peer_config);
 	const end_point = client.newEndpoint(options);
 	try {
 		logger.debug('%s - about to connect to endorser %s url:%s mspid:%s', method, peer_name, peer_config.url, mspid);
@@ -142,13 +142,13 @@ function findPeerMspid(name, config) {
 	return mspid;
 }
 
-function buildOptions(endpoint_config) {
+async function buildOptions(endpoint_config) {
 	const method = 'buildOptions';
 	logger.debug(`${method} - start`);
 	const options = {
 		url: endpoint_config.url
 	};
-	const pem = getPEMfromConfig(endpoint_config.tlsCACerts);
+	const pem = await getPEMfromConfig(endpoint_config.tlsCACerts);
 	if (pem) {
 		options.pem = pem;
 	}
@@ -161,7 +161,7 @@ function buildOptions(endpoint_config) {
 	return options;
 }
 
-function getPEMfromConfig(config) {
+async function getPEMfromConfig(config) {
 	let result = null;
 	if (config) {
 		if (config.pem) {
@@ -169,7 +169,7 @@ function getPEMfromConfig(config) {
 			result = config.pem;
 		} else if (config.path) {
 			// cert value is in a file
-			const data = fs.readFileSync(config.path);
+			const data = await fs.promises.readFile(config.path);
 			result = Buffer.from(data).toString();
 			result = utils.normalizeX509(result);
 		}

--- a/fabric-network/src/impl/wallet/identityproviderregistry.ts
+++ b/fabric-network/src/impl/wallet/identityproviderregistry.ts
@@ -11,20 +11,12 @@ const defaultProviders: IdentityProvider[] = [
 	new X509Provider(),
 ];
 
-function getDefaultProviders(): Map<string, IdentityProvider> {
-	const reducer: any = (accumulator: Map<string, IdentityProvider>, provider: IdentityProvider): Map<string, IdentityProvider> => {
-		accumulator.set(provider.type, provider);
-		return accumulator;
-	};
-	return defaultProviders.reduce(reducer, new Map());
-}
-
 /**
  * Registry of identity providers for use by a wallet.
  * @memberof module:fabric-network
  */
 export class IdentityProviderRegistry {
-	private readonly providers: Map<string, IdentityProvider> = getDefaultProviders();
+	private readonly providers: Map<string, IdentityProvider> = new Map();
 
 	/**
 	 * Get the provider for a given type from the registry. Throws an error if no provider for the type exists.
@@ -46,4 +38,10 @@ export class IdentityProviderRegistry {
 	public addProvider(provider: IdentityProvider): void {
 		this.providers.set(provider.type, provider);
 	}
+}
+
+export function newDefaultProviderRegistry(): IdentityProviderRegistry {
+	const registry = new IdentityProviderRegistry();
+	defaultProviders.forEach((provider) => registry.addProvider(provider));
+	return registry;
 }

--- a/fabric-network/src/impl/wallet/wallet.ts
+++ b/fabric-network/src/impl/wallet/wallet.ts
@@ -5,7 +5,7 @@
  */
 
 import { Identity } from './identity';
-import { IdentityProviderRegistry } from './identityproviderregistry';
+import { IdentityProviderRegistry, newDefaultProviderRegistry } from './identityproviderregistry';
 import { WalletStore } from './walletstore';
 
 const encoding = 'utf8';
@@ -17,7 +17,7 @@ const encoding = 'utf8';
  * @memberof module:fabric-network
  */
 export class Wallet {
-	private readonly providerRegistry = new IdentityProviderRegistry();
+	private readonly providerRegistry = newDefaultProviderRegistry();
 	private readonly store: WalletStore;
 
 	/**

--- a/fabric-network/test/impl/wallet/identityproviderregistry.spec.ts
+++ b/fabric-network/test/impl/wallet/identityproviderregistry.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { IdentityProvider } from '../../../src/impl/wallet/identityprovider';
-import { IdentityProviderRegistry } from '../../../src/impl/wallet/identityproviderregistry';
+import { newDefaultProviderRegistry, IdentityProviderRegistry } from '../../../src/impl/wallet/identityproviderregistry';
 
 import chai = require('chai');
 const expect: Chai.ExpectStatic = chai.expect;
@@ -30,8 +30,8 @@ describe('IdentityProviderRegistry', () => {
 			.to.throw(type);
 	});
 
-	it('Has default X.509 provider', () => {
-		const provider: IdentityProviderRegistry = new IdentityProviderRegistry();
+	it('Default registry has X.509 provider', () => {
+		const provider: IdentityProviderRegistry = newDefaultProviderRegistry();
 		const result: IdentityProvider = provider.getProvider('X.509');
 		expect(result).to.have.property('type', 'X.509');
 	});

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -9,16 +9,17 @@
 import { Wallet } from '../lib/impl/wallet/wallet';
 import { ContractListener, ListenerOptions } from '../lib/events';
 import { Identity } from '../lib/impl/wallet/identity';
+import { IdentityProvider } from '../lib/impl/wallet/identityprovider';
 import { QueryHandlerFactory } from '../lib/impl/query/queryhandler';
 import { Network } from '../lib/network';
-import { Client, Endorser, IdentityContext } from 'fabric-common';
+import { Client, Endorser } from 'fabric-common';
 
 export { Wallet };
 export { Wallets } from '../lib/impl/wallet/wallets';
 export { WalletStore } from '../lib/impl/wallet/walletstore';
 export { Identity };
 export { IdentityData } from '../lib/impl/wallet/identitydata';
-export { IdentityProvider } from '../lib/impl/wallet/identityprovider';
+export { IdentityProvider };
 export { IdentityProviderRegistry } from '../lib/impl/wallet/identityproviderregistry';
 export { HsmOptions, HsmX509Provider, HsmX509Identity } from '../lib/impl/wallet/hsmx509identity';
 export { X509Identity } from '../lib/impl/wallet/x509identity';
@@ -44,8 +45,9 @@ export { DefaultQueryHandlerStrategies };
 // Main fabric network classes
 // -------------------------------------------
 export interface GatewayOptions {
-	wallet: Wallet;
-	identity: string;
+	identity: string | Identity;
+	wallet?: Wallet;
+	identityProvider?: IdentityProvider;
 	clientTlsIdentity?: string;
 	discovery?: DiscoveryOptions;
 	eventHandlerOptions?: DefaultEventHandlerOptions;
@@ -97,6 +99,7 @@ export class Contract {
 export interface TransientMap {
 	[key: string]: Buffer;
 }
+
 export class Transaction {
 	getName(): string;
 	getTransactionId(): string | null;


### PR DESCRIPTION
Also solves an issue where a Gateway could be connected using a Client object instead of a Connection Profile but without specifying an identity.

Use non-blocking I/O to read PEM files references by Connection Profile.