### PR TITLE
FABN-1600: Better unstable version generation (#248)

### DIFF
--- a/fabric-ca-client/package.json
+++ b/fabric-ca-client/package.json
@@ -5,7 +5,7 @@
     "hyperledger",
     "blockchain"
   ],
-  "version": "1.4.11",
+  "version": "1.4.12-snapshot",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --exclude 'test/data/**/*.js' --recursive  -t 10000"

--- a/fabric-client/package.json
+++ b/fabric-client/package.json
@@ -5,7 +5,7 @@
     "hyperledger",
     "blockchain"
   ],
-  "version": "1.4.11",
+  "version": "1.4.12-snapshot",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --exclude 'test/data/**/*.js' --recursive  -t 10000"

--- a/fabric-common/package.json
+++ b/fabric-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric-common",
-  "version": "1.4.11",
+  "version": "1.4.12-snapshot",
   "description": "This package encapsulates the common code used by the `fabric-ca-client`, `fabric-client` packages.",
   "keywords": [
     "blockchain",

--- a/fabric-network/package.json
+++ b/fabric-network/package.json
@@ -5,7 +5,7 @@
     "hyperledger",
     "blockchain"
   ],
-  "version": "1.4.11",
+  "version": "1.4.12-snapshot",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fabric-sdk-node",
-  "version": "1.4.11",
-  "tag": "latest-1.4",
+  "version": "1.4.12-snapshot",
+  "tag": "unstable-1.4",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/scripts/ci_scripts/azurePublishNpmPackages.sh
+++ b/scripts/ci_scripts/azurePublishNpmPackages.sh
@@ -88,13 +88,11 @@ readCurrentPackageVersion() {
 
 readNextUnstablePackageVersion() {
     local nextVersion
-    nextVersion=$(npm dist-tags ls "$1" | awk "/^${RELEASE_TAG}:"/'{
+    nextVersion=$(npm view "$1" versions --json | awk -F . "/\"${RELEASE_VERSION}/"'{
         ver=$NF
-        rel=$NF
-        sub(/.*\./,"",rel)
-        sub(/\.[[:digit:]]+$/,"",ver)
-        print rel+1
-    }')
+        sub(/\".*/, "", ver)
+        print ver+1
+    }' | sort -r | head -1)
     echo "${RELEASE_VERSION}.${nextVersion:-1}"
 }
 


### PR DESCRIPTION
Cherry-pick of 6f29724ed68a20fa10a00f3c17a617a02a55e3f5

Rather than increment the snapshot version of whichever version was last published for a given tag, use the next available snapshot version for the given release version.

Also update versions and npm tags to snapshot/unstable following release.