### PR TITLE
[FABN-835] Fix recycle reference in Utils.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Hyperledger Fabric Client SDK makes it possible to use APIs to interact with
 
 This project publishes the following npm packages:
 * `fabric-ca-client` - client for the optional component in Hyperledger Fabric, [fabric-ca](http://hyperledger-fabric-ca.readthedocs.io/en/latest/users-guide.html). The fabric-ca component allows applications to enroll Peers and application users to establish trusted identities on the blockchain network. It also provides support for pseudonymous transaction submissions with Transaction Certificates. If the target blockchain network is configured with standard Certificate Authorities for trust anchors, the application does not need to use this package.
-* `fabric-common`, encapsulates the common code used by all fabric-sdk-node packages supporting fine grain interactions with the Fabric network to send transaction invocations
+* `fabric-common` - encapsulates the common code used by all fabric-sdk-node packages supporting fine grain interactions with the Fabric network to send transaction invocations
 * `fabric-network` - This package encapsulates the APIs to connect to a Fabric network, submit transactions and perform queries against the ledger at a higher level of abstraction than through the `fabric-common`.
 * `fabric-protos` - This package encapsulates the protobuffers that are used to communicate over gRPC
 

--- a/fabric-common/lib/Utils.js
+++ b/fabric-common/lib/Utils.js
@@ -15,7 +15,7 @@ const os = require('os');
 
 const Config = require('./Config');
 const InMemoryKeyValueStore = require('./impl/InMemoryKeyValueStore');
-
+const CryptoKeyStore = require('./impl/CryptoKeyStore');
 const sjcl = require('sjcl');
 const yn = require('yn');
 
@@ -462,7 +462,6 @@ module.exports.getDefaultKeyStorePath = () => {
  * @return {CryptoKeyStore}
  */
 module.exports.newCryptoKeyStore = (keyValueStore = new InMemoryKeyValueStore()) => {
-	const CryptoKeyStore = require('./impl/CryptoKeyStore');
 	return new CryptoKeyStore(keyValueStore);
 };
 

--- a/fabric-common/lib/impl/ecdsa/key.js
+++ b/fabric-common/lib/impl/ecdsa/key.js
@@ -7,20 +7,20 @@
 
 'use strict';
 
-const {HashPrimitives, Key, Utils: utils} = require('../../../');
+const Key = require('../../Key');
+const HashPrimitives = require('../../HashPrimitives');
 const jsrsa = require('jsrsasign');
 const asn1 = jsrsa.asn1;
 const KEYUTIL = jsrsa.KEYUTIL;
 const ECDSA = jsrsa.ECDSA;
 const jws = jsrsa.jws;
-const logger = utils.getLogger('ecdsa/key.js');
 
 /**
  * This module implements the {@link module:api.Key} interface, for ECDSA.
  * @class ECDSA_KEY
  * @extends module:api.Key
  */
-module.exports = class ECDSA_KEY extends Key {
+class ECDSA_KEY extends Key {
 	/**
 	 * this class represents the private or public key of an ECDSA key pair.
 	 *
@@ -59,8 +59,6 @@ module.exports = class ECDSA_KEY extends Key {
 			const xyhex = key.getPublicKeyXYHex();
 			const xBuffer = Buffer.from(xyhex.x, 'hex');
 			const yBuffer = Buffer.from(xyhex.y, 'hex');
-			logger.debug('ECDSA curve param X: %s', xBuffer.toString('hex'));
-			logger.debug('ECDSA curve param Y: %s', yBuffer.toString('hex'));
 			xBuffer.copy(newBuff, 1 + byteLen - xBuffer.length);
 			yBuffer.copy(newBuff, 1 + 2 * byteLen - yBuffer.length);
 			return newBuff;
@@ -182,4 +180,6 @@ module.exports = class ECDSA_KEY extends Key {
 			return KEYUTIL.getPEM(this._key);
 		}
 	}
-};
+}
+
+module.exports = ECDSA_KEY;


### PR DESCRIPTION
Utils.js rely on './impl/CryptoKeyStore.js'
CryptoKeyStore.js rely on impl/ecdsa/key.js
key.js rely on Utils.js

I break this cycle by delete some debug log in key.js

Signed-off-by: david <david-khala@hotmail.com>