### PR TITLE
FABN-1596 add noPrivateReads

### DIFF
--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -415,6 +415,23 @@ describe('DiscoveryService', () => {
 			const results = discovery._buildProtoChaincodeInterest(interest);
 			should.exist(results.chaincodes);
 		});
+		it('should handle two chaincode four collection in camel case', () => {
+			const interest = [
+				{name: 'chaincode1', collectionNames: ['collection1', 'collection3']},
+				{name: 'chaincode2', collectionNames: ['collection2', 'collection4']}
+			];
+			const results = discovery._buildProtoChaincodeInterest(interest);
+			should.exist(results.chaincodes);
+		});
+		it('should handle two chaincode four collection in camel case', () => {
+			const interest = [
+				{name: 'chaincode1', collectionNames: ['collection1', 'collection3'], noPrivateReads: true},
+				{name: 'chaincode2', collectionNames: ['collection2', 'collection4']}
+			];
+			const results = discovery._buildProtoChaincodeInterest(interest);
+			should.exist(results.chaincodes);
+			results.chaincodes[0].no_private_reads.should.be.true;
+		});
 		it('should handle two chaincodes same name', () => {
 			const interest = [{name: 'chaincode1'}, {name: 'chaincode1'}];
 			const results = discovery._buildProtoChaincodeInterest(interest);

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -78,19 +78,39 @@ describe('Proposal', () => {
 	describe('#buildProposalInterest', () => {
 		it('should return interest', () => {
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}]);
 		});
 		it('should return interest and collections', () => {
 			const collections = ['col1', 'col2'];
 			proposal.collectionsInterest = collections;
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false, collectionNames: collections}]);
+		});
+		it('should return interest and collections with noPrivateReads', () => {
+			const collections = ['col1', 'col2'];
+			proposal.collectionsInterest = collections;
+			proposal.noPrivateReads = true;
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: true, collectionNames: collections}]);
 		});
 		it('should return interest and chaincode and chaincode collections ', () => {
 			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2']};
 			proposal.chaincodesCollectionsInterest = [chaincode_collection];
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should return interest and chaincode and chaincode collections with no private reads ', () => {
+			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2'], noPrivateReads: true};
+			proposal.chaincodesCollectionsInterest = [chaincode_collection];
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should return interest and chaincode and chaincode collections with no private reads ', () => {
+			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2'], noPrivateReads: true};
+			proposal.noPrivateReads = true;
+			proposal.chaincodesCollectionsInterest = [chaincode_collection];
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: true}, chaincode_collection]);
 		});
 	});
 
@@ -105,7 +125,7 @@ describe('Proposal', () => {
 			proposal.addCollectionInterest('col2');
 			proposal.collectionsInterest.should.deep.equal(collections);
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false, collectionNames: collections}]);
 		});
 		it('should require a string collection name', () => {
 			(() => {
@@ -114,24 +134,63 @@ describe('Proposal', () => {
 		});
 	});
 
+	describe('#setNoPrivateReads', () => {
+		it('should set no private reads', () => {
+			proposal.setNoPrivateReads(true);
+			proposal.noPrivateReads.should.equal(true);
+		});
+		it('should set no private reads false', () => {
+			proposal.setNoPrivateReads(false);
+			proposal.noPrivateReads.should.equal(false);
+		});
+
+		it('should require a boolean', () => {
+			(() => {
+				proposal.setNoPrivateReads({});
+			}).should.throw(/The "no private reads" setting must be boolean/);
+		});
+	});
+
 	describe('#addChaincodeCollectionsInterest', () => {
 		it('should save chaincode collection interest', () => {
-			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2']};
+			const chaincode_collection = {name: 'chain2', noPrivateReads: false, collectionNames: ['col1', 'col2']};
 			proposal.addChaincodeCollectionsInterest('chain2', 'col1', 'col2');
 			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
 		});
 		it('should save chaincode only chaincode collection interest', () => {
-			const chaincode_collection = {name: 'chain2'};
+			const chaincode_collection = {name: 'chain2', noPrivateReads: false};
 			proposal.addChaincodeCollectionsInterest('chain2');
 			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
 		});
 		it('should require a string chaincode name', () => {
 			(() => {
 				proposal.addChaincodeCollectionsInterest({});
+			}).should.throw('Invalid chaincodeId parameter');
+		});
+	});
+
+	describe('#addChaincodeNoPrivateReadsCollectionsInterest', () => {
+		it('should save chaincode collection interest', () => {
+			const chaincode_collection = {name: 'chain2', noPrivateReads: true, collectionNames: ['col1', 'col2']};
+			proposal.addChaincodeNoPrivateReadsCollectionsInterest('chain2', true, 'col1', 'col2');
+			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should save chaincode only chaincode collection interest', () => {
+			const chaincode_collection = {name: 'chain2', noPrivateReads: false};
+			proposal.addChaincodeNoPrivateReadsCollectionsInterest('chain2');
+			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should require a string chaincode name', () => {
+			(() => {
+				proposal.addChaincodeNoPrivateReadsCollectionsInterest({});
 			}).should.throw('Invalid chaincodeId parameter');
 		});
 	});

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -213,7 +213,9 @@ export class Proposal extends ServiceAction {
 	public getTransactionId(): string;
 	public buildProposalInterest(): any;
 	public addCollectionInterest(collectionName: string): Proposal;
+	public setNoPrivateReads(noPrivateReads: boolean): Proposal;
 	public addChaincodeCollectionsInterest(collectionName: string, collectionNames: string[]): Proposal;
+	public addChaincodeNoPrivateReadsCollectionsInterest(collectionName: string, noPrivateReads: boolean, collectionNames: string[]): Proposal;
 	public build(idContext: IdentityContext, request?: BuildProposalRequest): Buffer;
 	public send(request?: SendProposalRequest): Promise<ProposalResponse>;
 	public verifyProposalResponse(proposalResponse?: any): boolean;

--- a/fabric-network/src/contract.ts
+++ b/fabric-network/src/contract.ts
@@ -46,6 +46,7 @@ function verifyNamespace(namespace?: string): void {
 export interface DiscoveryInterest {
 	name: string;
 	collectionNames?: string[];
+	noPrivateReads?: boolean;
 }
 
 export interface Contract {

--- a/fabric-network/test/contract.js
+++ b/fabric-network/test/contract.js
@@ -146,8 +146,15 @@ describe('Contract', () => {
 		it ('throws when not an interest', () => {
 			(() => contract.addDiscoveryInterest('intersts')).should.throw('"interest" parameter must be a DiscoveryInterest object');
 		});
-		it('add collection', async () => {
+		it('update collection', async () => {
 			const interest = {name: chaincodeId, collectionNames: ['c1', 'c2']};
+			contract.addDiscoveryInterest(interest);
+			expect(contract.discoveryInterests).to.deep.equal([
+				interest
+			]);
+		});
+		it('update collection with no private reads', async () => {
+			const interest = {name: chaincodeId, collectionNames: ['c1', 'c2'], noPrivateReads: true};
 			contract.addDiscoveryInterest(interest);
 			expect(contract.discoveryInterests).to.deep.equal([
 				interest
@@ -163,6 +170,14 @@ describe('Contract', () => {
 		});
 		it('add chaincode and collection', async () => {
 			const other = {name: 'other', collectionNames: ['c1', 'c2']};
+			contract.addDiscoveryInterest(other);
+			expect(contract.discoveryInterests).to.deep.equal([
+				{name: chaincodeId},
+				other
+			]);
+		});
+		it('add chaincode and collection with no private reads', async () => {
+			const other = {name: 'other', collectionNames: ['c1', 'c2'], noPrivateReads: true};
 			contract.addDiscoveryInterest(other);
 			expect(contract.discoveryInterests).to.deep.equal([
 				{name: chaincodeId},

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as FabricCAClient from 'fabric-ca-client';
-import { Contract, DefaultEventHandlerStrategies, DefaultQueryHandlerStrategies, Gateway, GatewayOptions, HsmOptions, HsmX509Provider, Identity, IdentityProvider, Network, QueryHandlerFactory, Transaction, TransientMap, TxEventHandlerFactory, Wallet, Wallets } from 'fabric-network';
+import { Contract, DefaultEventHandlerStrategies, DefaultQueryHandlerStrategies, Gateway, GatewayOptions, HsmOptions, HsmX509Provider, Identity, IdentityProvider, Network, QueryHandlerFactory, Transaction, TransientMap, TxEventHandlerFactory, Wallet, Wallets, DiscoveryInterest } from 'fabric-network';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createQueryHandler as sampleQueryStrategy } from '../../config/handlers/sample-query-handler';
@@ -382,7 +382,7 @@ export async function performGatewayTransaction(gatewayName: string, contractNam
 		BaseUtils.logMsg(` -- adding a discovery interest colletion name to the contrace ${collectionName}`);
 		const chaincodeId = contract.chaincodeId;
 		contract.resetDiscoveryInterests();
-		contract.addDiscoveryInterest({name: chaincodeId, collectionNames: [collectionName]});
+		contract.addDiscoveryInterest({name: chaincodeId, collectionNames: [collectionName], noPrivateReads: false});
 	}
 
 	// Split args

--- a/test/ts-scenario/steps/lib/utility/clientUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/clientUtils.ts
@@ -125,6 +125,10 @@ export async function buildChannelRequest(requestName: string, contractName: str
 		// centralize the endorsement operation, including the endorsement results.
 		// Proposals must be built from channel and chaincode name
 		const endorsement: Endorsement = channel.newEndorsement(contractName);
+
+		// ---- setup DISCOVERY
+		endorsement.setNoPrivateReads(true);
+		endorsement.addCollectionInterest('_implicit_org_Org1MSP');
 		const discovery: DiscoveryService = channel.newDiscoveryService('mydiscovery');
 		const discoverer: Discoverer = client.newDiscoverer('peer1-discovery');
 


### PR DESCRIPTION
Allow users to set the "noPrivateReads" when setting up a
discovery hint that will be used as the interest when the
discovery service builds an endorsement plan.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>