### PR TITLE
[FABN-1604]Modify generating command for unit test in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Clone the project and launch the following commands to install the dependencies 
 In the project root folder:
 * Install all dependancies via `npm install`
 * Optionally, to generate API docs via `npm run docs`
-* To generate the required crypto material used by the tests, use one of the following patform specific commands `npm run installAndGenerateCerts`
+* To generate the required crypto material used by the tests, use the npm task `npm run installAndGenerateCerts`
 * To run the unit tests that do not require any additional set up, use `npm run testHeadless`
 
 ### Run Integration Tests

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Clone the project and launch the following commands to install the dependencies 
 In the project root folder:
 * Install all dependancies via `npm install`
 * Optionally, to generate API docs via `npm run docs`
-* To generate the required crypto material used by the tests, use one of the following patform specific commands:
-  * For Linux `npm run installAndGenerateCerts`
-  * For mac `npm run installAndGenerateCertsMac`
+* To generate the required crypto material used by the tests, use one of the following patform specific commands `npm run installAndGenerateCerts`
 * To run the unit tests that do not require any additional set up, use `npm run testHeadless`
 
 ### Run Integration Tests

--- a/test/README.md
+++ b/test/README.md
@@ -13,7 +13,7 @@ The scenario tests are written in typescript and use [Cucumber](https://github.c
 Test certificates are set to expire a year after generation. Due to this the test suite generates new certificates as part of the build process, and is a manual requirement prior to running the tests locally. This process is orchestrated using test scripts that:
  - Generate the crypto-material, matching channel blocks and fabric-ca certificates required by the docker-compose files and test suites
 
-Use the npm task `npm run installAndGenerateCerts` to perform the above on a linux x64 machine, or `npm run installAndGenerateCertsMac` for a mac. This is only required to be performed upon initial project clone, and then yearly afterwards.
+Use the npm task `npm run installAndGenerateCerts`. This is only required to be performed upon initial project clone, and then yearly afterwards.
 
 ## Structure
 

--- a/test/fixtures/crypto-material/README.md
+++ b/test/fixtures/crypto-material/README.md
@@ -1,2 +1,2 @@
 All crypto material here is generated via the contained shell scripts files and orchestrated by npm scripts, please use the following to create any required certificates:
-- Obtain crypto-gen binaries and generate the crypto material required for tests (`npm installAndGenerateCerts` or `npm installAndGenerateCertsMac`)
+- Obtain crypto-gen binaries and generate the crypto material required for tests (`npm installAndGenerateCerts`)

--- a/test/ts-fixtures/crypto-material/README.md
+++ b/test/ts-fixtures/crypto-material/README.md
@@ -1,2 +1,2 @@
 All crypto material here is generated via the contained shell scripts files and orchestrated by npm scripts, please use the following to create any required certificates:
-- Obtain crypto-gen binaries and generate the crypto material required for tests (`npm installAndGenerateCerts` or `npm installAndGenerateCertsMac`)
+- Obtain crypto-gen binaries and generate the crypto material required for tests (`npm installAndGenerateCerts`)

--- a/test/ts-scenario/README.md
+++ b/test/ts-scenario/README.md
@@ -2,7 +2,7 @@
 
 This test suite is intended to provide high level test coverage from a scenario perspective, and tests herein represent those at the top of the test pyramid. Consequently, these test should be added to with due consideration and should encapsulate the completion of a high level user task; for more fine grained testing, the FV or unit test frameworks should be used.
 
-The test suite uses the docker network and crypto files from within `/test/ts-fixtures`. If crypto material does not exist, which is the case if you have recently cloned the repository, it is necessary to run the `installAndGenerateCerts` or `installAndGenerateCertsMac` npm task prior to running the tests.
+The test suite uses the docker network and crypto files from within `/test/ts-fixtures`. If crypto material does not exist, which is the case if you have recently cloned the repository, it is necessary to run the `installAndGenerateCerts` npm task prior to running the tests.
 
 ## Structure
 


### PR DESCRIPTION
- delete `installAndGenerateCertsMac` command in README.md

Signed-off-by: Sol Kang <pdpxpd@gmail.com>