### PR TITLE
FABN-1569: Revert newDefaultKeyValueStore() to async

### DIFF
--- a/fabric-common/lib/BaseClient.js
+++ b/fabric-common/lib/BaseClient.js
@@ -51,11 +51,10 @@ const BaseClient = class {
 	 * Obtains an instance of the [KeyValueStore]{@link module:api.KeyValueStore} class. By default
 	 * it returns the built-in implementation [InMemoryKeyValueStore]{@link InMemoryKeyValueStore}.
 	 *
-	 * @param {Object} options Specific to the implementation, for initializing the instance.
 	 * @returns {KeyValueStore} {@link module:api.KeyValueStore} instance of the KeyValueStore implementation
 	 */
-	static newDefaultKeyValueStore(options) {
-		return sdkUtils.newKeyValueStore(options);
+	static async newDefaultKeyValueStore() {
+		return sdkUtils.newKeyValueStore();
 	}
 
 	/**

--- a/fabric-common/lib/Utils.js
+++ b/fabric-common/lib/Utils.js
@@ -127,7 +127,7 @@ module.exports.newCryptoSuite = (setting) => {
 };
 
 // Provide an in-memory keyValueStore
-module.exports.newKeyValueStore = (options) => {
+module.exports.newKeyValueStore = () => {
 	return new InMemoryKeyValueStore();
 };
 

--- a/fabric-common/test/BaseClient.js
+++ b/fabric-common/test/BaseClient.js
@@ -76,16 +76,15 @@ describe('BaseClient', () => {
 			sandbox.restore();
 		});
 
-		it('should call `sdkUtils.newKeyValueStore` with passed parameters and return result', async () => {
+		it('should call `sdkUtils.newKeyValueStore` and return result', async () => {
 			const sdkUtilsStub = sandbox.stub();
 			const newDefaultKeyValueStoreStub = sandbox.stub().resolves('newDefaultKeyValueStore');
 			sdkUtilsStub.newKeyValueStore = newDefaultKeyValueStoreStub;
 			BaseClientRewire.__set__('sdkUtils', sdkUtilsStub);
 
-			BaseClientRewire.newDefaultKeyValueStore('setting');
+			await BaseClientRewire.newDefaultKeyValueStore();
 
 			sinon.assert.calledOnce(newDefaultKeyValueStoreStub);
-			sinon.assert.calledWith(newDefaultKeyValueStoreStub, 'setting');
 		});
 	});
 


### PR DESCRIPTION
A previous commit removed the async keyword from BaseClient.newDefaultKeyValueStore(), making it synchronous and potentially breaking client code. This commit reverts that specific change.