### PR TITLE
FABN-1570: Explicit dependency versions on publishing

### DIFF
--- a/fabric-ca-client/package.json
+++ b/fabric-ca-client/package.json
@@ -6,7 +6,6 @@
     "blockchain"
   ],
   "version": "2.1.1-snapshot",
-  "tag": "unstable",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --recursive  -t 10000"

--- a/fabric-common/package.json
+++ b/fabric-common/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "fabric-common",
 	"version": "2.1.1-snapshot",
-	"tag": "unstable",
 	"description": "This package encapsulates the common code used by the `fabric-ca-client`, `fabric-network` packages.",
 	"keywords": [
 		"blockchain",

--- a/fabric-network/package.json
+++ b/fabric-network/package.json
@@ -6,7 +6,6 @@
     "blockchain"
   ],
   "version": "2.1.1-snapshot",
-  "tag": "unstable",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -1,7 +1,6 @@
 {
   "name": "fabric-protos",
   "version": "2.1.1-snapshot",
-  "tag": "unstable",
   "description": "Protocol Buffer files and generated JavaScript classes for Hyperledger Fabric",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fabric-sdk-node",
   "version": "2.1.1-snapshot",
+  "tag": "unstable",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Dependencies on other packages within the Node SDK now use the exact published package versions instead of the npm tag.

The publishing script uses the version and tag from the top-level package.json only. Versions and tags of individual packages are rewritten to reflect the top-level package.json values at publish time. Unstable releases must have a pre-release version number (including a "-") and the pre-release version is incremented from the previously published pre-release package version. Stable releases must specify a release version, and the specified version is used without modification.

Packages with a tag of "skip" in their local package.json will not be published. Dependencies on those packages will be rewritten to the previously published version. This might be useful to recover from a situation where an integration build failed after publishing some but not all of the packages for a stable release. Generally all modules should be published together and the skip capability should not be used.