### PR TITLE
FABN-1603: Doc updates for 2.2 release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ The following tables show versions of Fabric, Node and other dependencies that a
 
 |     | Tested | Supported |
 | --- | ------ | --------- |
-| **Fabric** | 2.1 | 2.x |
+| **Fabric** | 2.2 | 2.2 |
 | **Node** | 10, 12 | 10.13+, 12.13+ |
 | **Platform** | Ubuntu 18.04 | |
 

--- a/docs/redirectTemplates/404.html
+++ b/docs/redirectTemplates/404.html
@@ -46,35 +46,10 @@ a:focus {
 </style>
 <head>
 	<meta charset="utf-8">
-	<title>Single Page Apps for GitHub Pages</title>
-	<script type="text/javascript">
-
-		let l = window.location;
-
-		// firstly need to check if we are in a loop
-		if (!l.search.match(/redirect=true/)){
-			let newUrl = l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '')
-			+ '/release-1.4/index.html?redirect=true'
-
-			let mapping = [FILENAME__MAPPING]
-			let release = "release-1.4";
-
-			// look up the maping
-			let requestedPage = l.pathname.split('/').slice(1)[0]
-
-			// if (mapping.indexOf(requestedPage)>-1) {
-				// newUrl = l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '')
-				// +'/release-1.4/fabric-shim.' + requestedPage+'?redirect=true';
-			// }
-
-			console.log(newUrl);
-			l.replace(newUrl);
-		}
-
-	</script>
+	<title>404: Page not found</title>
 </head>
 <body>
 <h1>Sorry, a suitable documentation page can not be found</h1>
-<h2>Please consult the main <a href="https://fabric-sdk-node.readthedocs.io/en/release-1.2/">Hyperledger Fabric documentation</a></h2>
+<h2>Please consult the <a href="https://hyperledger.github.io/fabric-sdk-node/">Node SDK documentation</a></h2>
 </body>
 </html>

--- a/docs/redirectTemplates/index.md
+++ b/docs/redirectTemplates/index.md
@@ -8,7 +8,7 @@ The SDK implements the Fabric programming model as described in the [Developing 
 ## Documentation
 
 Full documentation is published for each of the following versions:
-- [2.1](https://hyperledger.github.io/fabric-sdk-node/master/module-fabric-network.html)
+- [2.2](https://hyperledger.github.io/fabric-sdk-node/release-2.2/module-fabric-network.html)
 - [1.4](https://hyperledger.github.io/fabric-sdk-node/release-1.4/module-fabric-network.html)
 
 


### PR DESCRIPTION
- API documentation links on homepage
- Compatibility matrix
- Homepage link in 404 page

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>