### PR TITLE
FABN-1586 Do not wrap tlsCACerts

### DIFF
--- a/fabric-client/lib/Client.js
+++ b/fabric-client/lib/Client.js
@@ -562,7 +562,9 @@ const Client = class extends BaseClient {
 	_buildCAfromConfig(ca_info) {
 		let tlsCACerts = ca_info.getTlsCACerts();
 		if (tlsCACerts) {
-			tlsCACerts = [tlsCACerts];
+			if (!Array.isArray(tlsCACerts)) {
+				tlsCACerts = [tlsCACerts];
+			} // otherwise use it as it is
 		} else {
 			tlsCACerts = [];
 		}

--- a/fabric-client/test/Client.js
+++ b/fabric-client/test/Client.js
@@ -705,7 +705,19 @@ describe('Client', () => {
 			client = new Client();
 		});
 
-		it('should return the ca service', () => {
+		it('should return the ca service as array when array', () => {
+			getTlsCACertsStub.returns(['cert']);
+			getConnectionOptionsStub.returns({verify: true});
+			getUrlStub.returns('url');
+			getCaNameStub.returns('name');
+			getConfigSettingStub.returns('class-path');
+			client._buildCAfromConfig(caInfo);
+			sinon.assert.calledWith(getConfigSettingStub, 'certificate-authority-client');
+			sinon.assert.calledWith(requireStub, 'class-path');
+			sinon.assert.calledWith(caServiceStub, {tlsOptions: {trustedRoots: ['cert'], verify: true}, caName: 'name', cryptoSuite: null, url: 'url'});
+		});
+
+		it('should return the ca service as array when string', () => {
 			getTlsCACertsStub.returns('cert');
 			getConnectionOptionsStub.returns({verify: true});
 			getUrlStub.returns('url');


### PR DESCRIPTION
Use tlsCACerts as defined in the common connection profile
to avoid wrapping an array in an array. Both a single string
and an array of strings are valid for connecting to a Fabric-CA.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>