### PR TITLE
FABN-1560 add disconnected peer to channel

### DIFF
--- a/fabric-common/lib/Channel.js
+++ b/fabric-common/lib/Channel.js
@@ -254,8 +254,8 @@ const Channel = class {
 		if (!(endorser.type === 'Endorser')) {
 			throw Error('Missing valid endorser instance');
 		}
-		if (!(endorser.connected)) {
-			throw Error('Endorser must be connected');
+		if (!endorser.isConnectable()) {
+			throw Error('Endorser must be connectable');
 		}
 		const name = endorser.name;
 		const check = this.endorsers.get(name);
@@ -335,8 +335,8 @@ const Channel = class {
 		if (!(committer.type === 'Committer')) {
 			throw Error('Missing valid committer instance');
 		}
-		if (!(committer.connected)) {
-			throw Error('Committer must be connected');
+		if (!committer.isConnectable()) {
+			throw Error('Committer must be connectable');
 		}
 		const name = committer.name;
 		const check = this.committers.get(name);

--- a/fabric-common/lib/DiscoveryService.js
+++ b/fabric-common/lib/DiscoveryService.js
@@ -70,10 +70,10 @@ class DiscoveryService extends ServiceAction {
 		}
 
 		for (const discoverer of targets) {
-			if (discoverer.connected || discoverer.isConnectable()) {
-				logger.debug('%s - target is or could be connected %s', method, discoverer.name);
+			if (discoverer.isConnectable()) {
+				logger.debug('%s - target is connectable%s', method, discoverer.name);
 			} else {
-				throw Error(`Discoverer ${discoverer.name} is not connected`);
+				throw Error(`Discoverer ${discoverer.name} is not connectable`);
 			}
 		}
 		// must be all targets are connected
@@ -285,9 +285,12 @@ class DiscoveryService extends ServiceAction {
 		for (const target of this.targets) {
 			logger.debug(`${method} - about to discover on ${target.endpoint.url}`);
 			try {
-				response = await target.sendDiscovery(signedEnvelope, this.requestTimeout);
-				this.currentTarget = target;
-				break;
+				const isConnected = await target.checkConnection();
+				if (isConnected) {
+					response = await target.sendDiscovery(signedEnvelope, this.requestTimeout);
+					this.currentTarget = target;
+					break;
+				}
 			} catch (error) {
 				response = error;
 			}

--- a/fabric-common/lib/EventService.js
+++ b/fabric-common/lib/EventService.js
@@ -113,13 +113,13 @@ class EventService extends ServiceAction {
 		}
 
 		for (const eventer of targets) {
-			if (eventer.connected || eventer.isConnectable()) {
-				logger.debug('%s - target is or could be connected %s', method, eventer.name);
+			if (eventer.isConnectable()) {
+				logger.debug('%s - target is connectable %s', method, eventer.name);
 			} else {
 				throw Error(`Eventer ${eventer.name} is not connectable`);
 			}
 		}
-		// must be all targets are connected
+		// must be all targets are connectable
 		this.targets = targets;
 
 		return this;
@@ -356,10 +356,6 @@ class EventService extends ServiceAction {
 					logger.debug('%s - target has a stream, is already listening %s', method, target.toString());
 					startError = Error(`Event service ${target.name} is currently listening`);
 				} else {
-					if (target.isConnectable()) {
-						logger.debug('%s - target needs to connect %s', method, target.toString());
-						await target.connect(); // target endpoint has been previously assigned, but not connected yet
-					}
 					const isConnected = await target.checkConnection();
 					if (!isConnected) {
 						startError = Error(`Event service ${target.name} is not connected`);

--- a/fabric-common/lib/Eventer.js
+++ b/fabric-common/lib/Eventer.js
@@ -83,6 +83,8 @@ class Eventer extends ServiceEndpoint {
 		const method = `checkConnection[${this.name}:${this.myCount}]`;
 		logger.debug(`${method} - start`);
 
+		super.checkConnection();
+
 		let result = false;
 		if (this.service) {
 			try {

--- a/fabric-common/lib/Proposal.js
+++ b/fabric-common/lib/Proposal.js
@@ -374,9 +374,17 @@ message Endorsement {
 		} else if (targets) {
 			logger.debug('%s - have targets', method);
 			const peers = this.channel.getTargetEndorsers(targets);
-			const promises = peers.map(async (peer) => {
-				return peer.sendProposal(signedEnvelope, requestTimeout);
-			});
+			const promises = [];
+			for (const peer of peers) {
+				const isConnected = await peer.checkConnection();
+				if (isConnected) {
+					promises.push(peer.sendProposal(signedEnvelope, requestTimeout));
+				}
+			}
+			if (promises.length === 0) {
+				logger.error('%s - no targets are connected', method);
+				throw Error('No targets are connected');
+			}
 
 			logger.debug('%s - about to send to all peers', method);
 			const results = await settle(promises);

--- a/fabric-common/test/Channel.js
+++ b/fabric-common/test/Channel.js
@@ -231,7 +231,7 @@ describe('Channel', () => {
 				const endorser1 = getEndorser('endorser');
 				endorser1.connected = false;
 				channel.addEndorser(endorser1);
-			}).should.throw('Endorser must be connected');
+			}).should.throw('Endorser must be connectable');
 		});
 		it('should find a endorser.name', () => {
 			(() => {
@@ -311,7 +311,7 @@ describe('Channel', () => {
 				const committer1 = getCommitter('committer');
 				committer1.connected = false;
 				channel.addCommitter(committer1);
-			}).should.throw('Committer must be connected');
+			}).should.throw('Committer must be connectable');
 		});
 		it('should find a committer.name', () => {
 			(() => {

--- a/fabric-common/test/DiscoveryHandler.js
+++ b/fabric-common/test/DiscoveryHandler.js
@@ -34,6 +34,7 @@ describe('DiscoveryHandler', () => {
 	const tmpSetDelete = Set.prototype.delete;
 
 	let peer11, peer12, peer21, peer22, peer31, peer32, peer33;
+	let orderer1, orderer2, orderer3;
 
 	// const pem = '-----BEGIN CERTIFICATE-----    -----END CERTIFICATE-----\n';
 	const org1 = [
@@ -173,54 +174,67 @@ describe('DiscoveryHandler', () => {
 		peer11 = client.newEndorser(org1[1], org1[0]);
 		peer11.endpoint = {url: 'grpcs://' + org1[1], addr: org1[1]};
 		peer11.sendProposal = sandbox.stub().resolves(good);
+		peer11.checkConnection = sandbox.stub().resolves(true);
 		peer11.connected = true;
 		channel.addEndorser(peer11);
 		peer12 = client.newEndorser(org1[2], org1[0]);
 		peer12.endpoint = {url: 'grpcs://' + org1[2], addr: org1[2]};
 		peer12.sendProposal = sandbox.stub().resolves(good);
+		peer12.checkConnection = sandbox.stub().resolves(true);
 		peer12.connected = true;
 		channel.addEndorser(peer12);
 
 		peer21 = client.newEndorser(org2[1], org2[0]);
 		peer21.endpoint = {url: 'grpcs://' + org2[1], addr: org2[1]};
 		peer21.sendProposal = sandbox.stub().resolves(good);
+		peer21.checkConnection = sandbox.stub().resolves(true);
 		peer21.connected = true;
 		channel.addEndorser(peer21);
 		peer22 = client.newEndorser(org2[2], org2[0]);
 		peer22.endpoint = {url: 'grpcs://' + org2[2], addr: org2[2]};
 		peer22.sendProposal = sandbox.stub().resolves(good);
+		peer22.checkConnection = sandbox.stub().resolves(true);
 		peer22.connected = true;
 		channel.addEndorser(peer22);
 
 		peer31 = client.newEndorser(org3[1], org3[0]);
 		peer31.endpoint = {url: 'grpcs://' + org3[1], addr: org3[1]};
 		peer31.sendProposal = sandbox.stub().resolves(good);
+		peer31.checkConnection = sandbox.stub().resolves(true);
 		peer31.connected = true;
 		channel.addEndorser(peer31);
 		peer32 = client.newEndorser(org3[2], org3[0]);
 		peer32.endpoint = {url: 'grpcs://' + org3[2], addr: org3[2]};
 		peer32.sendProposal = sandbox.stub().resolves(good);
+		peer32.checkConnection = sandbox.stub().resolves(true);
 		peer32.connected = true;
 		channel.addEndorser(peer32);
 		peer33 = client.newEndorser(org3[3], org3[0]);
 		peer33.endpoint = {url: 'grpcs://' + org3[3], addr: org3[3]};
 		peer33.sendProposal = sandbox.stub().resolves(good);
+		peer33.checkConnection = sandbox.stub().resolves(true);
 		peer33.connected = true;
 		channel.addEndorser(peer33);
 
-		const orderer1 = client.newCommitter('orderer1', 'msp1');
+		orderer1 = client.newCommitter('orderer1', 'msp1');
 		orderer1.sendBroadcast = sandbox.stub().resolves({status: 'SUCCESS'});
+		orderer1.checkConnection = sandbox.stub().resolves(true);
 		orderer1.connected = true;
+		orderer1.endpoint = {url: 'grpc://orderer1.com'};
 		channel.addCommitter(orderer1);
 
-		const orderer2 = client.newCommitter('orderer2', 'msp2');
+		orderer2 = client.newCommitter('orderer2', 'msp2');
 		orderer2.sendBroadcast = sandbox.stub().resolves({status: 'SUCCESS'});
+		orderer2.checkConnection = sandbox.stub().resolves(true);
 		orderer2.connected = true;
+		orderer2.endpoint = {url: 'grpc://orderer2.com'};
 		channel.addCommitter(orderer2);
 
-		const orderer3 = client.newCommitter('orderer3', 'msp1');
+		orderer3 = client.newCommitter('orderer3', 'msp1');
 		orderer3.sendBroadcast = sandbox.stub().resolves({status: 'SUCCESS'});
+		orderer3.checkConnection = sandbox.stub().resolves(true);
 		orderer3.connected = true;
+		orderer3.endpoint = {url: 'grpc://orderer3.com'};
 		channel.addCommitter(orderer3);
 
 		discovery = channel.newDiscoveryService('mydiscovery');
@@ -300,7 +314,9 @@ describe('DiscoveryHandler', () => {
 			const results = await discoveryHandler.commit('signedEnvelope');
 			results.status.should.equal('SUCCESS');
 		});
-		it('should run with orderers assigned', async () => {
+		it('should run with some bad orderers assigned', async () => {
+			orderer1.checkConnection = sandbox.stub().resolves(false);
+			orderer2.checkConnection = sandbox.stub().resolves(false);
 			const results = await discoveryHandler.commit('signedEnvelope');
 			results.status.should.equal('SUCCESS');
 		});
@@ -320,6 +336,14 @@ describe('DiscoveryHandler', () => {
 			channel.getCommitter('orderer2').sendBroadcast = sandbox.stub().rejects(new Error('FAILED with Error'));
 			await discoveryHandler.commit('signedEnvelope', {mspid: 'msp2'})
 				.should.be.rejectedWith(/FAILED with Error/);
+		});
+		it('should reject when all orderers are no connected', async () => {
+			orderer1.checkConnection = sandbox.stub().resolves(false);
+			orderer2.checkConnection = sandbox.stub().resolves(false);
+			orderer3.checkConnection = sandbox.stub().resolves(false);
+
+			await discoveryHandler.commit('signedEnvelope')
+				.should.be.rejectedWith(/is not connected/);
 		});
 	});
 
@@ -365,7 +389,7 @@ describe('DiscoveryHandler', () => {
 			const results = await discoveryHandler._endorse({}, {preferredHeightGap: 0}, 'proposal');
 			results.should.equal('endorsements');
 		});
-		it('should run ok', async () => {
+		it('should run - show failed', async () => {
 			discovery.getDiscoveryResults = sandbox.stub().resolves({endorsement_plan: {something: 'plan a'}});
 			discoveryHandler._modify_groups = sinon.stub();
 			discoveryHandler._getRandom = sinon.stub().returns([{}]);
@@ -506,6 +530,23 @@ describe('DiscoveryHandler', () => {
 			);
 			results.response.status.should.equal(200);
 			sinon.assert.calledWith(FakeLogger.debug, '%s - start', '_build_endorse_group_member >> G0:0');
+		});
+		it('should run - show reconnect error', async () => {
+			endorsement_plan.endorsements = {};
+			peer11.checkConnection.resolves(false);
+			peer12.checkConnection.resolves(false);
+			// TEST CALL
+			const results = await discoveryHandler._build_endorse_group_member(
+				endorsement_plan, // endorsement plan
+				endorsement_plan.groups.G0, // group
+				'proposal', // proposal
+				2000, // timeout
+				0, // endorser_process_index
+				'G0' // group name
+			);
+			results.message.should.equal('Peer peer2.org1.example.com:7002 is not connected');
+			sinon.assert.notCalled(peer11.sendProposal);
+			sinon.assert.notCalled(peer12.sendProposal);
 		});
 		it('should run ok and return error when endorser rejects', async () => {
 			endorsement_plan.endorsements = {};

--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -99,8 +99,13 @@ describe('DiscoveryService', () => {
 
 	const endorser = sinon.createStubInstance(Endorser);
 	endorser.type = 'Endorser';
+	endorser.connected = true;
+	endorser.isConnectable = sinon.stub().returns(true);
+
 	const committer = sinon.createStubInstance(Committer);
 	committer.type = 'Committer';
+	committer.connected = true;
+	committer.isConnectable = sinon.stub().returns(true);
 
 	let FakeLogger;
 
@@ -121,6 +126,8 @@ describe('DiscoveryService', () => {
 		discoverer = new Discoverer('mydiscoverer', client);
 		endpoint = client.newEndpoint({url: 'grpc://somehost.com'});
 		discoverer.endpoint = endpoint;
+		discoverer.waitForReady = sinon.stub().resolves(true);
+		discoverer.checkConnection = sinon.stub().resolves(true);
 		discovery = new DiscoveryService('mydiscovery', channel);
 		client.getEndorser = sinon.stub().returns(endorser);
 		client.newEndorser = sinon.stub().returns(endorser);
@@ -178,7 +185,7 @@ describe('DiscoveryService', () => {
 			(() => {
 				discoverer.endpoint = undefined;
 				discovery.setTargets([discoverer]);
-			}).should.throw('Discoverer mydiscoverer is not connected');
+			}).should.throw('Discoverer mydiscoverer is not connectable');
 		});
 		it('should handle connected target', () => {
 			discoverer.connected = true;

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -41,6 +41,8 @@ describe('Proposal', () => {
 		endorser.type = 'Endorser';
 		endpoint = client.newEndpoint({url: 'grpc://somehost.com'});
 		endorser.endpoint = endpoint;
+		endorser.waitForReady = sinon.stub().resolves(true);
+		endorser.checkConnection = sinon.stub().resolves(true);
 		handler = new DiscoveryHandler('discovery');
 	});
 


### PR DESCRIPTION
Allow for all service endpoints to be disconnected when added
to a channel. When a service endpoint (peer, events, orderer, discovery) is
added to a channel, it may not be active or it may go down between usages.
The service connection will be checked and reset when an outbound request is made.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>