### PR TITLE
Add missing copyright to several files

### DIFF
--- a/fabric-ca-client/index.js
+++ b/fabric-ca-client/index.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-ca-client/lib/AffiliationService.js
+++ b/fabric-ca-client/lib/AffiliationService.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/fabric-ca-client/lib/FabricCAClient.js
+++ b/fabric-ca-client/lib/FabricCAClient.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/fabric-ca-client/test/AffiliationService.js
+++ b/fabric-ca-client/test/AffiliationService.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/fabric-ca-client/test/CertificateService.js
+++ b/fabric-ca-client/test/CertificateService.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/fabric-ca-client/test/FabricCAClient.js
+++ b/fabric-ca-client/test/FabricCAClient.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/fabric-ca-client/test/FabricCAServices.js
+++ b/fabric-ca-client/test/FabricCAServices.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-ca-client/test/IdentityService.js
+++ b/fabric-ca-client/test/IdentityService.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-ca-client/test/helper.js
+++ b/fabric-ca-client/test/helper.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/BaseClient.js
+++ b/fabric-common/lib/BaseClient.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/fabric-common/lib/BlockDecoder.js
+++ b/fabric-common/lib/BlockDecoder.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/Config.js
+++ b/fabric-common/lib/Config.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/CryptoAlgorithms.js
+++ b/fabric-common/lib/CryptoAlgorithms.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/CryptoSuite.js
+++ b/fabric-common/lib/CryptoSuite.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/Hash.js
+++ b/fabric-common/lib/Hash.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/HashPrimitives.js
+++ b/fabric-common/lib/HashPrimitives.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/Key.js
+++ b/fabric-common/lib/Key.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/KeyValueStore.js
+++ b/fabric-common/lib/KeyValueStore.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/fabric-common/lib/User.js
+++ b/fabric-common/lib/User.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 const TYPE = 'User';

--- a/fabric-common/lib/hash/hash_sha2_256.js
+++ b/fabric-common/lib/hash/hash_sha2_256.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /**

--- a/fabric-common/lib/hash/hash_sha2_384.js
+++ b/fabric-common/lib/hash/hash_sha2_384.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /**

--- a/fabric-common/test/DiscoveryHandler.js
+++ b/fabric-common/test/DiscoveryHandler.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 /* eslint-disable no-throw-literal */

--- a/fabric-common/test/EventService.js
+++ b/fabric-common/test/EventService.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 /* eslint-disable no-throw-literal */

--- a/fabric-common/test/hash/hash_sha2_256.js
+++ b/fabric-common/test/hash/hash_sha2_256.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const rewire = require('rewire');

--- a/fabric-common/test/hash/hash_sha2_384.js
+++ b/fabric-common/test/hash/hash_sha2_384.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const rewire = require('rewire');

--- a/fabric-protos/grpc.js
+++ b/fabric-protos/grpc.js
@@ -1,1 +1,7 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = require('grpc');

--- a/fabric-protos/index.js
+++ b/fabric-protos/index.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/scripts/npm_scripts/generateCerts.js
+++ b/scripts/npm_scripts/generateCerts.js
@@ -1,6 +1,8 @@
 /*
-# SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 const runShellCommand = require('./runShellCommand').runShellCommand;
 const os = require('os');

--- a/scripts/npm_scripts/runShellCommand.js
+++ b/scripts/npm_scripts/runShellCommand.js
@@ -1,6 +1,8 @@
 /*
-# SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 const childProcess = require('child_process');
 const stripAnsi = require('strip-ansi');

--- a/scripts/npm_scripts/testFunctions.js
+++ b/scripts/npm_scripts/testFunctions.js
@@ -1,6 +1,8 @@
 /*
-# SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 const fs = require('fs-extra');
 const path = require('path');

--- a/test/integration/e2e/updateAnchorPeers.js
+++ b/test/integration/e2e/updateAnchorPeers.js
@@ -1,4 +1,5 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/ts-fixtures/chaincode/node/events/index.js
+++ b/test/ts-fixtures/chaincode/node/events/index.js
@@ -1,4 +1,6 @@
 /*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/ts-fixtures/chaincode/node/events/lib/events.js
+++ b/test/ts-fixtures/chaincode/node/events/lib/events.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/ts-fixtures/chaincode/node/fabcar/index.js
+++ b/test/ts-fixtures/chaincode/node/fabcar/index.js
@@ -1,4 +1,6 @@
 /*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/ts-fixtures/chaincode/node/fabcar/lib/fabcar.js
+++ b/test/ts-fixtures/chaincode/node/fabcar/lib/fabcar.js
@@ -1,4 +1,6 @@
 /*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/ts-fixtures/chaincode/node/fabcarUpgrade/index.js
+++ b/test/ts-fixtures/chaincode/node/fabcarUpgrade/index.js
@@ -1,4 +1,6 @@
 /*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/ts-fixtures/chaincode/node/fabcarUpgrade/lib/fabcar.js
+++ b/test/ts-fixtures/chaincode/node/fabcarUpgrade/lib/fabcar.js
@@ -1,4 +1,6 @@
 /*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/ts-scenario/steps/lib/utility/commonConnectionProfileHelper.ts
+++ b/test/ts-scenario/steps/lib/utility/commonConnectionProfileHelper.ts
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
This adds the missing copyright and changes the license to SPDX.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>