### PR TITLE
FABN-1587 Use false as the default verify option

### DIFF
--- a/fabric-client/lib/Client.js
+++ b/fabric-client/lib/Client.js
@@ -567,7 +567,7 @@ const Client = class extends BaseClient {
 			tlsCACerts = [];
 		}
 		const connection_options = ca_info.getConnectionOptions();
-		let verify = true; // default if not found
+		let verify = false; // default if not found
 		if (connection_options && typeof connection_options.verify === 'boolean') {
 			verify = connection_options.verify;
 		}

--- a/fabric-client/test/Client.js
+++ b/fabric-client/test/Client.js
@@ -724,7 +724,7 @@ describe('Client', () => {
 			client._buildCAfromConfig(caInfo);
 			sinon.assert.calledWith(getConfigSettingStub, 'certificate-authority-client');
 			sinon.assert.calledWith(requireStub, 'class-path');
-			sinon.assert.calledWith(caServiceStub, {tlsOptions: {trustedRoots: [], verify: true}, caName: 'name', cryptoSuite: null, url: 'url'});
+			sinon.assert.calledWith(caServiceStub, {tlsOptions: {trustedRoots: [], verify: false}, caName: 'name', cryptoSuite: null, url: 'url'});
 		});
 	});
 


### PR DESCRIPTION
When the fabric-client.Client builds a FabricCAService
instance for the user from the information of a common
connection profile it should use false as the tls verify
option when one is not defined.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>