### PR TITLE
fabric-network: Convert contract.js and gateway.js to ts

### DIFF
--- a/fabric-network/src/contract.ts
+++ b/fabric-network/src/contract.ts
@@ -16,6 +16,7 @@ import { ListenerSession as IListenerSession } from './impl/event/listenersessio
 import { getLogger } from './logger';
 import * as util from 'util';
 
+// tslint:disable-next-line
 const Transaction = require('./transaction');
 const logger = getLogger('Contract');
 
@@ -82,6 +83,7 @@ export class Contract {
 	discoveryInterests: DiscoveryInterest[];
 	discoveryService: DiscoveryService | null;
 	private _name!: string;
+
 	constructor(network: NetworkImpl, chaincodeId: string, namespace: string) {
 		const method = `constructor[${namespace}]`;
 		logger.debug('%s - start', method);
@@ -94,7 +96,7 @@ export class Contract {
 		this.namespace = namespace;
 		this.discoveryService = null;
 		this.contractListeners = new Map();
-		this.discoveryInterests = [{name: chaincodeId}];
+		this.discoveryInterests = [{ name: chaincodeId }];
 	}
 
 	/**
@@ -102,9 +104,9 @@ export class Contract {
 	 * function implemented by this contract, and provides more control over
 	 * the transaction invocation. A new transaction object <strong>must</strong>
 	 * be created for each transaction invocation.
-     * @param {String} name Transaction function name.
+	 * @param {String} name Transaction function name.
 	 * @returns {module:fabric-network.Transaction} A transaction object.
-     */
+	 */
 	createTransaction(name: string) {
 		verifyTransactionName(name);
 		const qualifiedName = this._getQualifiedName(name);
@@ -122,12 +124,12 @@ export class Contract {
 	 * will be evaluated on the endorsing peers and then submitted to the ordering service
 	 * for committing to the ledger.
 	 * This function is equivalent to calling <code>createTransaction(name).submit()</code>.
-     * @param {string} name Transaction function name.
+	 * @param {string} name Transaction function name.
 	 * @param {...string} [args] Transaction function arguments.
 	 * @returns {Buffer} Payload response from the transaction function.
 	 * @throws {module:fabric-network.TimeoutError} If the transaction was successfully submitted to the orderer but
 	 * timed out before a commit event was received from peers.
-     */
+	 */
 	async submitTransaction(name: string, ...args: string[]) {
 		return this.createTransaction(name).submit(...args);
 	}
@@ -139,10 +141,10 @@ export class Contract {
 	 * the ordering service and hence will not be committed to the ledger.
 	 * This is used for querying the world state.
 	 * This function is equivalent to calling <code>createTransaction(name).evaluate()</code>.
-     * @param {string} name Transaction function name.
-     * @param {...string} [args] Transaction function arguments.
-     * @returns {Buffer} Payload response from the transaction function.
-     */
+	 * @param {string} name Transaction function name.
+	 * @param {...string} [args] Transaction function arguments.
+	 * @returns {Buffer} Payload response from the transaction function.
+	 */
 	async evaluateTransaction(name: string, ...args: string[]) {
 		return this.createTransaction(name).evaluate(...args);
 	}
@@ -214,12 +216,12 @@ export class Contract {
 				const asLocalhost = this.network.getGateway().getOptions().discovery!.asLocalhost;
 
 				logger.debug('%s - using discovery interest %j', method, this.discoveryInterests);
-				this.discoveryService.build(idx, {interest: this.discoveryInterests});
+				this.discoveryService.build(idx, { interest: this.discoveryInterests });
 				this.discoveryService.sign(idx);
 
 				// go get the endorsement plan from the peer's discovery service
 				// to be ready to be used by the transaction's submit
-				await this.discoveryService.send({asLocalhost, targets});
+				await this.discoveryService.send({ asLocalhost, targets });
 				logger.debug('%s - endorsement plan retrieved', method);
 			}
 
@@ -273,7 +275,7 @@ export class Contract {
 	resetDiscoveryInterests() {
 		const method = `resetDiscoveryInterest[${this._name}]`;
 		logger.debug('%s - start', method);
-		this.discoveryInterests = [{name: this.chaincodeId}];
+		this.discoveryInterests = [{ name: this.chaincodeId }];
 		this.discoveryService = null;
 
 		return this;

--- a/fabric-network/src/gateway.ts
+++ b/fabric-network/src/gateway.ts
@@ -16,14 +16,16 @@ import { NetworkImpl as Network } from './network';
 import { newDefaultProviderRegistry } from './impl/wallet/identityproviderregistry';
 import * as EventStrategies from './impl/event/defaulteventhandlerstrategies';
 import * as QueryStrategies from './impl/query/defaultqueryhandlerstrategies';
+import { getLogger } from './logger';
 
 interface NetworkConfig {
 	loadFromConfig: (client: Client, config: Client | object | string) => void;
 }
 
+// tslint:disable-next-line
 const NetworkConfig: NetworkConfig = require('./impl/ccp/networkconfig');
 
-const logger = require('./logger').getLogger('Gateway');
+const logger = getLogger('Gateway');
 
 export interface DiscoveryOptions {
 	asLocalhost?: boolean;
@@ -121,13 +123,6 @@ export interface GatewayOptions {
  * @memberof module:fabric-network
  */
 export class Gateway {
-	client!: Client;
-	wallet!: Wallet;
-	networks: Map<string, Network>;
-	identity!: Identity;
-	identityContext!: IdentityContext;
-	options: GatewayOptions;
-
 	static _mergeOptions(defaultOptions: any, suppliedOptions: any) {
 		for (const prop in suppliedOptions) {
 			if (typeof suppliedOptions[prop] === 'object' && suppliedOptions[prop] !== null) {
@@ -141,6 +136,13 @@ export class Gateway {
 			}
 		}
 	}
+
+	client!: Client;
+	wallet!: Wallet;
+	networks: Map<string, Network>;
+	identity!: Identity;
+	identityContext!: IdentityContext;
+	options: GatewayOptions;
 
 	constructor() {
 		logger.debug('in Gateway constructor');
@@ -165,15 +167,15 @@ export class Gateway {
 	}
 
 	/**
-     * Connect to the Gateway with a connection profile or a prebuilt Client instance.
-     * @async
-     * @param {(object|Client)} config The configuration for this Gateway which can be:
+	 * Connect to the Gateway with a connection profile or a prebuilt Client instance.
+	 * @async
+	 * @param {(object|Client)} config The configuration for this Gateway which can be:
 	 * <ul>
 	 *   <li>A common connection profile JSON (Object)</li>
 	 *   <li>A pre-configured client instance</li>
 	 * </ul>
-     * @param {module:fabric-network.Gateway~GatewayOptions} options - specific options
-	  * for creating this Gateway instance
+	 * @param {module:fabric-network.Gateway~GatewayOptions} options - specific options
+	 * for creating this Gateway instance
 	 * @example
 	 * const gateway = new Gateway();
 	 * const wallet = await Wallets.newFileSystemWallet('./WALLETS/wallet');
@@ -183,7 +185,7 @@ export class Gateway {
 	 *     identity: 'admin',
 	 *     wallet: wallet
 	 * });
-     */
+	 */
 	async connect(config: Client | string | object, options: GatewayOptions = {}) {
 		const method = 'connect';
 		logger.debug('%s - start', method);
@@ -191,14 +193,14 @@ export class Gateway {
 		Gateway._mergeOptions(this.options, options);
 		logger.debug('connection options: %j', options);
 
-		let load_ccp = false;
+		let loadCCP = false;
 		if (config && (config as any).type === 'Client') {
 			// initialize from an existing Client object instance
 			logger.debug('%s - using existing client object', method);
 			this.client = config as Client;
 		} else {
 			this.client = new Client('gateway client');
-			load_ccp = true;
+			loadCCP = true;
 		}
 
 		// setup an initial identity for the Gateway
@@ -242,7 +244,7 @@ export class Gateway {
 		}
 
 		// Load connection profile after client configuration has been completed
-		if (load_ccp) {
+		if (loadCCP) {
 			logger.debug('%s - NetworkConfig loading client from ccp', method);
 			await NetworkConfig.loadFromConfig(this.client, config);
 		}
@@ -281,8 +283,8 @@ export class Gateway {
 	}
 
 	/**
-     * Clean up and disconnect this Gateway connection in preparation for it to be discarded and garbage collected
-     */
+	 * Clean up and disconnect this Gateway connection in preparation for it to be discarded and garbage collected
+	 */
 	disconnect() {
 		logger.debug('in disconnect');
 		for (const network of this.networks.values()) {

--- a/fabric-network/src/network.ts
+++ b/fabric-network/src/network.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// @ts-ignore no implicit any
-import Contract = require('./contract');
+import { Contract } from './contract';
+import { Gateway } from './gateway';
 import { Channel, DiscoveryService, Endorser } from 'fabric-common';
 import { BlockListener, CommitListener, EventType, ListenerOptions } from './events';
 import { BlockEventSource } from './impl/event/blockeventsource';
@@ -15,10 +15,8 @@ import { IsolatedBlockListenerSession } from './impl/event/isolatedblocklistener
 import { checkpointBlockListener } from './impl/event/listeners';
 import { addListener, ListenerSession, removeListener } from './impl/event/listenersession';
 import { SharedBlockListenerSession } from './impl/event/sharedblocklistenersession';
-import { QueryHandlerFactory } from './impl/query/queryhandler';
+import { QueryHandler } from './impl/query/queryhandler';
 import * as Logger from './logger';
-// @ts-ignore no implicit any
-import Gateway = require('./gateway');
 
 const logger = Logger.getLogger('Network');
 
@@ -47,7 +45,7 @@ export interface Network {
 }
 
 export class NetworkImpl implements Network {
-	public queryHandler?: QueryHandlerFactory;
+	public queryHandler?: QueryHandler;
 	private readonly gateway: Gateway;
 	private readonly channel: Channel;
 	private readonly contracts = new Map<string, Contract>();
@@ -168,7 +166,7 @@ export class NetworkImpl implements Network {
 
 		// Must be created after channel initialization to ensure discovery has located the peers
 		const queryOptions = this.gateway.getOptions().queryHandlerOptions;
-		this.queryHandler = queryOptions.strategy(this);
+		this.queryHandler = queryOptions!.strategy!(this);
 		logger.debug('%s - end', method);
 	}
 
@@ -199,6 +197,10 @@ export class NetworkImpl implements Network {
 
 	getChannel() {
 		return this.channel;
+	}
+
+	getDiscoveryService() {
+		return this.discoveryService;
 	}
 
 	_dispose() {

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -7,12 +7,11 @@
 /* tslint:disable:max-classes-per-file */
 
 import { Wallet } from '../lib/impl/wallet/wallet';
-import { ContractListener, ListenerOptions } from '../lib/events';
 import { Identity } from '../lib/impl/wallet/identity';
 import { IdentityProvider } from '../lib/impl/wallet/identityprovider';
 import { QueryHandlerFactory } from '../lib/impl/query/queryhandler';
 import { Network } from '../lib/network';
-import { Client, Endorser } from 'fabric-common';
+import { Endorser } from 'fabric-common';
 
 export { Wallet };
 export { Wallets } from '../lib/impl/wallet/wallets';
@@ -41,60 +40,11 @@ export { TxEventHandler, TxEventHandlerFactory };
 
 import * as DefaultQueryHandlerStrategies from '../lib/impl/query/defaultqueryhandlerstrategies';
 export { DefaultQueryHandlerStrategies };
+export { GatewayOptions, DiscoveryOptions, Gateway, DefaultEventHandlerOptions, DefaultQueryHandlerOptions } from '../lib/gateway';
+export { DiscoveryInterest, Contract } from '../lib/contract';
 
 // Main fabric network classes
 // -------------------------------------------
-export interface GatewayOptions {
-	identity: string | Identity;
-	wallet?: Wallet;
-	identityProvider?: IdentityProvider;
-	clientTlsIdentity?: string;
-	discovery?: DiscoveryOptions;
-	eventHandlerOptions?: DefaultEventHandlerOptions;
-	queryHandlerOptions?: DefaultQueryHandlerOptions;
-}
-
-export interface DiscoveryOptions {
-	asLocalhost?: boolean;
-	enabled?: boolean;
-}
-
-export interface DiscoveryInterest {
-	name: string;
-	collectionNames?: string[];
-}
-
-export interface DefaultEventHandlerOptions {
-	commitTimeout?: number;
-	endorseTimeout?: number;
-	strategy?: TxEventHandlerFactory | null;
-}
-
-export interface DefaultQueryHandlerOptions {
-	strategy?: QueryHandlerFactory;
-	timeout?: number;
-}
-
-export class Gateway {
-	constructor();
-	public connect(config: Client | string | object, options: GatewayOptions): Promise<void>;
-	public disconnect(): void;
-	public getIdentity(): Identity;
-	public getNetwork(channelName: string): Promise<Network>;
-	public getOptions(): GatewayOptions;
-}
-
-export class Contract {
-	readonly chaincodeId: string;
-	readonly namespace: string;
-	createTransaction(name: string): Transaction;
-	evaluateTransaction(name: string, ...args: string[]): Promise<Buffer>;
-	submitTransaction(name: string, ...args: string[]): Promise<Buffer>;
-	addContractListener(listener: ContractListener, options?: ListenerOptions): Promise<ContractListener>;
-	removeContractListener(listener: ContractListener): void;
-	addDiscoveryInterest(interest: DiscoveryInterest): Contract;
-	resetDiscoveryInterests(): Contract;
-}
 
 export interface TransientMap {
 	[key: string]: Buffer;


### PR DESCRIPTION
When `Network` is imported, `tsc` complains:
> TS7016: Could not find a declaration file for module './contract'. './node_modules/fabric-network/lib/contract.js' implicitly has an 'any' type.

> TS7016: Could not find a declaration file for module './gateway'. '/mnt/c/Users/winderica/Projects/PreDAuth/app/backend/node_modules/fabric-network/lib/gateway.js' implicitly has an 'any' type.

This is because `// @ts-ignore` is removed when compiling.

Now `contract.js` and `gateway.js` are fully typed.

Because I am new to fabric, `any` is used where I'm not pretty sure.