### PR TITLE
FABN-1601 discovery required organizations

### DIFF
--- a/test/ts-scenario/features/discovery.feature
+++ b/test/ts-scenario/features/discovery.feature
@@ -63,3 +63,9 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 		Then The gateway named myDiscoveryGateway has a submit type response matching {"key0":"value1","key1":"value2"}
 		When I modify myDiscoveryGateway to evaluate a transaction with transient data using args [getTransient,valueA,valueB] for contract fabcar instantiated on channel discoverychannel
 		Then The gateway named myDiscoveryGateway has a evaluate type response matching {"key0":"valueA","key1":"valueB"}
+
+	Scenario: Using a Gateway I can submit and evaluate transactions on instantiated node smart contract with specific organizations
+		When I use the discovery gateway named myDiscoveryGateway to submit a transaction with args [createCar,2001,Ford,F350,red,Sam] for contract fabcar instantiated on channel discoverychannel using requiredOrgs ["Org1MSP","Org2MSP"]
+		Then The gateway named myDiscoveryGateway has a submit type response
+		When I use the gateway named myDiscoveryGateway to evaluate a transaction with args [queryCar,2001] for contract fabcar instantiated on channel discoverychannel
+		Then The gateway named myDiscoveryGateway has a evaluate type response matching {"color":"red","docType":"car","make":"Ford","model":"F350","owner":"Sam"}

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -333,7 +333,7 @@ async function createHSMUser(wallet: Wallet, ccp: CommonConnectionProfileHelper,
  * @param {String} txnType the type of transaction (submit/evaluate)
  * @param {String} handlerOption Optional: the handler option to use
  */
-export async function performGatewayTransaction(gatewayName: string, contractName: string, channelName: string, collectionName: string, args: string, txnType: string, handlerOption?: string): Promise<void> {
+export async function performGatewayTransaction(gatewayName: string, contractName: string, channelName: string, collectionName: string, args: string, txnType: string, handlerOption?: string, requiredOrgs?: string[]): Promise<void> {
 
 	const gatewayObj = getGatewayObject(gatewayName);
 	const gateway = gatewayObj.gateway;
@@ -393,6 +393,10 @@ export async function performGatewayTransaction(gatewayName: string, contractNam
 	// Submit/evaluate transaction
 	try {
 		const transaction: Transaction = contract.createTransaction(func);
+		if (requiredOrgs) {
+			transaction.setEndorsingOrganizations(...requiredOrgs);
+		}
+
 		let resultBuffer: Buffer;
 		if (submit) {
 			resultBuffer = await transaction.submit(...funcArgs);

--- a/test/ts-scenario/steps/network-model.ts
+++ b/test/ts-scenario/steps/network-model.ts
@@ -38,6 +38,10 @@ Given(/^I have a (.+?) backed gateway named (.+?) with discovery set to (.+?) fo
 	}
 });
 
+When(/^I use the discovery gateway named (.+?) to (.+?) a transaction with args (.+?) for contract (.+?) instantiated on channel (.+?) using requiredOrgs (.+?)$/, { timeout: Constants.STEP_MED as number }, async (gatewayName: string, txnType: string, txnArgs: string, ccName: string, channelName: string, requiredOrgs: string) => {
+	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, '', txnArgs, txnType, '', JSON.parse(requiredOrgs));
+});
+
 When(/^I use the discovery gateway named (.+?) to (.+?) a transaction with args (.+?) for contract (.+?) instantiated on channel (.+?) using collection (.+?)$/, { timeout: Constants.STEP_MED as number }, async (gatewayName: string, txnType: string, txnArgs: string, ccName: string, channelName: string, collectionName: string) => {
 	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, collectionName, txnArgs, txnType);
 });


### PR DESCRIPTION
When a discovery user knows the organizations that are needed
to endorse a proposal, they may use the 'requiredOrgs' setting
to have the DiscoveryHandler send it to peer that have been
discovered for the required organizations.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>