### PR TITLE
Update SoftHSM Label

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
 - group: credentials
 - group: npm
 - name: SOFTHSM2_CONF
-  value: "$(Build.Repository.LocalPath)/test/ts-fixtures/hsm/softhsm2.conf"
+  value: $(Build.Repository.LocalPath)/test/ts-fixtures/hsm/softhsm2.conf
 - name: FABRIC_VERSION
   value: 2.1
 
@@ -44,7 +44,7 @@ stages:
           displayName: Install Node.js
         - script: |
             sudo apt-get install softhsm2
-            softhsm2-util --init-token --slot 0 --label "My token 1" --pin 98765432 --so-pin 98765432
+            softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
           displayName: Install SoftHSM
         - script: npm install
           displayName: npm install

--- a/test/README.md
+++ b/test/README.md
@@ -65,11 +65,12 @@ export SOFTHSM2_CONF="./test/ts-fixtures/hsm/softhsm2.conf"
 ### Create a token to store keys in the HSM
 
 ```bash
-softhsm2-util --init-token --slot 0 --label "My token 1"
+softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
 ```
 
-Then you will be prompted two PINs: SO (Security Officer) PIN that can be used to re-initialize the token, and user PIN
-(see below) to be used by applications to access the token for generating and retrieving keys.
+The Security Officer PIN, specified with the `--so-pin` flag, can be used to re-initialize the token, 
+and the user PIN (see below), specified with the `--pin` flag, is used by applications to access the token for 
+generating and retrieving keys.
 
 ### Configure tests
 


### PR DESCRIPTION
Changes the SoftHSM token label to match that contained in the core Fabric pre-reqs doc.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>