### PR TITLE
Use Official CouchDB 3.1 Image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
 - name: SOFTHSM2_CONF
   value: $(Build.Repository.LocalPath)/test/ts-fixtures/hsm/softhsm2.conf
 - name: FABRIC_VERSION
-  value: 2.1
+  value: 2.2
 
 # A Pipeline contains one or more stages
 # A stage is a related collection of jobs. By default stages run sequentially

--- a/scripts/utility/fabric_images.sh
+++ b/scripts/utility/fabric_images.sh
@@ -6,7 +6,7 @@
 #
 set -euo pipefail
 
-version=${FABRIC_VERSION:-2.1}
+version=${FABRIC_VERSION:-2.2}
 artifactory_url=hyperledger-fabric.jfrog.io
 
 for image in peer orderer ccenv baseos nodeenv javaenv tools; do
@@ -16,7 +16,7 @@ for image in peer orderer ccenv baseos nodeenv javaenv tools; do
     docker rmi -f "${artifactory_image}" >/dev/null
 done
 
-docker pull -q hyperledger/fabric-couchdb
+docker pull -q couchdb:3.1
 docker pull -q hyperledger/fabric-ca:1.4
 docker tag hyperledger/fabric-ca:1.4 hyperledger/fabric-ca
 docker rmi hyperledger/fabric-ca:1.4 >/dev/null

--- a/test/fixtures/docker-compose/docker-compose-base.yaml
+++ b/test/fixtures/docker-compose/docker-compose-base.yaml
@@ -100,6 +100,9 @@ services:
       - CORE_CHAINCODE_GOLANG_RUNTIME=hyperledger/fabric-baseos
       - CORE_CHAINCODE_JAVA_RUNTIME=hyperledger/fabric-javaenv
       - CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv
+
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: peer node start
     volumes:
@@ -107,4 +110,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: hyperledger/fabric-couchdb
+    image: couchdb:3.1
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=adminpw

--- a/test/ts-fixtures/crypto-material/config-base/core.yaml
+++ b/test/ts-fixtures/crypto-material/config-base/core.yaml
@@ -569,12 +569,12 @@ ledger:
        # CouchDB client (on the peer) and server.
        couchDBAddress: 127.0.0.1:5984
        # This username must have read and write authority on CouchDB
-       username:
+       username: admin
        # The password is recommended to pass as an environment variable
        # during start up (eg LEDGER_COUCHDBCONFIG_PASSWORD).
        # If it is stored here, the file must be access control protected
        # to prevent unintended users from discovering the password.
-       password:
+       password: adminpw
        # Number of retries for CouchDB errors
        maxRetries: 3
        # Number of retries for CouchDB errors during peer startup

--- a/test/ts-fixtures/docker-compose/docker-compose-base.yaml
+++ b/test/ts-fixtures/docker-compose/docker-compose-base.yaml
@@ -102,6 +102,9 @@ services:
       - CORE_CHAINCODE_GOLANG_RUNTIME=hyperledger/fabric-baseos
       - CORE_CHAINCODE_JAVA_RUNTIME=hyperledger/fabric-javaenv
       - CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv
+
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: peer node start
     volumes:
@@ -133,4 +136,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: hyperledger/fabric-couchdb
+    image: couchdb:3.1
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=adminpw

--- a/test/ts-scenario/steps/constants.ts
+++ b/test/ts-scenario/steps/constants.ts
@@ -66,7 +66,7 @@ export enum Constants {
 	MEMORY_WALLET = 'memory',
 	FILE_WALLET = 'file',
 	COUCH_WALLET = 'couchDB',
-	COUCH_WALLET_URL = 'http://localhost:5984',
+	COUCH_WALLET_URL = 'http://admin:adminpw@localhost:5984',
 	HSM_WALLET = 'HSM',
 
 	// provider types


### PR DESCRIPTION
Fabric 2.2 removes official support for CouchDB 2.x.
The migration to 3.1 was to address fsync issues
in the underlying storage implementation in Couch.

This change moves to CouchDB 3.1 which requires the
user to now set an admin identity at startup.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>