### PR TITLE
FABN-1566 add transaction code to event error

### DIFF
--- a/fabric-network/lib/errors/transactionerror.js
+++ b/fabric-network/lib/errors/transactionerror.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+const FabricError = require('./fabricerror');
+
+/**
+ * Error indicating a transaction error.
+ * @extends module:fabric-network.FabricError
+ * @memberof module:fabric-network
+ */
+class TransactionError extends FabricError {
+	constructor(info) {
+		super(info);
+	}
+}
+
+module.exports = TransactionError;

--- a/fabric-network/lib/impl/event/transactioneventhandler.js
+++ b/fabric-network/lib/impl/event/transactioneventhandler.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const TimeoutError = require('fabric-network/lib/errors/timeouterror');
+const TransactionError = require('fabric-network/lib/errors/transactionerror');
 
 const logger = require('fabric-network/lib/logger').getLogger('TransactionEventHandler');
 const util = require('util');
@@ -110,7 +111,11 @@ class TransactionEventHandler {
 		this._receivedEventHubResponse(eventHub);
 		if (code !== 'VALID') {
 			const message = util.format('Peer %s has rejected transaction %j with code %j', eventHub.getPeerAddr(), txId, code);
-			this._strategyFail(new Error(message));
+			this._strategyFail(new TransactionError({
+				message,
+				transactionId: txId,
+				transactionCode: code
+			}));
 		} else {
 			this.strategy.eventReceived(this._strategySuccess.bind(this), this._strategyFail.bind(this));
 		}

--- a/fabric-network/test/errors.js
+++ b/fabric-network/test/errors.js
@@ -11,9 +11,10 @@ const expect = chai.expect;
 
 const FabricError = require('fabric-network/lib/errors/fabricerror');
 const TimeoutError = require('fabric-network/lib/errors/timeouterror');
+const TransactionError = require('fabric-network/lib/errors/transactionerror');
 
 describe('Common error behaviour', () => {
-	[FabricError, TimeoutError].forEach((ErrorType) => describe(ErrorType.name, () => {
+	[FabricError, TimeoutError, TransactionError].forEach((ErrorType) => describe(ErrorType.name, () => {
 		it('name property matches class name', () => {
 			const error = new ErrorType();
 			expect(error.name).to.equal(ErrorType.name);
@@ -29,6 +30,12 @@ describe('Common error behaviour', () => {
 			const info = {message: 'message'};
 			const error = new ErrorType(info);
 			expect(error.message).to.equal(info.message);
+		});
+
+		it('created with error message property', () => {
+			const info = {transactionCode: 'NOT_VALID'};
+			const error = new ErrorType(info);
+			expect(error.transactionCode).to.equal(info.transactionCode);
 		});
 
 		it('created with cause error', () => {

--- a/fabric-network/test/impl/event/transactioneventhandler.js
+++ b/fabric-network/test/impl/event/transactioneventhandler.js
@@ -16,6 +16,7 @@ const ChannelEventHub = require('fabric-client').ChannelEventHub;
 const Transaction = require('fabric-network/lib/transaction');
 const TransactionEventHandler = require('fabric-network/lib/impl/event/transactioneventhandler');
 const TimeoutError = require('fabric-network/lib/errors/timeouterror');
+const TransactionError = require('fabric-network/lib/errors/transactionerror');
 const TransactionID = require('fabric-client/lib/TransactionID');
 
 describe('TransactionEventHandler', () => {
@@ -123,7 +124,7 @@ describe('TransactionEventHandler', () => {
 			const code = 'ERROR_CODE';
 			await handler.startListening();
 			stubEventHub._onEventFn(transactionId, code);
-			return expect(handler.waitForEvents()).to.be.rejectedWith(code);
+			return expect(handler.waitForEvents()).to.be.rejectedWith(TransactionError);
 		});
 
 		it('succeeds when strategy calls success function after event received', async () => {

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -140,6 +140,9 @@ export interface FabricError extends Error {
 }
 
 export interface TimeoutError extends FabricError {} // tslint:disable-line:no-empty-interface
+export interface TransactionError extends FabricError {
+	transationCode: string;
+}
 
 //-------------------------------------------
 // Wallet Management


### PR DESCRIPTION
Users will be able to check the transaction code when their
error callback is called with an error. The error will be of
type 'TransactionError' and it will have an attribute of
'transactionCode' along with the 'transactionId'.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>