### PR TITLE
FABN-1566 Add TransactionError with event status

### DIFF
--- a/fabric-network/src/errors/transactionerror.ts
+++ b/fabric-network/src/errors/transactionerror.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+import { FabricError } from './fabricerror';
+
+export interface TransactionErrorInfo {
+	message: string;
+	transactionId: string;
+	transactionCode: string;
+}
+
+/**
+ * Base type for Fabric-specific errors.
+ * @memberof module:fabric-network
+ * @property {string} [transactionId] ID of the associated transaction.
+ * @property {string} [transactionCode] The transaction validation code of the associated transaction.
+ */
+export class TransactionError extends FabricError {
+	transactionCode?: string;
+
+	/*
+	 * Constructor.
+	 * @param {(string|object)} [info] Either an error message (string) or additional properties to assign to this
+	 * instance (object).
+	 */
+	constructor(info?: string | TransactionErrorInfo) {
+		super(info);
+		this.name = TransactionError.name;
+	}
+}

--- a/fabric-network/src/impl/event/transactioneventhandler.ts
+++ b/fabric-network/src/impl/event/transactioneventhandler.ts
@@ -9,6 +9,7 @@ import { TransactionEventStrategy } from './transactioneventstrategy';
 import { Network } from '../../network';
 import { Endorser } from 'fabric-common';
 import { CommitError, CommitEvent, CommitListener } from '../../events';
+import { TransactionError } from '../../errors/transactionerror';
 
 import * as Logger from '../../logger';
 const logger = Logger.getLogger('TransactionEventHandler');
@@ -121,7 +122,11 @@ export class TransactionEventHandler implements TxEventHandler {
 	private eventCallback(error?: CommitError, event?: CommitEvent) {
 		if (event && !event.isValid) {
 			const message = `Commit of transaction ${this.transactionId} failed on peer ${event.peer.name} with status ${event.status}`;
-			this.strategyFail(new Error(message));
+			this.strategyFail(new TransactionError({
+				message,
+				transactionId: event.transactionId,
+				transactionCode: event.status
+			}));
 		}
 
 		const peer = error?.peer || event!.peer;

--- a/fabric-network/test/impl/event/transactioneventhandler.spec.ts
+++ b/fabric-network/test/impl/event/transactioneventhandler.spec.ts
@@ -228,6 +228,13 @@ describe('TransactionEventHandler', () => {
 
 			await expect(handler.waitForEvents()).to.be.rejectedWith(invalidEventInfo.status);
 		});
+
+		it('fails when receiving an invalid event from peer', async () => {
+			await handler.startListening();
+			eventService.sendEvent(invalidEventInfo);
+
+			await expect(handler.waitForEvents()).to.be.rejectedWith(invalidEventInfo.status);
+		});
 	});
 
 	describe('timeouts', () => {
@@ -304,5 +311,4 @@ describe('TransactionEventHandler', () => {
 			}
 		});
 	});
-
 });

--- a/fabric-network/types/index.d.ts
+++ b/fabric-network/types/index.d.ts
@@ -24,6 +24,7 @@ export { X509Identity } from '../lib/impl/wallet/x509identity';
 export * from '../lib/events';
 export { FabricError } from '../lib/errors/fabricerror';
 export { TimeoutError } from '../lib/errors/timeouterror';
+export { TransactionError, TransactionErrorInfo } from '../lib/errors/transactionerror';
 export { QueryHandlerFactory };
 export { QueryHandler } from '../lib/impl/query/queryhandler';
 export { Query, QueryResults, QueryResponse } from '../lib/impl/query/query';


### PR DESCRIPTION
When a transaction completes with a non-valid status
the error object will be of type TransactionError which
will include the transactionCode and transactionId attribute.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>