### PR TITLE
FABN-1611 Blockdecoder needs kv_reads array

### DIFF
--- a/fabric-common/lib/BlockDecoder.js
+++ b/fabric-common/lib/BlockDecoder.js
@@ -1513,7 +1513,7 @@ function decodeRangeQueryInfo(rangeQueryInfoProto) {
 	if (rangeQueryInfoProto.raw_reads) {
 		range_query_info.raw_reads = {};
 		range_query_info.raw_reads.kv_reads = [];
-		for (const kVReadProto of rangeQueryInfoProto.raw_reads) {
+		for (const kVReadProto of rangeQueryInfoProto.raw_reads.kv_reads) {
 			range_query_info.raw_reads.kv_reads.push(decodeKVRead(kVReadProto));
 		}
 	} else if (rangeQueryInfoProto.reads_merkle_hashes) {

--- a/fabric-common/test/BlockDecoder.js
+++ b/fabric-common/test/BlockDecoder.js
@@ -2018,13 +2018,13 @@ describe('BlockDecoder', () => {
 				start_key: 'start_key',
 				end_key: 'end_key',
 				itr_exhausted: 'itr_exhausted',
-				raw_reads: ['raw_read']
+				raw_reads: {kv_reads: ['kv_read']}
 			};
 			const rangeQueryInfo = decodeRangeQueryInfo(mockProtoRangeQueryInfo);
 			rangeQueryInfo.start_key.should.equal('start_key');
 			rangeQueryInfo.end_key.should.equal('end_key');
 			rangeQueryInfo.itr_exhausted.should.equal('itr_exhausted');
-			sinon.assert.calledWith(decodeKVReadStub, 'raw_read');
+			sinon.assert.calledWith(decodeKVReadStub, 'kv_read');
 		});
 
 		it('should return the correct range query info with reads merklehashes', () => {


### PR DESCRIPTION
The RangeQueryInfo raw_reads attribute is a QueryRead message object
which has an array of KVRead objects and is not an array itself.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>