### PR TITLE
FABN-1608 remove error message from discovery

### DIFF
--- a/fabric-common/lib/DiscoveryHandler.js
+++ b/fabric-common/lib/DiscoveryHandler.js
@@ -259,7 +259,7 @@ class DiscoveryHandler extends ServiceHandler {
 			if (required > group.peers.length) {
 				results.success = false;
 				const error = new Error(`Endorsement plan group does not contain enough peers (${group.peers.length}) to satisfy policy (required:${required})`);
-				logger.error(error);
+				logger.debug(error.message);
 				results.endorsements.push(error);
 				break; // no need to look at other groups, this layout failed
 			}


### PR DESCRIPTION
When a group has insufficient members after filtering
based on user's requirements (specific mspids, specific peers,
ledger height) an error message was posted. This will be
changed to a debug message as this is not an error, but an expected
result of the filtering.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>