### PR TITLE
FABN-1607: Start event replay from previous block (#299)

### DIFF
--- a/fabric-network/src/impl/gatewayutils.ts
+++ b/fabric-network/src/impl/gatewayutils.ts
@@ -64,3 +64,12 @@ export function cachedResult<T>(f: () => T): () => T {
 		return value;
 	};
 }
+
+/**
+ * Typesafe check that a value is not nullish.
+ * @private
+ * @param value Any value, including null and undefined.
+ */
+export function notNullish<T>(value?: T): value is T {
+	return value !== null && value !== undefined;
+}

--- a/fabric-network/src/network.ts
+++ b/fabric-network/src/network.ts
@@ -16,6 +16,7 @@ import { checkpointBlockListener } from './impl/event/listeners';
 import { addListener, ListenerSession, removeListener } from './impl/event/listenersession';
 import { SharedBlockListenerSession } from './impl/event/sharedblocklistenersession';
 import { QueryHandler } from './impl/query/queryhandler';
+import { notNullish } from './impl/gatewayutils';
 import * as Logger from './logger';
 
 const logger = Logger.getLogger('Network');
@@ -355,7 +356,7 @@ export class NetworkImpl implements Network {
 			listener = checkpointBlockListener(listener, options.checkpointer);
 		}
 
-		if (options.startBlock) {
+		if (notNullish(options.startBlock)) {
 			return this.newIsolatedBlockListenerSession(listener, options);
 		} else {
 			return this.newSharedBlockListenerSession(listener, options.type);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "unitTest:all": "export HFC_LOGGING='{\"debug\":\"test/temp/debug.log\"}' && nyc run-s unitTest:common unitTest:ca-client unitTest:network",
     "unitTest:common": "mocha --reporter list 'fabric-common/test/**/*.js'",
     "unitTest:ca-client": "mocha --reporter list 'fabric-ca-client/test/**/*.js'",
-    "unitTest:network": "npm run compile && mocha --require ts-node/register --reporter list 'fabric-network/test/**/*.{js,ts}'",
+    "unitTest:network": "run-s compile \"unitTest -- 'fabric-network/test/**/*.{js,ts}'\"",
     "unitTest": "mocha --require ts-node/register --reporter list",
     "dockerReady": "npm run dockerClean && (cd test/fixtures/docker-compose && docker-compose -f docker-compose-tls-level-db.yaml -p node up -d && sleep 15 && docker ps -a)",
     "tapeIntegration": "./scripts/npm_scripts/runTape.sh",


### PR DESCRIPTION
Cherry-pick of 2322eb0dfc605bfa16c31930511c25bb488d6ad1 from master branch.

Ensure that a block is received quickly to avoid the start of the event service blocking waiting for events, which in turn would block the call to Network.addBlockListener()