### PR TITLE
FABN-1549: JSDoc fixes

### DIFF
--- a/docs/jsdoc.json
+++ b/docs/jsdoc.json
@@ -14,10 +14,15 @@
     },
     "opts": {
         "tutorials": "docs/tutorials",
-        "destination": "docs/gen"
+        "destination": "docs/gen",
+        "recurse": true,
+        "pedantic": true
     },
     "templates": {
         "systemName": "Hyperledger Fabric SDK for Node.js",
         "theme": "cosmo"
+    },
+    "tags": {
+        "allowUnknownTags": false
     }
 }

--- a/docs/redirectTemplates/index.md
+++ b/docs/redirectTemplates/index.md
@@ -8,7 +8,7 @@ The SDK implements the Fabric programming model as described in the [Developing 
 ## Documentation
 
 Full documentation is published for each of the following versions:
-- [2.x](https://hyperledger.github.io/fabric-sdk-node/master/module-fabric-network.html)
+- [2.1](https://hyperledger.github.io/fabric-sdk-node/master/module-fabric-network.html)
 - [1.4](https://hyperledger.github.io/fabric-sdk-node/release-1.4/module-fabric-network.html)
 
 

--- a/fabric-network/index.js
+++ b/fabric-network/index.js
@@ -33,33 +33,44 @@
  * <p>Private data can be submitted to transactions as [transient]{@link module:fabric-network.Transaction#setTransient}
  * data to prevent it from being recorded on the ledger.</p>
  *
- * Client applications can initiate actions or business processes in response to events emitted by smart contract
- * transactions using [smart contract event listeners]{@link module:fabric-network.Contract}. All updates to the ledger
- * can be observed using [block event listeners]{@link module:fabric-network.Network}.
+ * Client applications can initiate actions or business processes in response to chaincode events emitted by smart
+ * contract transactions using [smart contract event listeners]{@link module:fabric-network.Contract}. All updates to
+ * the ledger can be observed using [block event listeners]{@link module:fabric-network.Network}.
  *
  * @example
- * // Obtain the smart contract with which our application wants to interact
+ * // Connect to a gateway peer
+ * const connectionProfileJson = (await fs.promises.readFile(connectionProfileFileName)).toString();
+ * const connectionProfile = JSON.parse(connectionProfileJson);
  * const wallet = await Wallets.newFileSystemWallet(walletDirectoryPath);
  * const gatewayOptions: GatewayOptions = {
  *     identity: 'user@example.org', // Previously imported identity
  *     wallet,
  * };
  * const gateway = new Gateway();
- * await gateway.connect(commonConnectionProfile, gatewayOptions);
- * const network = await gateway.getNetwork(channelName);
- * const contract = network.getContract(chaincodeId);
+ * await gateway.connect(connectionProfile, gatewayOptions);
  *
- * // Submit transactions for the smart contract
- * const args = [arg1, arg2];
- * const submitResult = await contract.submitTransaction("transactionName", ...args);
+ * try {
  *
- * // Evaluate queries for the smart contract
- * const evalResult = await contract.evaluateTransaction("transactionName", ...args);
+ *     // Obtain the smart contract with which our application wants to interact
+ *     const network = await gateway.getNetwork(channelName);
+ *     const contract = network.getContract(chaincodeId);
  *
- * // Create and submit transactions for the smart contract with transient data
- * const transientResult = await contract.createTransaction(transactionName)
- *     .setTransient(privateData)
- *     .submit(arg1, arg2);
+ *     // Submit transactions for the smart contract
+ *     const args = [arg1, arg2];
+ *     const submitResult = await contract.submitTransaction('transactionName', ...args);
+ *
+ *     // Evaluate queries for the smart contract
+ *     const evalResult = await contract.evaluateTransaction('transactionName', ...args);
+ *
+ *     // Create and submit transactions for the smart contract with transient data
+ *     const transientResult = await contract.createTransaction(transactionName)
+ *         .setTransient(privateData)
+ *         .submit(arg1, arg2);
+ *
+ * } finally {
+ *     // Disconnect from the gateway peer when all work for this client identity is complete
+ *     gateway.disconnect();
+ * }
  *
  * @module fabric-network
  */
@@ -68,7 +79,7 @@
  * A base user identity. Actual identity objects will extend this basic structure with credentials applicable to their
  * type. See [X509Identity]{@link module:fabric-network.X509Identity} and
  * [HsmX509Identity]{@link module:fabric-network.HsmX509Identity}.
- * @typedef {object} Identity
+ * @interface Identity
  * @memberof module:fabric-network
  * @property {string} type The type of the identity.
  * @property {string} mspId The member services provider with which this identity is associated.
@@ -76,7 +87,7 @@
 
 /**
  * Identity described by an X.509 certificate.
- * @typedef {object} X509Identity
+ * @interface X509Identity
  * @memberof module:fabric-network
  * @implements module:fabric-network.Identity
  * @property {'X.509'} type The type of the identity.
@@ -88,7 +99,7 @@
  * Identity described by an X.509 certificate where the private key is stored in a hardware security module.
  * To use identities of this type, a suitable [HsmX509Provider]{@link module:fabric-network.HsmX509Provider} must be
  * created and added to the identity provider registry of the wallet containing the identity.
- * @typedef {object} HsmX509Identity
+ * @interface HsmX509Identity
  * @memberof module:fabric-network
  * @implements module:fabric-network.Identity
  * @property {'HSM-X.509'} type The type of the identity.
@@ -98,7 +109,7 @@
 /**
  * Understands the format of identities of a given type. Converts identity objects to/from the persistent format used
  * within wallet stores, and configures the client with a given identity.
- * @typedef IdentityProvider
+ * @interface IdentityProvider
  * @memberof module:fabric-network
  * @property {string} type The type identifier for identities that this provider understands.
  */
@@ -106,7 +117,7 @@
 /**
  * Options describing how to connect to a hardware security module. Options without default values are mandatory but
  * may be be omitted from this object if they are specified through environment variables or external configuration.
- * @typedef {object} HsmOptions
+ * @interface HsmOptions
  * @memberof module:fabric-network
  * @property {string} [lib] Path to implementation-specific PKCS#11 library used to interact with the HSM.
  * @property {string} [pin] PIN used to access the HSM.
@@ -150,120 +161,7 @@
  */
 
 /**
- * Factory function to obtain transaction event handler instances. Called on every transaction submit.
- * @typedef {Function} TxEventHandlerFactory
- * @memberof module:fabric-network
- * @param {string} transactionId The ID of the transaction being submitted.
- * @param {module:fabric-network.Network} network The network on which this transaction is being submitted.
- * @returns {module:fabric-network.TxEventHandler} A transaction event handler.
- */
-
-/**
- * Handler used to wait for commit events when a transaction is submitted.
- * @interface TxEventHandler
- * @memberof module:fabric-network
- */
-/**
- * Resolves when the handler has started listening for transaction commit events. Called after the transaction proposal
- * has been accepted and prior to submission of the transaction to the orderer.
- * @function module:fabric-network.TxEventHandler#startListening
- * @async
- * @returns {Promise<void>}
- */
-/**
- * Resolves (or rejects) when suitable transaction commit events have been received. Called after submission of the
- * transaction to the orderer.
- * @function module:fabric-network.TxEventHandler#waitForEvents
- * @async
- * @returns {Promise<void>}
- */
-/**
- * Called if submission of the transaction to the orderer fails.
- * @function module:fabric-network.TxEventHandler#cancelListening
- * @returns {void}
- */
-
-/**
- * Factory function to obtain query handler instances. Called on every network creation.
- * @typedef {Function} QueryHandlerFactory
- * @memberof module:fabric-network
- * @param {module:fabric-network.Network} network The network on which queries are being evaluated.
- * @returns {module:fabric-network.QueryHandler} A query handler.
- */
-
-/**
- * Handler used to obtain query results from peers when a transaction is evaluated.
- * @interface QueryHandler
- * @memberof module:fabric-network
- */
-/**
- * Called when a transaction is evaluated to obtain query results from suitable network peers.
- * @function module:fabric-network.QueryHandler#evaluate
- * @async
- * @param {module:fabric-network.Query} query Query object that can be used by the handler to send the query to
- * specific peers.
- * @returns {Promise<Buffer>}
- */
-
-/**
- * Used by query handler implementations to evaluate transactions on peers of their choosing.
- * @interface Query
- * @memberof module:fabric-network
- */
-/**
- * Get query results from specified peers.
- * @function module:fabric-network.Query#evaluate
- * @async
- * @param {Endorser[]} peers
- * @returns {Promise<Array<module:fabric-network.Query~QueryResponse | Error>>}
- */
-
-/**
- * @typedef {Object} Query~QueryResponse
- * @memberof module:fabric-network
- * @property {boolean} isEndorsed True if the proposal was endorsed by the peer.
- * @property {number} status The status value from the endorsement. This attriibute will be set by the chaincode.
- * @property {Buffer} payload The payload value from the endorsement. This attribute may be considered the query value
- * if the proposal was endorsed by the peer.
- * @property {string} message The message value from the endorsement. This property contains the error message from
- * the peer if it did not endorse the proposal.
- */
-
-/**
- * A callback function that will be invoked when either a peer communication error occurs or a transaction commit event
- * is received. Only one of the two arguments will have a value for any given invocation.
- * @callback CommitListener
- * @memberof module:fabric-network
- * @param {module:fabric-network.CommitError} [error] Peer communication error.
- * @param {module:fabric-network.CommitEvent} [event] Transaction commit event from a specific peer.
- */
-
-/**
- * @typedef {Error} CommitError
- * @memberof module:fabric-network
- * @property {Endorser} peer The peer that raised this error.
- */
-
-/**
- * @interface CommitEvent
- * @implements {module:fabric-network.TransactionEvent}
- * @memberof module:fabric-network
- * @property {Endorser} peer The endorsing peer that produced this event.
- */
-
-
-/**
- * A callback function that will be invoked when a block event is received.
- * @callback BlockListener
- * @memberof module:fabric-network
- * @async
- * @param {module:fabric-network.BlockEvent} event A block event.
- * @returns {Promise<void>}
- */
-
-
-/**
- * @typedef ListenerOptions
+ * @interface ListenerOptions
  * @memberof module:fabric-network
  * @property {(number | string | Long)} [startBlock] The block number from which events should be received. Leaving this
  * value undefined starts listening from the current block.
@@ -273,7 +171,6 @@
  * is set, the <code>startBlock</code> option is used if present.
  */
 
-
 /**
  * The type of an event. The type is based on the type of the raw event data: filtered, full block or including
  * private data. The presence of optional fields and the type of raw protobuf data associated with events is dictated
@@ -281,7 +178,6 @@
  * @typedef {('filtered' | 'full' | 'private')} EventType
  * @memberof module:fabric-network
  */
-
 
 /**
  * Persists the current block and transactions within that block to enable event listening to be resumed following an
@@ -323,7 +219,6 @@
  * @returns {Promise<void>}
  */
 
-
 /**
  * Event representing a block on the ledger.
  * @interface BlockEvent
@@ -337,7 +232,6 @@
  * @memberof module:fabric-network
  * @returns {module:fabric-network.TransactionEvent[]} Transaction events.
  */
-
 
 /**
  * Event representing a transaction processed within a block.
@@ -365,7 +259,6 @@
  * @returns {module:fabric-network.ContractEvent[]} Contract events.
  */
 
-
 /**
  * Event representing a contract event emitted by a smart contract.
  * @interface ContractEvent
@@ -381,110 +274,6 @@
  * @memberof module:fabric-network
  * @returns {module:fabric-network.TransactionEvent} A transaction event.
  */
-
-
-/**
- * A callback function that will be invoked when a block event is received.
- * @callback ContractListener
- * @memberof module:fabric-network
- * @async
- * @param {module:fabric-network.ContractEvent} event Contract event.
- * @returns {Promise<void>}
- */
-
-
-/**
- * <p>A Network represents the set of peers in a Fabric network.
- * Applications should get a Network instance using the
- * gateway's [getNetwork]{@link module:fabric-network.Gateway#getNetwork} method.</p>
- *
- * <p>The Network object provides the ability for applications to:</p>
- * <ul>
- *   <li>Obtain a specific smart contract deployed to the network using [getContract]{@link module:fabric-network.Network#getContract},
- *       in order to submit and evaluate transactions for that smart contract.</li>
- *   <li>Listen to new block events and replay previous block events using
- *       [addBlockListener]{@link module:fabric-network.Network#addBlockListener}.</li>
- * </ul>
- * @interface Network
- * @memberof module:fabric-network
- */
-/**
- * Get the owning Gateway connection.
- * @method Network#getGateway
- * @memberof module:fabric-network
- * @returns {module:fabric-network.Gateway} A Gateway.
- */
-/**
- * Get an instance of a contract (chaincode) on the current network.
- * @method Network#getContract
- * @memberof module:fabric-network
- * @param {string} chaincodeId - the chaincode identifier.
- * @param {string} [name] - the name of the contract.
- * @param {string[]} [collections] - the names of collections defined for this chaincode.
- * @returns {module:fabric-network.Contract} the contract.
- */
-/**
- * Get the underlying channel object representation of this network.
- * @method Network#getChannel
- * @memberof module:fabric-network
- * @returns {Channel} A channel.
- */
-/**
- * Add a listener to receive transaction commit and peer disconnect events for a set of peers. This is typically used
- * only within the implementation of a custom [transaction commit event handler]{@tutorial transaction-commit-events}.
- * @method Network#addCommitListener
- * @memberof module:fabric-network
- * @param {module:fabric-network.CommitListener} listener A transaction commit listener callback function.
- * @param {Endorser[]} peers The peers from which to receive events.
- * @param {string} transactionId A transaction ID.
- * @returns {module:fabric-network.CommitListener} The added listener.
- * @example
- * const listener: CommitListener = (error, event) => {
- *     if (error) {
- *         // Handle peer communication error
- *     } else {
- *         // Handle transaction commit event
- *     }
- * }
- * const peers = network.channel.getEndorsers();
- * await network.addCommitListener(listener, peers, transactionId);
- */
-/**
- * Remove a previously added transaction commit listener.
- * @method Network#removeCommitListener
- * @memberof module:fabric-network
- * @param {module:fabric-network.CommitListener} listener A transaction commit listener callback function.
- */
-/**
- * Add a listener to receive block events for this network. Blocks will be received in order and without duplication.
- * The default is to listen for full block events from the current block position.
- * @method Network#addBlockListener
- * @memberof module:fabric-network
- * @async
- * @param {module:fabric-network.BlockListener} listener A block listener callback function.
- * @param {module:fabric-network.ListenerOptions} [options] Listener options.
- * @returns {Promise<module:fabric-network.BlockListener>} The added listener.
- * @example
- * const listener: BlockListener = async (event) => {
- *     // Handle block event
- *
- *     // Listener may remove itself if desired
- *     if (event.blockNumber.equals(endBlock)) {
- *         network.removeBlockListener(listener);
- *     }
- * }
- * const options: ListenerOptions = {
- *     startBlock: 1
- * };
- * await network.addBlockListener(listener, options);
- */
-/**
- * Remove a previously added block listener.
- * @method Network#removeBlockListener
- * @memberof module:fabric-network
- * @param listener {module:fabric-network.BlockListener} A block listener callback function.
- */
-
 
 module.exports.Gateway = require('./lib/gateway').Gateway;
 module.exports.Wallet = require('./lib/impl/wallet/wallet').Wallet;

--- a/fabric-network/src/gateway.ts
+++ b/fabric-network/src/gateway.ts
@@ -17,61 +17,8 @@ import * as QueryStrategies from './impl/query/defaultqueryhandlerstrategies';
 import * as IdentityProviderRegistry from './impl/wallet/identityproviderregistry';
 
 import * as Logger from './logger';
-import { X509Identity, X509Provider } from './impl/wallet/x509identity';
+import { X509Identity } from './impl/wallet/x509identity';
 const logger = Logger.getLogger('Gateway');
-
-/**
- * @typedef {Object} Gateway~GatewayOptions
- * @memberof module:fabric-network
- * @property {(string|module:fabric-network.Identity)} identity The identity used for all interactions on this Gateway
- * instance. This can be either:
- * <ul>
- *   <li>a label matching an identity within the supplied wallet.</li>
- *   <li>an identity object.</li>
- * </ul
- * @property {module:fabric-network.Wallet} [wallet] The identity wallet implementation for use with this Gateway
- * instance. Required if a label is specified as the <code>identity</code>, or <code>clientTlsIdentity</code> is specified.
- * @property {module:fabric-network.IdentityProvider} [identityProvider] An identity provider for the supplied identity
- * object. Required if an identity object is not one of the default supported types.
- * @property {string} [clientTlsIdentity] The identity within the wallet to use as the client TLS identity.
- * @property {module:fabric-network.Gateway~TransactionOptions} [transaction]
- * Options for the default event handler capability.
- * @property {module:fabric-network.Gateway~QueryOptions} [query]
- * Options for the default query handler capability.
- * @property {module:fabric-network.Gateway~DiscoveryOptions} [discovery] Discovery options.
- */
-
-/**
- * @typedef {Object} Gateway~TransactionOptions
- * @memberof module:fabric-network
- * @property {number} [commitTimeout = 300] The timeout period in seconds to wait
- * for commit notification to complete.
- * @property {number} [endorseTimeout = 30] The timeout period in seconds to wait
- * for the endorsement to complete.
- * @property {?module:fabric-network.TxEventHandlerFactory} [strategy=MSPID_SCOPE_ALLFORTX]
- * Event handling strategy to identify successful transaction commits. A null value indicates
- * that no event handling is desired. The default is
- * [MSPID_SCOPE_ALLFORTX]{@link module:fabric-network.EventHandlerStrategies}.
- */
-
-/**
- * @typedef {Object} Gateway~QueryOptions
- * @memberof module:fabric-network
- * @property {number} [timeout = 30] The timeout period in seconds to wait for the query to
- * complete.
- * @property {module:fabric-network.QueryHandlerFactory} [strategy=MSPID_SCOPE_SINGLE]
- * Query handling strategy used to evaluate queries. The default is
- * [MSPID_SCOPE_SINGLE]{@link module:fabric-network.QueryHandlerStrategies}.
- */
-
-/**
- * @typedef {Object} Gateway~DiscoveryOptions
- * @memberof module:fabric-network
- * @property {boolean} [enabled=true] True if discovery should be used; otherwise false.
- * @property {boolean} [asLocalhost=false] Convert discovered host addresses to be 'localhost'.
- * Will be needed when running a docker composed fabric network on the local system;
- * otherwise should be disabled.
- */
 
 export interface GatewayOptions {
 	identity: string | Identity;
@@ -143,6 +90,144 @@ export function mergeOptions<B, E>(currentOptions: B, additionalOptions: E): B &
 }
 
 /**
+ * @interface GatewayOptions
+ * @memberof module:fabric-network
+ * @property {(string|module:fabric-network.Identity)} identity The identity used for all interactions on this Gateway
+ * instance. This can be either:
+ * <ul>
+ *   <li>a label matching an identity within the supplied wallet.</li>
+ *   <li>an identity object.</li>
+ * </ul
+ * @property {module:fabric-network.Wallet} [wallet] The identity wallet implementation for use with this Gateway
+ * instance. Required if a label is specified as the <code>identity</code>, or <code>clientTlsIdentity</code> is specified.
+ * @property {module:fabric-network.IdentityProvider} [identityProvider] An identity provider for the supplied identity
+ * object. Required if an identity object is not one of the default supported types.
+ * @property {string} [clientTlsIdentity] The identity within the wallet to use as the client TLS identity.
+ * @property {object} [tlsInfo] Credentials to use as the client TLS identity.
+ * @property {string} tlsInfo.certificate Certificate PEM.
+ * @property {string} tlsInfo.key Private key PEM.
+ * @property {module:fabric-network.DefaultEventHandlerOptions} [eventHandlerOptions]
+ * Options for event handling when submitting transactions.
+ * @property {module:fabric-network.DefaultQueryHandlerOptions} [queryHandlerOptions]
+ * Options for query handling when evaluating transactions.
+ * @property {module:fabric-network.DiscoveryOptions} [discovery] Discovery options.
+ */
+
+/**
+ * @interface DefaultEventHandlerOptions
+ * @memberof module:fabric-network
+ * @property {number} [commitTimeout = 300] The timeout period in seconds to wait
+ * for commit notification to complete.
+ * @property {number} [endorseTimeout = 30] The timeout period in seconds to wait
+ * for the endorsement to complete.
+ * @property {?module:fabric-network.TxEventHandlerFactory} [strategy=MSPID_SCOPE_ALLFORTX]
+ * Event handling strategy to identify successful transaction commits. A <code>null</code> value indicates that no
+ * event handling is desired. The default is
+ * [MSPID_SCOPE_ALLFORTX]{@link module:fabric-network.DefaultEventHandlerStrategies}.
+ */
+
+/**
+ * @interface DefaultQueryHandlerOptions
+ * @memberof module:fabric-network
+ * @property {number} [timeout = 30] The timeout period in seconds to wait for the query to
+ * complete.
+ * @property {module:fabric-network.QueryHandlerFactory} [strategy=MSPID_SCOPE_SINGLE]
+ * Query handling strategy used to evaluate queries. The default is
+ * [MSPID_SCOPE_SINGLE]{@link module:fabric-network.DefaultQueryHandlerStrategies}.
+ */
+
+/**
+ * @interface DiscoveryOptions
+ * @memberof module:fabric-network
+ * @property {boolean} [enabled=true] True if discovery should be used; otherwise false.
+ * @property {boolean} [asLocalhost=false] Convert discovered host addresses to be 'localhost'.
+ * Will be needed when running a docker composed fabric network on the local system;
+ * otherwise should be disabled.
+ */
+
+/**
+ * Factory function to obtain transaction event handler instances. Called on every transaction submit.
+ * @typedef {function} TxEventHandlerFactory
+ * @memberof module:fabric-network
+ * @param {string} transactionId The ID of the transaction being submitted.
+ * @param {module:fabric-network.Network} network The network on which this transaction is being submitted.
+ * @returns {module:fabric-network.TxEventHandler} A transaction event handler.
+ * @see module:fabric-network.DefaultEventHandlerStrategies
+ */
+
+/**
+ * Handler used to wait for commit events when a transaction is submitted.
+ * @interface TxEventHandler
+ * @memberof module:fabric-network
+ */
+/**
+ * Resolves when the handler has started listening for transaction commit events. Called after the transaction proposal
+ * has been accepted and prior to submission of the transaction to the orderer.
+ * @function module:fabric-network.TxEventHandler#startListening
+ * @async
+ * @returns {Promise<void>}
+ */
+/**
+ * Resolves (or rejects) when suitable transaction commit events have been received. Called after submission of the
+ * transaction to the orderer.
+ * @function module:fabric-network.TxEventHandler#waitForEvents
+ * @async
+ * @returns {Promise<void>}
+ */
+/**
+ * Called if submission of the transaction to the orderer fails.
+ * @function module:fabric-network.TxEventHandler#cancelListening
+ * @returns {void}
+ */
+
+/**
+ * Factory function to obtain query handler instances. Called on every network creation.
+ * @typedef {Function} QueryHandlerFactory
+ * @memberof module:fabric-network
+ * @param {module:fabric-network.Network} network The network on which queries are being evaluated.
+ * @returns {module:fabric-network.QueryHandler} A query handler.
+ * @see module:fabric-network.DefaultQueryHandlerStrategies
+ */
+
+/**
+ * Handler used to obtain query results from peers when a transaction is evaluated.
+ * @interface QueryHandler
+ * @memberof module:fabric-network
+ */
+/**
+ * Called when a transaction is evaluated to obtain query results from suitable network peers.
+ * @function module:fabric-network.QueryHandler#evaluate
+ * @async
+ * @param {module:fabric-network.Query} query Query object that can be used by the handler to send the query to
+ * specific peers.
+ * @returns {Promise<Buffer>}
+ */
+
+/**
+ * Used by query handler implementations to evaluate transactions on peers of their choosing.
+ * @interface Query
+ * @memberof module:fabric-network
+ */
+/**
+ * Get query results from specified peers.
+ * @function module:fabric-network.Query#evaluate
+ * @async
+ * @param {Endorser[]} peers
+ * @returns {Promise<Array<module:fabric-network.Query~QueryResponse | Error>>}
+ */
+
+/**
+ * @typedef {Object} Query~QueryResponse
+ * @memberof module:fabric-network
+ * @property {boolean} isEndorsed True if the proposal was endorsed by the peer.
+ * @property {number} status The status value from the endorsement. This attribute will be set by the chaincode.
+ * @property {Buffer} payload The payload value from the endorsement. This attribute may be considered the query value
+ * if the proposal was endorsed by the peer.
+ * @property {string} message The message value from the endorsement. This property contains the error message from
+ * the peer if it did not endorse the proposal.
+ */
+
+/**
  * The gateway peer provides the connection point for an application to access the Fabric network.
  * It is instantiated using the default constructor.
  * It can then be connected to a fabric network using the [connect]{@link #connect} method by
@@ -172,14 +257,14 @@ export class Gateway {
 	 *   <li>A common connection profile JSON (Object)</li>
 	 *   <li>A pre-configured client instance</li>
 	 * </ul>
-	 * @param {module:fabric-network.Gateway~GatewayOptions} options - specific options
+	 * @param {module:fabric-network.GatewayOptions} options - specific options
 	 * for creating this Gateway instance
 	 * @example
 	 * const gateway = new Gateway();
 	 * const wallet = await Wallets.newFileSystemWallet('./WALLETS/wallet');
-	 * const ccpFile = await fs.promises.readFile('./network.json');
-	 * const ccp = JSON.parse(ccpFile.toString());
-	 * await gateway.connect(ccp, {
+	 * const connectionProfileJson = (await fs.promises.readFile('network.json')).toString();
+	 * const connectionProfile = JSON.parse(connectionProfileJson);
+	 * await gateway.connect(connectionProfile, {
 	 *     identity: 'admin',
 	 *     wallet: wallet
 	 * });

--- a/fabric-network/src/impl/query/defaultqueryhandlerstrategies.ts
+++ b/fabric-network/src/impl/query/defaultqueryhandlerstrategies.ts
@@ -17,9 +17,9 @@ function getOrganizationPeers(network: Network) {
 /**
  * @typedef DefaultQueryHandlerStrategies
  * @memberof module:fabric-network
- * @property {module:fabric-network.QueryHandlerFactory} MSPID_SCOPE_SINGLE Query any one of the event services for the connected organisation. Continue
+ * @property {module:fabric-network.QueryHandlerFactory} MSPID_SCOPE_SINGLE Query any one of the peers for the connected organization. Continue
  * to use the same event service for all queries unless it fails.
- * @property {module:fabric-network.QueryHandlerFactory} MSPID_SCOPE_ROUND_ROBIN Query any one of the event services for the connected organisation.
+ * @property {module:fabric-network.QueryHandlerFactory} MSPID_SCOPE_ROUND_ROBIN Query any one of the peers for the connected organization.
  * Use the next available peer for each successive query.
  */
 

--- a/fabric-network/src/network.ts
+++ b/fabric-network/src/network.ts
@@ -44,6 +44,130 @@ export interface Network {
 	removeBlockListener(listener: BlockListener): void;
 }
 
+/**
+ * <p>A Network represents the set of peers in a Fabric network.
+ * Applications should get a Network instance using the
+ * gateway's [getNetwork]{@link module:fabric-network.Gateway#getNetwork} method.</p>
+ *
+ * <p>The Network object provides the ability for applications to:</p>
+ * <ul>
+ *   <li>Obtain a specific smart contract deployed to the network using [getContract]{@link module:fabric-network.Network#getContract},
+ *       in order to submit and evaluate transactions for that smart contract.</li>
+ *   <li>Listen to new block events and replay previous block events using
+ *       [addBlockListener]{@link module:fabric-network.Network#addBlockListener}.</li>
+ * </ul>
+ * @interface Network
+ * @memberof module:fabric-network
+ */
+/**
+ * Get the owning Gateway connection.
+ * @method Network#getGateway
+ * @memberof module:fabric-network
+ * @returns {module:fabric-network.Gateway} A Gateway.
+ */
+/**
+ * Get an instance of a contract (chaincode) on the current network.
+ * @method Network#getContract
+ * @memberof module:fabric-network
+ * @param {string} chaincodeId - the chaincode identifier.
+ * @param {string} [name] - the name of the contract.
+ * @param {string[]} [collections] - the names of collections defined for this chaincode.
+ * @returns {module:fabric-network.Contract} the contract.
+ */
+/**
+ * Get the underlying channel object representation of this network.
+ * @method Network#getChannel
+ * @memberof module:fabric-network
+ * @returns {Channel} A channel.
+ */
+/**
+ * Add a listener to receive transaction commit and peer disconnect events for a set of peers. This is typically used
+ * only within the implementation of a custom [transaction commit event handler]{@tutorial transaction-commit-events}.
+ * @method Network#addCommitListener
+ * @memberof module:fabric-network
+ * @param {module:fabric-network.CommitListener} listener A transaction commit listener callback function.
+ * @param {Endorser[]} peers The peers from which to receive events.
+ * @param {string} transactionId A transaction ID.
+ * @returns {module:fabric-network.CommitListener} The added listener.
+ * @example
+ * const listener: CommitListener = (error, event) => {
+ *     if (error) {
+ *         // Handle peer communication error
+ *     } else {
+ *         // Handle transaction commit event
+ *     }
+ * }
+ * const peers = network.channel.getEndorsers();
+ * await network.addCommitListener(listener, peers, transactionId);
+ */
+/**
+ * Remove a previously added transaction commit listener.
+ * @method Network#removeCommitListener
+ * @memberof module:fabric-network
+ * @param {module:fabric-network.CommitListener} listener A transaction commit listener callback function.
+ */
+/**
+ * Add a listener to receive block events for this network. Blocks will be received in order and without duplication.
+ * The default is to listen for full block events from the current block position.
+ * @method Network#addBlockListener
+ * @memberof module:fabric-network
+ * @async
+ * @param {module:fabric-network.BlockListener} listener A block listener callback function.
+ * @param {module:fabric-network.ListenerOptions} [options] Listener options.
+ * @returns {Promise<module:fabric-network.BlockListener>} The added listener.
+ * @example
+ * const listener: BlockListener = async (event) => {
+ *     // Handle block event
+ *
+ *     // Listener may remove itself if desired
+ *     if (event.blockNumber.equals(endBlock)) {
+ *         network.removeBlockListener(listener);
+ *     }
+ * }
+ * const options: ListenerOptions = {
+ *     startBlock: 1
+ * };
+ * await network.addBlockListener(listener, options);
+ */
+/**
+ * Remove a previously added block listener.
+ * @method Network#removeBlockListener
+ * @memberof module:fabric-network
+ * @param listener {module:fabric-network.BlockListener} A block listener callback function.
+ */
+
+/**
+ * A callback function that will be invoked when a block event is received.
+ * @callback BlockListener
+ * @memberof module:fabric-network
+ * @async
+ * @param {module:fabric-network.BlockEvent} event A block event.
+ * @returns {Promise<void>}
+ */
+
+/**
+ * A callback function that will be invoked when either a peer communication error occurs or a transaction commit event
+ * is received. Only one of the two arguments will have a value for any given invocation.
+ * @callback CommitListener
+ * @memberof module:fabric-network
+ * @param {module:fabric-network.CommitError} [error] Peer communication error.
+ * @param {module:fabric-network.CommitEvent} [event] Transaction commit event from a specific peer.
+ */
+
+/**
+ * @interface CommitError
+ * @extends Error
+ * @memberof module:fabric-network
+ * @property {Endorser} peer The peer that raised this error.
+ */
+
+/**
+ * @interface CommitEvent
+ * @extends {module:fabric-network.TransactionEvent}
+ * @memberof module:fabric-network
+ * @property {Endorser} peer The endorsing peer that produced this event.
+ */
+
 export class NetworkImpl implements Network {
 	queryHandler?: QueryHandler;
 	discoveryService?: DiscoveryService;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1891,6 +1891,7 @@
       "requires": {
         "fabric-ca-client": "file:fabric-ca-client",
         "fabric-common": "file:fabric-common",
+        "fabric-protos": "file:fabric-protos",
         "fs-extra": "^9.0.0",
         "long": "^4.0.0",
         "nano": "^8.2.2",
@@ -2176,7 +2177,8 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
             },
             "minipass": {
@@ -2200,7 +2202,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "run-s eslint tslint",
     "eslint": "eslint fabric-network/ fabric-ca-client/lib/ fabric-common/ test/",
     "tslint": "tslint -t prose -p fabric-common/types/tsconfig.json 'fabric-common/**/*.ts' && tslint -t prose 'test/**/*.ts' && tslint -t prose -p fabric-network/tsconfig.json 'fabric-network/**/*.ts' ",
-    "docs": "node -e 'require(\"./scripts/npm_scripts/testFunctions.js\").cleanUpDocs()' && jsdoc -r -c docs/jsdoc.json -t ./node_modules/ink-docstrap/template",
+    "docs": "node -e 'require(\"./scripts/npm_scripts/testFunctions.js\").cleanUpDocs()' && jsdoc -c docs/jsdoc.json -t ./node_modules/ink-docstrap/template",
     "unitTest:all": "export HFC_LOGGING='{\"debug\":\"test/temp/debug.log\"}' && nyc run-s unitTest:common unitTest:ca-client unitTest:network",
     "unitTest:common": "mocha --reporter list 'fabric-common/test/**/*.js'",
     "unitTest:ca-client": "mocha --reporter list 'fabric-ca-client/test/**/*.js'",


### PR DESCRIPTION
- TypeScript compiler was not including some JSDoc in output JavaScript files depending on its positioning in the TypeScript file.
- Ensure Contract is documented as the Contract interface rather than the internal ContractImpl implementation class.
- Some minor rewording and example code changes for clarity based on user questions.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>