### PR TITLE
FABN-1536: Return copy from IdentityContext.calculateTransactionId()

### DIFF
--- a/fabric-common/lib/IdentityContext.js
+++ b/fabric-common/lib/IdentityContext.js
@@ -36,7 +36,6 @@ const IdentityContext = class {
 		this.type = TYPE;
 		this.client = client;
 		this.user = user;
-		this.options = {};
 		if (!user.getName) {
 			throw Error('Missing valid user parameter');
 		}
@@ -47,7 +46,10 @@ const IdentityContext = class {
 	}
 
 	/**
-	 * create a new transaction ID value
+	 * Create a new transaction ID value. The new transaction ID will be set both on this object and on the return
+	 * value, which is a copy of this identity context. Calls to this function will not affect the transaction ID value
+	 * on copies returned from previous calls.
+	 * @returns A copy of this identity context.
 	 */
 	calculateTransactionId() {
 		const method = 'calculateTransactionId';
@@ -59,12 +61,12 @@ const IdentityContext = class {
 		this.transactionId = Buffer.from(trans_hash).toString();
 		logger.debug('%s - %s', method, this.transactionId);
 
-		return this;
+		return this.clone();
 	}
 
 	/**
 	 * Get the protobuf serialized identity of this user
-	 * @returns {byte[]} serialized identity in bytes
+	 * @returns {Buffer} serialized identity in bytes
 	 */
 	serializeIdentity() {
 		const method = 'serializeIdentity';
@@ -75,8 +77,8 @@ const IdentityContext = class {
 
 	/**
 	 * Sign the bytes provided
-	 * @param {byte[]} payload - The payload bytes that require a signature
-	 * @return  {byte[]} - The signature in bytes
+	 * @param {Buffer} payload - The payload bytes that require a signature
+	 * @return {Buffer} - The signature in bytes
 	 */
 	sign(payload = checkParameter('payload')) {
 		const method = 'sign';
@@ -96,10 +98,14 @@ const IdentityContext = class {
 
 	/**
 	 * Creates a copy of this object.
+	 * @private
 	 * @return {IdentityContext} An identity context.
 	 */
 	clone() {
-		return new IdentityContext(this.user, this.client);
+		const result = new IdentityContext(this.user, this.client);
+		result.transactionId = this.transactionId;
+		result.nonce = this.nonce;
+		return result;
 	}
 };
 

--- a/fabric-common/test/IdentityContext.js
+++ b/fabric-common/test/IdentityContext.js
@@ -51,6 +51,24 @@ describe('IdentityContext', () => {
 			should.exist(idx.nonce);
 			should.exist(idx.transactionId);
 		});
+
+		it('should return new identity context', () => {
+			const result = idx.calculateTransactionId();
+			result.should.be.an.instanceof(IdentityContext).that.does.not.equal(idx);
+		});
+
+		it('result should have same serialized identity', () => {
+			const actual = idx.calculateTransactionId().serializeIdentity();
+
+			const expected = idx.serializeIdentity();
+			actual.should.deep.equal(expected);
+		});
+
+		it('result should have matching transaction ID and nonce', () => {
+			const result = idx.calculateTransactionId();
+			result.transactionId.should.equal(idx.transactionId);
+			result.nonce.should.equal(idx.nonce);
+		});
 	});
 
 	describe('#serializeIdentity', () => {
@@ -76,20 +94,6 @@ describe('IdentityContext', () => {
 		it('should return string', () => {
 			const string = idx.toString();
 			should.equal(string, 'IdentityContext: { user: user, transactionId: null, nonce:null}');
-		});
-	});
-
-	describe('#clone', () => {
-		it('should create a new identity context', () => {
-			const result = idx.clone();
-			result.should.be.an.instanceof(IdentityContext).that.does.not.equal(idx);
-		});
-
-		it('should have same serialized identity', () => {
-			const expected = idx.serializeIdentity();
-			const actual = idx.clone().serializeIdentity();
-
-			actual.should.deep.equal(expected);
 		});
 	});
 });

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -363,9 +363,9 @@ export class Channel {
 export class IdentityContext {
 	readonly transactionId: string;
 	constructor(user: User, client: Client);
-	calculateTransactionId(): this;
-	getNonce(): Buffer;
-	clone(): IdentityContext;
+	calculateTransactionId(): IdentityContext;
+	serializeIdentity(): Buffer;
+	sign(payload: Buffer): Buffer;
 }
 
 export interface BlockData {

--- a/fabric-network/src/transaction.ts
+++ b/fabric-network/src/transaction.ts
@@ -116,10 +116,9 @@ export class Transaction {
 		this.eventHandlerStrategyFactory = this.gatewayOptions.eventHandlerOptions.strategy || EventHandlers.NONE;
 		this.queryHandler = contract.network.queryHandler!;
 
-		// Calculating transaction ID modifies the state of the identity context so take a copy to prevent the state
-		// being modified by other code before it is used to send any proposals
-		this.identityContext = this.contract.gateway.identityContext!.clone();
-		this.transactionId = this.identityContext.calculateTransactionId().transactionId;
+		// Store the returned copy to prevent state being modified by other code before it is used to send proposals
+		this.identityContext = this.contract.gateway.identityContext!.calculateTransactionId();
+		this.transactionId = this.identityContext.transactionId;
 	}
 
 	/**


### PR DESCRIPTION
Removes the need for IdentityContext.clone() as a public method.
Also correct IdentityContext TypeScript definitions and JSDoc.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>