### PR TITLE
FABN-1556: Fix broken doc links

### DIFF
--- a/docs/tutorials/query-peers.md
+++ b/docs/tutorials/query-peers.md
@@ -71,4 +71,4 @@ class MyQueryHandler {
 }
 ```
 
-For a complete sample plug-in query handler implementation, see [sample-query-handler.ts](https://github.com/hyperledger/fabric-sdk-node/blob/master/test/typescript/integration/network-e2e/sample-query-handler.ts).
+For a complete sample plug-in query handler implementation, see [sample-query-handler.ts](https://github.com/hyperledger/fabric-sdk-node/blob/release-1.4/test/typescript/integration/network-e2e/sample-query-handler.ts).

--- a/docs/tutorials/transaction-commit-events.md
+++ b/docs/tutorials/transaction-commit-events.md
@@ -112,4 +112,4 @@ class MyTransactionEventHandler {
 }
 ```
 
-For a complete sample plug-in event handler implementation, see [sample-transaction-event-handler.js](https://github.com/hyperledger/fabric-sdk-node/blob/master/test/integration/network-e2e/sample-transaction-event-handler.js).
+For a complete sample plug-in event handler implementation, see [sample-transaction-event-handler.js](https://github.com/hyperledger/fabric-sdk-node/blob/release-1.4/test/integration/network-e2e/sample-transaction-event-handler.js).


### PR DESCRIPTION
Broken links to sample code in the tutorial pages for query handlers and transaction handlers.
