### PR TITLE
FABN-1612 cherrypick from master to release-2.2

### DIFF
--- a/fabric-ca-client/lib/FabricCAServices.js
+++ b/fabric-ca-client/lib/FabricCAServices.js
@@ -12,7 +12,7 @@ const FabricCAClient = require('./FabricCAClient');
 
 const {normalizeX509} = BaseClient;
 const path = require('path');
-const {parseURL, checkRegistrar, getSubjectCommonName} = require('./helper');
+const {parseURL, checkRegistrar, getSubject} = require('./helper');
 const logger = utils.getLogger('FabricCAClientService.js');
 
 // setup the location of the default config shipped with code
@@ -30,7 +30,7 @@ utils.getConfig().reorderFileStores(default_config, true);
  * @class
  * @extends BaseClient
  */
-const FabricCAServices = class extends BaseClient {
+class FabricCAServices extends BaseClient {
 
 	/**
 	 * constructor
@@ -136,16 +136,18 @@ const FabricCAServices = class extends BaseClient {
 	 * @typedef {Object} EnrollmentRequest
 	 * @property {string} enrollmentID - The registered ID to use for enrollment
 	 * @property {string} enrollmentSecret - The secret associated with the enrollment ID
-	 * @property {string} profile - The profile name.  Specify the 'tls' profile for a TLS certificate;
+	 * @property {string} [profile] - The profile name.  Specify the 'tls' profile for a TLS certificate;
 	 *                   otherwise, an enrollment certificate is issued.
-	 * @property {string} csr - Optional. PEM-encoded PKCS#10 Certificate Signing Request. The message sent from client side to
+	 * @property {string} [csr] - Optional. PEM-encoded PKCS#10 Certificate Signing Request. The message sent from client side to
 	 *                   Fabric-ca for the digital identity certificate.
-	 * @property {AttributeRequest[]} attr_reqs - An array of {@link AttributeRequest}
+	 * @property {AttributeRequest[]} [attr_reqs] - An array of {@link AttributeRequest}
+	 * @property {string} [subject] - Optional. The X509 Subject to use in generating CSR inline
+	 *      (when <code>csr</code> is not specified). If not specified, the default subject is built on <code>enrollmentID</code>
 	 */
 
 	/**
 	 * @typedef {Object} Enrollment
-	 * @property {Object} key - the private key
+	 * @property {Object} [key] - the private key when CSR is created inline.
 	 * @property {string} certificate - The enrollment certificate in base 64 encoded PEM format
 	 * @property {string} rootCertificate - Base 64 encoded PEM-encoded certificate chain of the CA's signing certificate
 	 */
@@ -191,46 +193,38 @@ const FabricCAServices = class extends BaseClient {
 
 		const storeKey = !!this.getCryptoSuite()._cryptoKeyStore;
 
-		try {
-			let csr;
+		let csr = req.csr;
+
+		const enrollment = {};
+		if (!csr) {
 			let privateKey;
-			if (req.csr) {
-				logger.debug('try to enroll with a csr');
-				csr = req.csr;
-			} else {
-				try {
-					if (storeKey) {
-						privateKey = await this.getCryptoSuite().generateKey();
-					} else {
-						privateKey = this.getCryptoSuite().generateEphemeralKey();
-					}
-					logger.debug('successfully generated key pairs');
-				} catch (err) {
-					throw new Error(`Failed to generate key for enrollment due to error [${err}]: ${err.stack}`);
+			try {
+				if (storeKey) {
+					privateKey = await this.getCryptoSuite().generateKey();
+				} else {
+					privateKey = this.getCryptoSuite().generateEphemeralKey();
 				}
-				try {
-					csr = privateKey.generateCSR('CN=' + req.enrollmentID);
-					logger.debug('successfully generated csr');
-				} catch (err) {
-					throw new Error(`Failed to generate CSR for enrollment due to error [${err}]: ${err.stack}`);
-				}
-			}
-
-			const enrollResponse = await this._fabricCAClient.enroll(req.enrollmentID, req.enrollmentSecret, csr, req.profile, req.attr_reqs);
-			logger.debug('successfully enrolled %s', req.enrollmentID);
-
-			const enrollment = {
-				certificate: enrollResponse.enrollmentCert,
-				rootCertificate: enrollResponse.caCertChain
-			};
-			if (!req.csr) {
+				logger.debug('successfully generated key pairs');
 				enrollment.key = privateKey;
+			} catch (err) {
+				throw new Error(`Failed to generate key for enrollment due to error [${err}]: ${err.stack}`);
 			}
-			return enrollment;
-		} catch (error) {
-			logger.error('Failed to enroll %s, error:%o', req.enrollmentID, error);
-			throw error;
+			try {
+				csr = privateKey.generateCSR(req.subject || 'CN=' + req.enrollmentID);
+				logger.debug('successfully generated csr');
+			} catch (err) {
+				throw new Error(`Failed to generate CSR for enrollment due to error [${err}]: ${err.stack}`);
+			}
 		}
+
+		const enrollResponse = await this._fabricCAClient.enroll(req.enrollmentID, req.enrollmentSecret, csr, req.profile, req.attr_reqs);
+		logger.debug('successfully enrolled %s', req.enrollmentID);
+
+		Object.assign(enrollment, {
+			certificate: enrollResponse.enrollmentCert,
+			rootCertificate: enrollResponse.caCertChain
+		});
+		return enrollment;
 	}
 
 	/**
@@ -266,14 +260,11 @@ const FabricCAServices = class extends BaseClient {
 		}
 
 		const cert = currentUser.getIdentity()._certificate;
-		let subject = null;
+		let subject;
 		try {
-			subject = getSubjectCommonName(normalizeX509(cert));
+			subject = getSubject(normalizeX509(cert));
 		} catch (err) {
 			logger.error(`Failed to parse enrollment certificate ${cert} for Subject. \nError: ${err}`);
-		}
-
-		if (!subject) {
 			throw new Error('Failed to parse the enrollment certificate of the current user for its subject');
 		}
 
@@ -289,7 +280,7 @@ const FabricCAServices = class extends BaseClient {
 		// generate CSR using the subject of the current user's certificate
 		let csr;
 		try {
-			csr = privateKey.generateCSR('CN=' + subject);
+			csr = privateKey.generateCSR(subject);
 		} catch (e) {
 			throw Error(`Failed to generate CSR for enrollment due to error [${e}]`);
 		}
@@ -423,6 +414,6 @@ const FabricCAServices = class extends BaseClient {
 	static _parseURL(url) {
 		return parseURL(url);
 	}
-};
+}
 
 module.exports = FabricCAServices;

--- a/fabric-ca-client/lib/helper.js
+++ b/fabric-ca-client/lib/helper.js
@@ -11,7 +11,7 @@ const jsrsasign = require('jsrsasign');
 const {X509, ASN1HEX} = jsrsasign;
 const urlParser = require('url');
 
-function checkRegistrar(registrar) {
+const checkRegistrar = (registrar) => {
 
 	if (!registrar) {
 		throw new Error('Missing required argument "registrar"');
@@ -28,23 +28,17 @@ function checkRegistrar(registrar) {
 	if (!registrar.getSigningIdentity()) {
 		throw new Error('Can not get signingIdentity from registrar');
 	}
-}
+};
 
 // This utility is based on jsrsasign.X509.getSubjectString() implementation
 // we can not use that method directly because it requires calling readCertPEM()
 // first which as of jsrsasign@6.2.3 always assumes RSA based certificates and
 // fails to parse certs that includes ECDSA keys.
-function getSubjectCommonName(pem) {
+const getSubject = (pem) => {
 	const hex = jsrsasign.pemtohex(pem);
 	const d = ASN1HEX.getTLVbyList(hex, 0, [0, 5]);
-	const subject = X509.hex2dn(d); // format: '/C=US/ST=California/L=San Francisco/CN=Admin@org1.example.com/emailAddress=admin@org1.example.com'
-	const m = subject.match(/CN=.+[^/]/);
-	if (!m) {
-		throw new Error('Certificate PEM does not seem to contain a valid subject with common name "CN"');
-	} else {
-		return m[0].substring(3);
-	}
-}
+	return X509.hex2dn(d); // format: '/C=US/ST=California/L=San Francisco/CN=Admin@org1.example.com/emailAddress=admin@org1.example.com'
+};
 
 /**
  * Utility function which parses an HTTP URL into its component parts
@@ -53,7 +47,7 @@ function getSubjectCommonName(pem) {
  * @throws InvalidURL for malformed URLs
  * @ignore
  */
-function parseURL(url) {
+const parseURL = (url) => {
 
 	const endpoint = {};
 
@@ -77,8 +71,10 @@ function parseURL(url) {
 	}
 
 	return endpoint;
-}
+};
 
-module.exports.checkRegistrar = checkRegistrar;
-module.exports.getSubjectCommonName = getSubjectCommonName;
-module.exports.parseURL = parseURL;
+module.exports = {
+	checkRegistrar,
+	getSubject,
+	parseURL
+};

--- a/fabric-ca-client/test/FabricCAServices.js
+++ b/fabric-ca-client/test/FabricCAServices.js
@@ -29,7 +29,7 @@ describe('FabricCAServices', () => {
 	});
 
 	const checkRegistrarStub = sinon.stub();
-	const getSubjectCommonNameStub = sinon.stub();
+	const getSubjectStub = sinon.stub();
 	const normalizeX509Stub = sinon.stub();
 	const cryptoPrimitives = sinon.createStubInstance(CryptoSuite);
 	cryptoPrimitives.name = 'testCrypto';
@@ -38,7 +38,7 @@ describe('FabricCAServices', () => {
 		revert = [];
 		revert.push(FabricCAServicesRewire.__set__('parseURL', parseURLStub));
 		revert.push(FabricCAServicesRewire.__set__('checkRegistrar', checkRegistrarStub));
-		revert.push(FabricCAServicesRewire.__set__('getSubjectCommonName', getSubjectCommonNameStub));
+		revert.push(FabricCAServicesRewire.__set__('getSubject', getSubjectStub));
 		revert.push(FabricCAServicesRewire.__set__('normalizeX509', normalizeX509Stub));
 	});
 
@@ -249,7 +249,7 @@ describe('FabricCAServices', () => {
 
 		it('should reject on enroll failure', async () => {
 
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -272,7 +272,7 @@ describe('FabricCAServices', () => {
 
 		it('should reject in generate CSR failure', async () => {
 
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -293,7 +293,7 @@ describe('FabricCAServices', () => {
 
 		it('should reject in generate key failure', async () => {
 
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			cryptoPrimitives.generateEphemeralKey.throws(new Error('Key error'));
@@ -321,7 +321,7 @@ describe('FabricCAServices', () => {
 
 			service._fabricCAClient = clientMock;
 
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -349,7 +349,7 @@ describe('FabricCAServices', () => {
 
 		it('should call the enroll function on the FabricCAClient object ', async () => {
 
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -388,7 +388,7 @@ describe('FabricCAServices', () => {
 
 		it('should return a known object on success', async () => {
 
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -445,7 +445,7 @@ describe('FabricCAServices', () => {
 		it('should throw if unable to parse enrollment certificate', async () => {
 			const user = sinon.createStubInstance(User);
 			user.getIdentity.resolves({_certificate: null});
-			getSubjectCommonNameStub.throws(new Error('forced error'));
+			getSubjectStub.throws(new Error('forced error'));
 			await service.reenroll(user, [{name: 'penguin'}, {name: 'power'}]).should.be.rejectedWith(/Failed to parse the enrollment certificate of the current user for its subject/);
 		});
 
@@ -453,7 +453,7 @@ describe('FabricCAServices', () => {
 			const user = sinon.createStubInstance(User);
 			user.getSigningIdentity.returns('myID');
 			user.getIdentity.returns({_certificate: 'my_cert'});
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			cryptoPrimitives.generateKey.rejects(new Error('Key Error'));
@@ -466,7 +466,7 @@ describe('FabricCAServices', () => {
 			const user = sinon.createStubInstance(User);
 			user.getSigningIdentity.returns('myID');
 			user.getIdentity.returns({_certificate: 'my_cert'});
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -481,7 +481,7 @@ describe('FabricCAServices', () => {
 			const user = sinon.createStubInstance(User);
 			user.getSigningIdentity.returns('myID');
 			user.getIdentity.returns({_certificate: 'my_cert'});
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -499,7 +499,7 @@ describe('FabricCAServices', () => {
 			const user = sinon.createStubInstance(User);
 			user.getSigningIdentity.returns('myID');
 			user.getIdentity.returns({_certificate: 'my_cert'});
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);
@@ -528,7 +528,7 @@ describe('FabricCAServices', () => {
 			const user = sinon.createStubInstance(User);
 			user.getSigningIdentity.returns('myID');
 			user.getIdentity.returns({_certificate: 'test_cert'});
-			getSubjectCommonNameStub.returns('mr_penguin');
+			getSubjectStub.returns('/CN=mr_penguin');
 			normalizeX509Stub.returns('normal');
 
 			const keyStub = sinon.createStubInstance(ECDSAKey);

--- a/fabric-ca-client/test/helper.js
+++ b/fabric-ca-client/test/helper.js
@@ -51,64 +51,26 @@ describe('Helper', () => {
 
 	});
 
-	describe('#getSubjectCommonName', () => {
+	describe('#getSubject', () => {
 
-		const CERT_WITHOUT_CN = '-----BEGIN CERTIFICATE-----' +
-			'MIIFjzCCA3egAwIBAgIJAOLWW2j2g36vMA0GCSqGSIb3DQEBCwUAMF4xCzAJBgNV' +
-			'BAYTAlVTMRcwFQYDVQQIDA5Ob3J0aCBDYXJvbGluYTEPMA0GA1UEBwwGRHVyaGFt' +
-			'MRQwEgYDVQQKDAtIeXBlcmxlZGdlcjEPMA0GA1UECwwGRmFicmljMB4XDTE3MDMy' +
-			'OTA0MTc0OFoXDTE4MDMyOTA0MTc0OFowXjELMAkGA1UEBhMCVVMxFzAVBgNVBAgM' +
-			'Dk5vcnRoIENhcm9saW5hMQ8wDQYDVQQHDAZEdXJoYW0xFDASBgNVBAoMC0h5cGVy' +
-			'bGVkZ2VyMQ8wDQYDVQQLDAZGYWJyaWMwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw' +
-			'ggIKAoICAQC/1MwnAefSeTNtUtQSEoH/KiFR3kEWPpBdG5BwMsf5p8X67jBIZoQZ' +
-			'8NG3iOjF/H3kUbOw3YdrJ7ow+Pq1q5siyYweW2NZKj6cHkkHzrohJkvDTLE7nCwf' +
-			'OPp/j2Rsk44J0v2v9B5wWCSzjmwJMTIul9PYEc3OkivuwxOMu8RZ7ocWriI6nbs3' +
-			'42Z1vIgDsJTOrKNfluqL6xHbQvSUPNikIqsrnIHRLsFZIahfmxA9mmRW75u76oiu' +
-			'JIgbqGnItcxD0092KoBBVbB5/2SSC9tBGDdFaF3aPlRQkllN1sHDt689zZ1TbYd/' +
-			'NlVC0SKJwaLyKjYpjOZMYYhoDYJoq84yF33vsn5q9zdiGhF48XHjx69QTnp8MHuo' +
-			'5AyJYXHG+6MXuRrmi9YOMmTGyp6kRkJh/E8PDO+rMMSuqNFNQGGKJMnC08N2o0EO' +
-			'xo11uSwdSDiguUNTLnL2lAK0U7MbpnwdP4u3E4riRUIUhjN8CfWKGKe9bR3YyIZg' +
-			'ig3Y+reTI+bMnZ9E/bqghikApS+tawAy7m9EgWf1jkrsBiudd21qE+THLX2X2zh4' +
-			'+kL+MhoE1+Tat8nCBhvR/adxKKmqy+tT2GAQMKf+f35sqN+twI/aiwn8jv1KxQLt' +
-			'PFmHaoNJUDwnGjNk09QFkMNRulhwHXXMf/FO/dyKYb1USpYLT+SQHwIDAQABo1Aw' +
-			'TjAdBgNVHQ4EFgQU3H7zu+z+t0MJ/PrnPvp/SZk20agwHwYDVR0jBBgwFoAU3H7z' +
-			'u+z+t0MJ/PrnPvp/SZk20agwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC' +
-			'AgEAYj9VrdQlSzCVBxgEizl/H92Loov/5CPxRBqkBAWi+09NrUNnvIQcmMMbbIXe' +
-			'nXo2/egPM0z8cxJH3CfVFomHfQFiquWvm25L/38PAYjoOLDEwGHl3J7q9NXiAMft' +
-			'glMcef+IhVXCoayFxhMlxmN13bPYN/vLAAFasDU5ElhZTEH5DEUTV4ku9q0FsF2f' +
-			'fG6TXk++fVjUA5ykYo+megb0D39uBUE1E6CHLPuFrOrjWBRIf7CP8hWEwIwvJYKh' +
-			'x1iz6INS6Zu/juTTcAD1jMjnAPy2nz2VbEQc/LNtFEi0E7s9dJvYItLwk7NMYAAg' +
-			'DbWcEARwRtJCbcb/53j2fQyN7XNIAo58Oioa7rsINX6oy4F0XCKToF3FpTvXF8pn' +
-			'0Mu65Q7XYfeMyNBhbdrvXVwL2jeIHMM0clVz4W2k8BNpvy/KBU6fai3xwfIjqDtl' +
-			'aGzPELag9dwLOERJ5rLF5hQfRpok3ntZvBFq3nONfQ/o3qK5TyE3dTEGPG1/8nY3' +
-			'qYFLWCZ1XvCo1bQ+Ujm0WdWrgggAEwov07m1SnSeBactg0YKUd+KI5EkDbSMuGyG' +
-			'Pe6+emu31ygH9hiCNQ9XoRJDHsZpbenyqpGRKPw+F9jqjR/Z2CjCluDqqBCyDkAB' +
-			'HSiaITVCUB0ecS/2d4DyIBf/His2WR5+rEbctl8INrdFaM4=' +
-			'-----END CERTIFICATE-----';
+		const VALID_CERT = `-----BEGIN CERTIFICATE-----
+			MIICEDCCAbagAwIBAgIUXoY6X7jIpHAAgL267xHEpVr6NSgwCgYIKoZIzj0EAwIw
+			fzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNh
+			biBGcmFuY2lzY28xHzAdBgNVBAoTFkludGVybmV0IFdpZGdldHMsIEluYy4xDDAK
+			BgNVBAsTA1dXVzEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMTcwMTAzMDEyNDAw
+			WhcNMTgwMTAzMDEyNDAwWjAQMQ4wDAYDVQQDEwVhZG1pbjBZMBMGByqGSM49AgEG
+			CCqGSM49AwEHA0IABLoGEWBb+rQ/OuTBPlGVZO3jVWBcuC4+/pAq8axbtKorpORw
+			J/GxahKPLr+vVLPNMyeLcnyJBGgneug+ajE8srijfzB9MA4GA1UdDwEB/wQEAwIF
+			oDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAd
+			BgNVHQ4EFgQU9BUt7QfgDXx9g6zpzCyJGxXsNM0wHwYDVR0jBBgwFoAUF2dCPaqe
+			gj/ExR2fW8OZ0bWcSBAwCgYIKoZIzj0EAwIDSAAwRQIgcWQbMzluyZsmvQCvGzPg
+			f5B7ECxK0kdmXPXIEBiizYACIQD2x39Q4oVwO5uL6m3AVNI98C2LZWa0g2iea8wk
+			BAHpeA==
+			-----END CERTIFICATE-----`;
 
-		const VALID_CERT = '-----BEGIN CERTIFICATE-----' +
-			'MIICEDCCAbagAwIBAgIUXoY6X7jIpHAAgL267xHEpVr6NSgwCgYIKoZIzj0EAwIw' +
-			'fzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNh' +
-			'biBGcmFuY2lzY28xHzAdBgNVBAoTFkludGVybmV0IFdpZGdldHMsIEluYy4xDDAK' +
-			'BgNVBAsTA1dXVzEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMTcwMTAzMDEyNDAw' +
-			'WhcNMTgwMTAzMDEyNDAwWjAQMQ4wDAYDVQQDEwVhZG1pbjBZMBMGByqGSM49AgEG' +
-			'CCqGSM49AwEHA0IABLoGEWBb+rQ/OuTBPlGVZO3jVWBcuC4+/pAq8axbtKorpORw' +
-			'J/GxahKPLr+vVLPNMyeLcnyJBGgneug+ajE8srijfzB9MA4GA1UdDwEB/wQEAwIF' +
-			'oDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAd' +
-			'BgNVHQ4EFgQU9BUt7QfgDXx9g6zpzCyJGxXsNM0wHwYDVR0jBBgwFoAUF2dCPaqe' +
-			'gj/ExR2fW8OZ0bWcSBAwCgYIKoZIzj0EAwIDSAAwRQIgcWQbMzluyZsmvQCvGzPg' +
-			'f5B7ECxK0kdmXPXIEBiizYACIQD2x39Q4oVwO5uL6m3AVNI98C2LZWa0g2iea8wk' +
-			'BAHpeA==' +
-			'-----END CERTIFICATE-----';
-
-		it('should throw if does not contain common name', () => {
-			(() => {
-				Helper.getSubjectCommonName(CERT_WITHOUT_CN);
-			}).should.throw(/Certificate PEM does not seem to contain a valid subject with common name "CN"/);
-		});
 
 		it('should return the common name on success', () => {
-			Helper.getSubjectCommonName(VALID_CERT).should.equal('admin');
+			Helper.getSubject(VALID_CERT).should.equal('/CN=admin');
 		});
 	});
 

--- a/fabric-ca-client/types/index.d.ts
+++ b/fabric-ca-client/types/index.d.ts
@@ -67,6 +67,7 @@ declare namespace FabricCAServices {
 		profile?: string;
 		attr_reqs?: IAttributeRequest[];
 		csr?: string;
+		subject?: string;
 	}
 
 	export interface IKey {

--- a/fabric-common/lib/BlockDecoder.js
+++ b/fabric-common/lib/BlockDecoder.js
@@ -1513,7 +1513,7 @@ function decodeRangeQueryInfo(rangeQueryInfoProto) {
 	if (rangeQueryInfoProto.raw_reads) {
 		range_query_info.raw_reads = {};
 		range_query_info.raw_reads.kv_reads = [];
-		for (const kVReadProto of rangeQueryInfoProto.raw_reads) {
+		for (const kVReadProto of rangeQueryInfoProto.raw_reads.kv_reads) {
 			range_query_info.raw_reads.kv_reads.push(decodeKVRead(kVReadProto));
 		}
 	} else if (rangeQueryInfoProto.reads_merkle_hashes) {

--- a/fabric-common/lib/Channel.js
+++ b/fabric-common/lib/Channel.js
@@ -255,8 +255,8 @@ const Channel = class {
 		if (!(endorser.type === 'Endorser')) {
 			throw Error('Missing valid endorser instance');
 		}
-		if (!(endorser.connected)) {
-			throw Error('Endorser must be connected');
+		if (!endorser.isConnectable()) {
+			throw Error('Endorser must be connectable');
 		}
 		const name = endorser.name;
 		const check = this.endorsers.get(name);
@@ -336,8 +336,8 @@ const Channel = class {
 		if (!(committer.type === 'Committer')) {
 			throw Error('Missing valid committer instance');
 		}
-		if (!(committer.connected)) {
-			throw Error('Committer must be connected');
+		if (!committer.isConnectable()) {
+			throw Error('Committer must be connectable');
 		}
 		const name = committer.name;
 		const check = this.committers.get(name);

--- a/fabric-common/lib/Channel.js
+++ b/fabric-common/lib/Channel.js
@@ -66,8 +66,7 @@ const Channel = class {
 	}
 
 	/**
-	 * Close the service connections of all assigned endorsers, committers,
-	 * channel event hubs, and channel discovery.
+	 * Close the service connections of all assigned endorsers and committers
 	 */
 	close() {
 		const method = `close[${this.name}]`;

--- a/fabric-common/lib/Channel.js
+++ b/fabric-common/lib/Channel.js
@@ -12,6 +12,7 @@ const Endorsement = require('./Endorsement.js');
 const Commit = require('./Commit.js');
 const Query = require('./Query.js');
 const fabproto6 = require('fabric-protos');
+const util = require('util');
 const {checkParameter, getLogger} = require('./Utils.js');
 
 const logger = getLogger(TYPE);
@@ -473,11 +474,11 @@ const Channel = class {
 	 */
 	buildChannelHeader(type = checkParameter('type'), chaincode_id = checkParameter('chaincode_id'), tx_id = checkParameter('tx_id')) {
 		const method = `buildChannelHeader[${this.name}]`;
-		logger.debug(`${method} - start - type ${type} chaincode_id ${chaincode_id} tx_id ${tx_id}`);
+		logger.debug(`${method} - start - type ${type} chaincode_id ${util.inspect(chaincode_id)} tx_id ${tx_id}`);
 
-		const chaincodeID = fabproto6.protos.ChaincodeID.create({
+		const chaincodeID = fabproto6.protos.ChaincodeID.create(typeof chaincode_id === 'string' ? {
 			name: chaincode_id
-		});
+		} : chaincode_id);
 
 		logger.debug('%s - chaincodeID %j', method, chaincodeID);
 
@@ -513,9 +514,7 @@ const Channel = class {
 		}
 
 		const channelHeader = fabproto6.common.ChannelHeader.create(fields);
-		const channelHeaderBuf = fabproto6.common.ChannelHeader.encode(channelHeader).finish();
-
-		return channelHeaderBuf;
+		return fabproto6.common.ChannelHeader.encode(channelHeader).finish();
 	}
 
 	/**

--- a/fabric-common/lib/Client.js
+++ b/fabric-common/lib/Client.js
@@ -404,7 +404,7 @@ const Client = class {
 			// HSM, or the default has been set to HSM. FABN-830
 			const key = newCryptoSuite({software: true}).generateEphemeralKey();
 			this._tls_mutual.clientKey = key.toBytes();
-			this._tls_mutual.clientCert = key.generateX509Certificate('fabric-common');
+			this._tls_mutual.clientCert = key.generateX509Certificate('/CN=fabric-common');
 			this._tls_mutual.selfGenerated = true;
 		}
 

--- a/fabric-common/lib/Client.js
+++ b/fabric-common/lib/Client.js
@@ -498,6 +498,21 @@ const Client = class {
 
 		return getConfigSetting(name, default_value);
 	}
+
+	close() {
+		this.endorsers.forEach(endorser => {
+			endorser.disconnect();
+		});
+		this.endorsers.clear();
+		this.committers.forEach(committer => {
+			committer.disconnect();
+		});
+		this.committers.clear();
+		this.channels.forEach(channel => {
+			channel.close();
+		});
+		this.channels.clear();
+	}
 };
 
 function computeHash(data) {

--- a/fabric-common/lib/DiscoveryHandler.js
+++ b/fabric-common/lib/DiscoveryHandler.js
@@ -160,7 +160,20 @@ class DiscoveryHandler extends ServiceHandler {
 
 		const results = await this.discovery.getDiscoveryResults(true);
 
-		if (results && results.endorsement_plan) {
+		if (results && request.requiredOrgs) {
+			// special case when user knows which organizations to send the endorsement
+			// let's build our own endorsement plan so that we can use the sorting and sending code
+			const endorsement_plan = this._buildRequiredOrgPlan(results.peers_by_org);
+
+			// remove all org and peer
+			const orgs_request = {
+				sort: request.sort,
+				preferredHeightGap: request.preferredHeightGap
+			};
+
+			return this._endorse(endorsement_plan, orgs_request, signedProposal, timeout);
+		} else if (results && results.endorsement_plan) {
+			// normal processing of the discovery results
 			const working_discovery = JSON.parse(JSON.stringify(results.endorsement_plan));
 
 			return this._endorse(working_discovery, request, signedProposal, timeout);
@@ -305,6 +318,23 @@ class DiscoveryHandler extends ServiceHandler {
 		}
 
 		return responses;
+	}
+
+	_buildRequiredOrgPlan(peers_by_org) {
+		const method = '_buildRequiredOrgPlan';
+		logger.debug('%s - starting', method);
+		const endorsement_plan = {plan_id: 'required organizations'};
+		endorsement_plan.groups = {};
+		endorsement_plan.layouts = [{}]; // only one layout which will have all organizations
+
+		for (const mspid in peers_by_org) {
+			logger.debug(`${method} - found org:${mspid}`);
+			endorsement_plan.groups[mspid] = {}; // make a group for each organization
+			endorsement_plan.groups[mspid].peers = peers_by_org[mspid].peers; // now put in all peers from that organization
+			endorsement_plan.layouts[0][mspid] = 1; // add this org to the one layout and require one peer to endorse
+		}
+
+		return endorsement_plan;
 	}
 
 	/*

--- a/fabric-common/lib/DiscoveryHandler.js
+++ b/fabric-common/lib/DiscoveryHandler.js
@@ -259,7 +259,7 @@ class DiscoveryHandler extends ServiceHandler {
 			if (required > group.peers.length) {
 				results.success = false;
 				const error = new Error(`Endorsement plan group does not contain enough peers (${group.peers.length}) to satisfy policy (required:${required})`);
-				logger.error(error);
+				logger.debug(error.message);
 				results.endorsements.push(error);
 				break; // no need to look at other groups, this layout failed
 			}

--- a/fabric-common/lib/DiscoveryService.js
+++ b/fabric-common/lib/DiscoveryService.js
@@ -70,10 +70,10 @@ class DiscoveryService extends ServiceAction {
 		}
 
 		for (const discoverer of targets) {
-			if (discoverer.connected || discoverer.isConnectable()) {
-				logger.debug('%s - target is or could be connected %s', method, discoverer.name);
+			if (discoverer.isConnectable()) {
+				logger.debug('%s - target is connectable%s', method, discoverer.name);
 			} else {
-				throw Error(`Discoverer ${discoverer.name} is not connected`);
+				throw Error(`Discoverer ${discoverer.name} is not connectable`);
 			}
 		}
 		// must be all targets are connected
@@ -285,9 +285,12 @@ class DiscoveryService extends ServiceAction {
 		for (const target of this.targets) {
 			logger.debug(`${method} - about to discover on ${target.endpoint.url}`);
 			try {
-				response = await target.sendDiscovery(signedEnvelope, this.requestTimeout);
-				this.currentTarget = target;
-				break;
+				const isConnected = await target.checkConnection();
+				if (isConnected) {
+					response = await target.sendDiscovery(signedEnvelope, this.requestTimeout);
+					this.currentTarget = target;
+					break;
+				}
 			} catch (error) {
 				response = error;
 			}

--- a/fabric-common/lib/DiscoveryService.js
+++ b/fabric-common/lib/DiscoveryService.js
@@ -103,14 +103,18 @@ class DiscoveryService extends ServiceAction {
 	 *  sending to the peer.
 	 * @property {Endorsement} [endorsement] - Optional. Include the endorsement
 	 *  instance to build the discovery request based on the proposal.
-	 *  This will get the discovery interest (chaincode names and collections)
+	 *  This will get the discovery interest (chaincode names, collections and "no private reads")
 	 *  from the endorsement instance. Use the {@link Proposal#addCollectionInterest}
-	 *  to add collections to the endorsement's chaincode. Use the
-	 *  {@link Proposal#addChaincodeCollectionsInterest} to add chaincodes
-	 *  and collections that will be called by the endorsement's chaincode.
+	 *  to add collections to the endorsement's chaincode.
+	 *  Use the {@link Proposal#setNoPrivateReads} to set the proposals "no private reads"
+	 *  setting of the discovery interest.
+	 *  Use the {@link Proposal#addCollectionInterest} to add chaincodes,
+	 *  collections, and no private reads that will be used to get an endorsement plan
+	 *  from the peer's discovery service.
 	 * @property {DiscoveryChaincode} [interest] - Optional. An
-	 *  array of {@link DiscoveryChaincodeInterest} that have chaincodes
-	 *  and collections to calculate the endorsement plans.
+	 *  array of {@link DiscoveryChaincodeInterest} that have chaincodes, collections,
+	 *  and "no private reads" to help the peer's discovery service calculate the
+	 *  endorsement plan.
 	 * @example <caption>"single chaincode"</caption>
 	 *  [
 	 *     { name: "mychaincode"}
@@ -121,17 +125,21 @@ class DiscoveryService extends ServiceAction {
 	 *  ]
 	 * @example <caption>"single chaincode with a collection"</caption>
 	 *  [
-	 *     { name: "mychaincode", collection_names: ["mycollection"] }
+	 *     { name: "mychaincode", collectionNames: ["mycollection"] }
+	 *  ]
+	 * @example <caption>"single chaincode with a collection allowing no private data reads"</caption>
+	 *  [
+	 *     { name: "mychaincode", collectionNames: ["mycollection"], noPrivateReads: true }
 	 *  ]
 	 * @example <caption>"chaincode to chaincode with a collection"</caption>
 	 *  [
-	 *     { name: "mychaincode", collection_names: ["mycollection"] },
-	 *     { name: "myotherchaincode", collection_names: ["mycollection"] }}
+	 *     { name: "mychaincode", collectionNames: ["mycollection"] },
+	 *     { name: "myotherchaincode", collectionNames: ["mycollection"] }}
 	 *  ]
 	 * @example <caption>"chaincode to chaincode with collections"</caption>
 	 *  [
-	 *     { name: "mychaincode", collection_names: ["mycollection", "myothercollection"] },
-	 *     { name: "myotherchaincode", collection_names: ["mycollection", "myothercollection"] }}
+	 *     { name: "mychaincode", collectionNames: ["mycollection", "myothercollection"] },
+	 *     { name: "myotherchaincode", collectionNames: ["mycollection", "myothercollection"] }}
 	 *  ]
 	 */
 
@@ -144,7 +152,8 @@ class DiscoveryService extends ServiceAction {
 	/**
 	 * @typedef {Object} DiscoveryChaincodeCall
 	 * @property {string} name - The name of the chaincode
-	 * @property {string[]} [collection_names] - The names of the related collections
+	 * @property {string[]} [collectionNames] - The names of the related collections
+	 * @property {boolean} [noPrivateReads] - Indicates we do not need to read from private data
 	 */
 
 	/**
@@ -195,7 +204,7 @@ class DiscoveryService extends ServiceAction {
 			queries.push(localQuery);
 		}
 
-		// add a chaincode query to get endorsement plans
+		// add a discovery chaincode query to get endorsement plans
 		if (endorsement || interest) {
 			const interests = [];
 
@@ -379,6 +388,9 @@ class DiscoveryService extends ServiceAction {
 			const chaincodeCall = fabproto6.discovery.ChaincodeCall.create();
 			if (typeof chaincode.name === 'string') {
 				chaincodeCall.name = chaincode.name;
+				if (chaincode.noPrivateReads) {
+					chaincodeCall.no_private_reads = chaincode.noPrivateReads;
+				}
 				// support both names
 				if (chaincode.collection_names) {
 					_getCollectionNames(chaincode.collection_names, chaincodeCall);
@@ -741,7 +753,7 @@ class DiscoveryService extends ServiceAction {
 	}
 }
 
-function _getCollectionNames(names, chaincode_call) {
+function _getCollectionNames(names, chaincodeCall) {
 	if (Array.isArray(names)) {
 		const collection_names = [];
 		names.map(name => {
@@ -751,7 +763,9 @@ function _getCollectionNames(names, chaincode_call) {
 				throw Error('The collection name must be a string');
 			}
 		});
-		chaincode_call.collection_names = collection_names;
+		// this collection_names must be in snake case as it will
+		// be used by the gRPC create message
+		chaincodeCall.collection_names = collection_names;
 	} else {
 		throw Error('Collection names must be an array of strings');
 	}

--- a/fabric-common/lib/EventService.js
+++ b/fabric-common/lib/EventService.js
@@ -114,13 +114,13 @@ class EventService extends ServiceAction {
 		}
 
 		for (const eventer of targets) {
-			if (eventer.connected || eventer.isConnectable()) {
-				logger.debug('%s - target is or could be connected %s', method, eventer.name);
+			if (eventer.isConnectable()) {
+				logger.debug('%s - target is connectable %s', method, eventer.name);
 			} else {
 				throw Error(`Eventer ${eventer.name} is not connectable`);
 			}
 		}
-		// must be all targets are connected
+		// must be all targets are connectable
 		this.targets = targets;
 
 		return this;
@@ -358,10 +358,6 @@ class EventService extends ServiceAction {
 					logger.debug('%s - target has a stream, is already listening %s', method, target.toString());
 					startError = Error(`Event service ${target.name} is currently listening`);
 				} else {
-					if (target.isConnectable()) {
-						logger.debug('%s - target needs to connect %s', method, target.toString());
-						await target.connect(); // target endpoint has been previously assigned, but not connected yet
-					}
 					const isConnected = await target.checkConnection();
 					if (!isConnected) {
 						startError = Error(`Event service ${target.name} is not connected`);

--- a/fabric-common/lib/Eventer.js
+++ b/fabric-common/lib/Eventer.js
@@ -83,6 +83,8 @@ class Eventer extends ServiceEndpoint {
 		const method = `checkConnection[${this.name}:${this.myCount}]`;
 		logger.debug(`${method} - start`);
 
+		super.checkConnection();
+
 		let result = false;
 		if (this.service) {
 			try {

--- a/fabric-common/lib/impl/ecdsa/key.js
+++ b/fabric-common/lib/impl/ecdsa/key.js
@@ -126,17 +126,13 @@ class ECDSA_KEY extends Key {
 
 	/**
 	 * Generates a self-signed X.509 certificate
-	 * @param {string} [commonName] The common name to use as the subject for the X509 certificate
+	 * @param {string} [subjectDN] The subject to use for the X509 certificate
 	 * @returns {string} PEM-encoded X.509 certificate
 	 * @throws Will throw an error if this is not a private key
 	 * @throws Will throw an error if X.509 certificate generation fails for any other reason
 	 */
-	generateX509Certificate(commonName) {
+	generateX509Certificate(subjectDN = '/CN=self') {
 
-		let subjectDN = '/CN=self';
-		if (commonName) {
-			subjectDN = '/CN=' + commonName;
-		}
 		// check to see if this is a private key
 		if (!this.isPrivate()) {
 			throw new Error('An X509 certificate cannot be generated from a public key');

--- a/fabric-common/test/BlockDecoder.js
+++ b/fabric-common/test/BlockDecoder.js
@@ -2018,13 +2018,13 @@ describe('BlockDecoder', () => {
 				start_key: 'start_key',
 				end_key: 'end_key',
 				itr_exhausted: 'itr_exhausted',
-				raw_reads: ['raw_read']
+				raw_reads: {kv_reads: ['kv_read']}
 			};
 			const rangeQueryInfo = decodeRangeQueryInfo(mockProtoRangeQueryInfo);
 			rangeQueryInfo.start_key.should.equal('start_key');
 			rangeQueryInfo.end_key.should.equal('end_key');
 			rangeQueryInfo.itr_exhausted.should.equal('itr_exhausted');
-			sinon.assert.calledWith(decodeKVReadStub, 'raw_read');
+			sinon.assert.calledWith(decodeKVReadStub, 'kv_read');
 		});
 
 		it('should return the correct range query info with reads merklehashes', () => {

--- a/fabric-common/test/Channel.js
+++ b/fabric-common/test/Channel.js
@@ -231,7 +231,7 @@ describe('Channel', () => {
 				const endorser1 = getEndorser('endorser');
 				endorser1.connected = false;
 				channel.addEndorser(endorser1);
-			}).should.throw('Endorser must be connected');
+			}).should.throw('Endorser must be connectable');
 		});
 		it('should find a endorser.name', () => {
 			(() => {
@@ -311,7 +311,7 @@ describe('Channel', () => {
 				const committer1 = getCommitter('committer');
 				committer1.connected = false;
 				channel.addCommitter(committer1);
-			}).should.throw('Committer must be connected');
+			}).should.throw('Committer must be connectable');
 		});
 		it('should find a committer.name', () => {
 			(() => {

--- a/fabric-common/test/Client.js
+++ b/fabric-common/test/Client.js
@@ -429,6 +429,28 @@ describe('Client', () => {
 		});
 	});
 
+	describe('#close', () => {
+		it('should be able close with no endpoints', () => {
+			client.close();
+		});
+		it('should allow multiple close attempt', () => {
+			client.close();
+			client.close();
+		});
+		it('should be able close with endpoints', () => {
+			client.getEndorser('endoser1');
+			client.getCommitter('committer1');
+			client.getChannel('mychannel');
+			should.equal(client.endorsers.size, 1);
+			should.equal(client.committers.size, 1);
+			should.equal(client.channels.size, 1);
+			client.close();
+			should.equal(client.endorsers.size, 0);
+			should.equal(client.committers.size, 0);
+			should.equal(client.channels.size, 0);
+
+		});
+	});
 	describe('#toString', () => {
 		it('should return string', () => {
 			const string = client.toString();

--- a/fabric-common/test/DiscoveryHandler.js
+++ b/fabric-common/test/DiscoveryHandler.js
@@ -36,7 +36,7 @@ describe('DiscoveryHandler', () => {
 	let peer11, peer12, peer21, peer22, peer31, peer32, peer33;
 	let orderer1, orderer2, orderer3;
 
-	// const pem = '-----BEGIN CERTIFICATE-----    -----END CERTIFICATE-----\n';
+	const pem = '-----BEGIN CERTIFICATE-----    -----END CERTIFICATE-----\n';
 	const org1 = [
 		'Org1MSP',
 		'peer1.org1.example.com:7001',
@@ -88,8 +88,8 @@ describe('DiscoveryHandler', () => {
 		layouts: [{G0: 1, G1: 1}, {G3: 3, G1: 1}]
 	};
 
-	/*
-	const discovery_plan = {
+
+	const config_results = {
 		msps: {
 			OrdererMSP: {
 				id: 'OrdererMSP',
@@ -129,7 +129,7 @@ describe('DiscoveryHandler', () => {
 			Org2MSP: {endpoints: [{host: 'orderer.org2.example.com', port: 7150, name: 'orderer.org2.example.com'}]},
 			Org3MSP: {endpoints: [{host: 'orderer.org3.example.com', port: 7150, name: 'orderer.org3.example.com'}]}
 		},
-		peersByOrg: {
+		peers_by_org: {
 			Org1MSP: {
 				peers: [
 					{mspid: org1[0], endpoint: org1[1], ledgerHeight, chaincodes, name: org1[1]},
@@ -145,14 +145,38 @@ describe('DiscoveryHandler', () => {
 			Org3MSP: {
 				peers: [
 					{mspid: org3[0], endpoint: org3[1], ledgerHeight, chaincodes, name: org3[1]},
-					{mspid: org3[0], endpoint: org3[2], ledgerHeight, chaincodes, name: org3[2]},
-					{mspid: org3[0], endpoint: org3[3], ledgerHeight, chaincodes, name: org3[3]}
+					{mspid: org3[0], endpoint: org3[2], ledgerHeight: highest, chaincodes, name: org3[2]},
+					{mspid: org3[0], endpoint: org3[3], ledgerHeight: smaller, chaincodes, name: org3[3]}
+				]
+			}
+		}
+	};
+
+	const organization_plan = {
+		plan_id: 'required organizations',
+		groups: {
+			Org1MSP: {
+				peers: [
+					{mspid: org1[0], endpoint: org1[1], ledgerHeight, chaincodes, name: org1[1]},
+					{mspid: org1[0], endpoint: org1[2], ledgerHeight, chaincodes, name: org1[2]}
+				]
+			},
+			Org2MSP: {
+				peers: [
+					{mspid: org2[0], endpoint: org2[1], ledgerHeight, chaincodes, name: org2[1]},
+					{mspid: org2[0], endpoint: org2[2], ledgerHeight, chaincodes, name: org2[2]}
+				]
+			},
+			Org3MSP: {
+				peers: [
+					{mspid: org3[0], endpoint: org3[1], ledgerHeight, chaincodes, name: org3[1]},
+					{mspid: org3[0], endpoint: org3[2], ledgerHeight: highest, chaincodes, name: org3[2]},
+					{mspid: org3[0], endpoint: org3[3], ledgerHeight: smaller, chaincodes, name: org3[3]}
 				]
 			}
 		},
-		endorsement_plan: endorsement_plan
+		layouts: [{Org1MSP: 1, Org2MSP: 1, Org3MSP: 1}]
 	};
-	*/
 
 	const good = {response: {status: 200}};
 	beforeEach(() => {
@@ -361,6 +385,14 @@ describe('DiscoveryHandler', () => {
 			const results = await discoveryHandler.endorse('signedProposal', {requestTimeout: 2000});
 			results.should.equal('DONE');
 		});
+		it('should run ok with required orgs', async () => {
+			discovery.getDiscoveryResults = sandbox.stub().resolves(config_results);
+			discoveryHandler._endorse = sandbox.stub().resolves('DONE');
+			const results = await discoveryHandler.endorse('signedProposal', {requiredOrgs: ['Org1MSP', 'Org2MSP', 'Org3MSP'], sort: 'check'});
+			results.should.equal('DONE');
+			sinon.assert.calledWith(discoveryHandler._endorse, organization_plan, {sort: 'check', preferredHeightGap: undefined});
+
+		});
 	});
 
 	describe('#_endorse', () => {
@@ -513,6 +545,15 @@ describe('DiscoveryHandler', () => {
 			results[0].success.should.equal(true);
 			results[2].should.be.instanceof(Error);
 			sinon.assert.calledWith(FakeLogger.debug, '%s - endorsement failed: %s');
+		});
+	});
+
+	describe('#_buildRequiredOrgPlan', () => {
+		it('should run ok', async () => {
+
+			// TEST CALL
+			const results = await discoveryHandler._buildRequiredOrgPlan(config_results.peers_by_org);
+			results.should.deep.equal(organization_plan);
 		});
 	});
 

--- a/fabric-common/test/DiscoveryHandler.js
+++ b/fabric-common/test/DiscoveryHandler.js
@@ -34,6 +34,7 @@ describe('DiscoveryHandler', () => {
 	const tmpSetDelete = Set.prototype.delete;
 
 	let peer11, peer12, peer21, peer22, peer31, peer32, peer33;
+	let orderer1, orderer2, orderer3;
 
 	// const pem = '-----BEGIN CERTIFICATE-----    -----END CERTIFICATE-----\n';
 	const org1 = [
@@ -173,54 +174,67 @@ describe('DiscoveryHandler', () => {
 		peer11 = client.newEndorser(org1[1], org1[0]);
 		peer11.endpoint = {url: 'grpcs://' + org1[1], addr: org1[1]};
 		peer11.sendProposal = sandbox.stub().resolves(good);
+		peer11.checkConnection = sandbox.stub().resolves(true);
 		peer11.connected = true;
 		channel.addEndorser(peer11);
 		peer12 = client.newEndorser(org1[2], org1[0]);
 		peer12.endpoint = {url: 'grpcs://' + org1[2], addr: org1[2]};
 		peer12.sendProposal = sandbox.stub().resolves(good);
+		peer12.checkConnection = sandbox.stub().resolves(true);
 		peer12.connected = true;
 		channel.addEndorser(peer12);
 
 		peer21 = client.newEndorser(org2[1], org2[0]);
 		peer21.endpoint = {url: 'grpcs://' + org2[1], addr: org2[1]};
 		peer21.sendProposal = sandbox.stub().resolves(good);
+		peer21.checkConnection = sandbox.stub().resolves(true);
 		peer21.connected = true;
 		channel.addEndorser(peer21);
 		peer22 = client.newEndorser(org2[2], org2[0]);
 		peer22.endpoint = {url: 'grpcs://' + org2[2], addr: org2[2]};
 		peer22.sendProposal = sandbox.stub().resolves(good);
+		peer22.checkConnection = sandbox.stub().resolves(true);
 		peer22.connected = true;
 		channel.addEndorser(peer22);
 
 		peer31 = client.newEndorser(org3[1], org3[0]);
 		peer31.endpoint = {url: 'grpcs://' + org3[1], addr: org3[1]};
 		peer31.sendProposal = sandbox.stub().resolves(good);
+		peer31.checkConnection = sandbox.stub().resolves(true);
 		peer31.connected = true;
 		channel.addEndorser(peer31);
 		peer32 = client.newEndorser(org3[2], org3[0]);
 		peer32.endpoint = {url: 'grpcs://' + org3[2], addr: org3[2]};
 		peer32.sendProposal = sandbox.stub().resolves(good);
+		peer32.checkConnection = sandbox.stub().resolves(true);
 		peer32.connected = true;
 		channel.addEndorser(peer32);
 		peer33 = client.newEndorser(org3[3], org3[0]);
 		peer33.endpoint = {url: 'grpcs://' + org3[3], addr: org3[3]};
 		peer33.sendProposal = sandbox.stub().resolves(good);
+		peer33.checkConnection = sandbox.stub().resolves(true);
 		peer33.connected = true;
 		channel.addEndorser(peer33);
 
-		const orderer1 = client.newCommitter('orderer1', 'msp1');
+		orderer1 = client.newCommitter('orderer1', 'msp1');
 		orderer1.sendBroadcast = sandbox.stub().resolves({status: 'SUCCESS'});
+		orderer1.checkConnection = sandbox.stub().resolves(true);
 		orderer1.connected = true;
+		orderer1.endpoint = {url: 'grpc://orderer1.com'};
 		channel.addCommitter(orderer1);
 
-		const orderer2 = client.newCommitter('orderer2', 'msp2');
+		orderer2 = client.newCommitter('orderer2', 'msp2');
 		orderer2.sendBroadcast = sandbox.stub().resolves({status: 'SUCCESS'});
+		orderer2.checkConnection = sandbox.stub().resolves(true);
 		orderer2.connected = true;
+		orderer2.endpoint = {url: 'grpc://orderer2.com'};
 		channel.addCommitter(orderer2);
 
-		const orderer3 = client.newCommitter('orderer3', 'msp1');
+		orderer3 = client.newCommitter('orderer3', 'msp1');
 		orderer3.sendBroadcast = sandbox.stub().resolves({status: 'SUCCESS'});
+		orderer3.checkConnection = sandbox.stub().resolves(true);
 		orderer3.connected = true;
+		orderer3.endpoint = {url: 'grpc://orderer3.com'};
 		channel.addCommitter(orderer3);
 
 		discovery = channel.newDiscoveryService('mydiscovery');
@@ -300,7 +314,9 @@ describe('DiscoveryHandler', () => {
 			const results = await discoveryHandler.commit('signedEnvelope');
 			results.status.should.equal('SUCCESS');
 		});
-		it('should run with orderers assigned', async () => {
+		it('should run with some bad orderers assigned', async () => {
+			orderer1.checkConnection = sandbox.stub().resolves(false);
+			orderer2.checkConnection = sandbox.stub().resolves(false);
 			const results = await discoveryHandler.commit('signedEnvelope');
 			results.status.should.equal('SUCCESS');
 		});
@@ -320,6 +336,14 @@ describe('DiscoveryHandler', () => {
 			channel.getCommitter('orderer2').sendBroadcast = sandbox.stub().rejects(new Error('FAILED with Error'));
 			await discoveryHandler.commit('signedEnvelope', {mspid: 'msp2'})
 				.should.be.rejectedWith(/FAILED with Error/);
+		});
+		it('should reject when all orderers are no connected', async () => {
+			orderer1.checkConnection = sandbox.stub().resolves(false);
+			orderer2.checkConnection = sandbox.stub().resolves(false);
+			orderer3.checkConnection = sandbox.stub().resolves(false);
+
+			await discoveryHandler.commit('signedEnvelope')
+				.should.be.rejectedWith(/is not connected/);
 		});
 	});
 
@@ -365,7 +389,7 @@ describe('DiscoveryHandler', () => {
 			const results = await discoveryHandler._endorse({}, {preferredHeightGap: 0}, 'proposal');
 			results.should.equal('endorsements');
 		});
-		it('should run ok', async () => {
+		it('should run - show failed', async () => {
 			discovery.getDiscoveryResults = sandbox.stub().resolves({endorsement_plan: {something: 'plan a'}});
 			discoveryHandler._modify_groups = sinon.stub();
 			discoveryHandler._getRandom = sinon.stub().returns([{}]);
@@ -506,6 +530,23 @@ describe('DiscoveryHandler', () => {
 			);
 			results.response.status.should.equal(200);
 			sinon.assert.calledWith(FakeLogger.debug, '%s - start', '_build_endorse_group_member >> G0:0');
+		});
+		it('should run - show reconnect error', async () => {
+			endorsement_plan.endorsements = {};
+			peer11.checkConnection.resolves(false);
+			peer12.checkConnection.resolves(false);
+			// TEST CALL
+			const results = await discoveryHandler._build_endorse_group_member(
+				endorsement_plan, // endorsement plan
+				endorsement_plan.groups.G0, // group
+				'proposal', // proposal
+				2000, // timeout
+				0, // endorser_process_index
+				'G0' // group name
+			);
+			results.message.should.equal('Peer peer2.org1.example.com:7002 is not connected');
+			sinon.assert.notCalled(peer11.sendProposal);
+			sinon.assert.notCalled(peer12.sendProposal);
 		});
 		it('should run ok and return error when endorser rejects', async () => {
 			endorsement_plan.endorsements = {};

--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -422,6 +422,23 @@ describe('DiscoveryService', () => {
 			const results = discovery._buildProtoChaincodeInterest(interest);
 			should.exist(results.chaincodes);
 		});
+		it('should handle two chaincode four collection in camel case', () => {
+			const interest = [
+				{name: 'chaincode1', collectionNames: ['collection1', 'collection3']},
+				{name: 'chaincode2', collectionNames: ['collection2', 'collection4']}
+			];
+			const results = discovery._buildProtoChaincodeInterest(interest);
+			should.exist(results.chaincodes);
+		});
+		it('should handle two chaincode four collection in camel case', () => {
+			const interest = [
+				{name: 'chaincode1', collectionNames: ['collection1', 'collection3'], noPrivateReads: true},
+				{name: 'chaincode2', collectionNames: ['collection2', 'collection4']}
+			];
+			const results = discovery._buildProtoChaincodeInterest(interest);
+			should.exist(results.chaincodes);
+			results.chaincodes[0].no_private_reads.should.be.true;
+		});
 		it('should handle two chaincodes same name', () => {
 			const interest = [{name: 'chaincode1'}, {name: 'chaincode1'}];
 			const results = discovery._buildProtoChaincodeInterest(interest);

--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -99,8 +99,13 @@ describe('DiscoveryService', () => {
 
 	const endorser = sinon.createStubInstance(Endorser);
 	endorser.type = 'Endorser';
+	endorser.connected = true;
+	endorser.isConnectable = sinon.stub().returns(true);
+
 	const committer = sinon.createStubInstance(Committer);
 	committer.type = 'Committer';
+	committer.connected = true;
+	committer.isConnectable = sinon.stub().returns(true);
 
 	let FakeLogger;
 
@@ -121,6 +126,8 @@ describe('DiscoveryService', () => {
 		discoverer = new Discoverer('mydiscoverer', client);
 		endpoint = client.newEndpoint({url: 'grpc://somehost.com'});
 		discoverer.endpoint = endpoint;
+		discoverer.waitForReady = sinon.stub().resolves(true);
+		discoverer.checkConnection = sinon.stub().resolves(true);
 		discovery = new DiscoveryService('mydiscovery', channel);
 		client.getEndorser = sinon.stub().returns(endorser);
 		client.newEndorser = sinon.stub().returns(endorser);
@@ -178,7 +185,7 @@ describe('DiscoveryService', () => {
 			(() => {
 				discoverer.endpoint = undefined;
 				discovery.setTargets([discoverer]);
-			}).should.throw('Discoverer mydiscoverer is not connected');
+			}).should.throw('Discoverer mydiscoverer is not connectable');
 		});
 		it('should handle connected target', () => {
 			discoverer.connected = true;

--- a/fabric-common/test/EventService.js
+++ b/fabric-common/test/EventService.js
@@ -173,6 +173,7 @@ describe('EventService', () => {
 			eventService2._closeRunning.should.be.false;
 			eventService2.blockType.should.be.equal('filtered');
 			eventService2.replay.should.be.false;
+			eventService2.startSpecified.should.be.false;
 		});
 	});
 
@@ -367,6 +368,7 @@ describe('EventService', () => {
 			};
 			eventService.build(idx, options);
 			should.exist(eventService._payload);
+			should.equal(eventService.startSpecified, true);
 		});
 		it('should build with startBlock and endBlock as valid numbers', () => {
 			const options = {
@@ -516,6 +518,21 @@ describe('EventService', () => {
 			};
 			eventService.blockType = 'full';
 			await eventService._startService(eventer1, {}, 10).should.be.rejectedWith('Event service timed out - Unable to start listening');
+		});
+		it('throws timeout on stream', async () => {
+			const eventer1 = client.newEventer('eventer1');
+			eventer1.endpoint = endpoint;
+			eventer1.checkConnection = sinon.stub().returns(true);
+			const stream = sinon.stub();
+			stream.on = sinon.stub();
+			stream.write = sinon.stub();
+			eventer1.setStreamByType = function() {
+				this.stream = stream;
+			};
+			eventService.blockType = 'full';
+			eventService.startSpecified = true;
+			await eventService._startService(eventer1, {}, 10);
+			eventService.close();
 		});
 		it('throws error on stream write', async () => {
 			const eventer1 = client.newEventer('eventer1');

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -41,6 +41,8 @@ describe('Proposal', () => {
 		endorser.type = 'Endorser';
 		endpoint = client.newEndpoint({url: 'grpc://somehost.com'});
 		endorser.endpoint = endpoint;
+		endorser.waitForReady = sinon.stub().resolves(true);
+		endorser.checkConnection = sinon.stub().resolves(true);
 		handler = new DiscoveryHandler('discovery');
 	});
 

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -80,19 +80,39 @@ describe('Proposal', () => {
 	describe('#buildProposalInterest', () => {
 		it('should return interest', () => {
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}]);
 		});
 		it('should return interest and collections', () => {
 			const collections = ['col1', 'col2'];
 			proposal.collectionsInterest = collections;
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false, collectionNames: collections}]);
+		});
+		it('should return interest and collections with noPrivateReads', () => {
+			const collections = ['col1', 'col2'];
+			proposal.collectionsInterest = collections;
+			proposal.noPrivateReads = true;
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: true, collectionNames: collections}]);
 		});
 		it('should return interest and chaincode and chaincode collections ', () => {
 			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2']};
 			proposal.chaincodesCollectionsInterest = [chaincode_collection];
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should return interest and chaincode and chaincode collections with no private reads ', () => {
+			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2'], noPrivateReads: true};
+			proposal.chaincodesCollectionsInterest = [chaincode_collection];
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should return interest and chaincode and chaincode collections with no private reads ', () => {
+			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2'], noPrivateReads: true};
+			proposal.noPrivateReads = true;
+			proposal.chaincodesCollectionsInterest = [chaincode_collection];
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: true}, chaincode_collection]);
 		});
 	});
 
@@ -107,7 +127,7 @@ describe('Proposal', () => {
 			proposal.addCollectionInterest('col2');
 			proposal.collectionsInterest.should.deep.equal(collections);
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode', collectionNames: collections}]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false, collectionNames: collections}]);
 		});
 		it('should require a string collection name', () => {
 			(() => {
@@ -116,24 +136,63 @@ describe('Proposal', () => {
 		});
 	});
 
+	describe('#setNoPrivateReads', () => {
+		it('should set no private reads', () => {
+			proposal.setNoPrivateReads(true);
+			proposal.noPrivateReads.should.equal(true);
+		});
+		it('should set no private reads false', () => {
+			proposal.setNoPrivateReads(false);
+			proposal.noPrivateReads.should.equal(false);
+		});
+
+		it('should require a boolean', () => {
+			(() => {
+				proposal.setNoPrivateReads({});
+			}).should.throw(/The "no private reads" setting must be boolean/);
+		});
+	});
+
 	describe('#addChaincodeCollectionsInterest', () => {
 		it('should save chaincode collection interest', () => {
-			const chaincode_collection = {name: 'chain2', collectionNames: ['col1', 'col2']};
+			const chaincode_collection = {name: 'chain2', noPrivateReads: false, collectionNames: ['col1', 'col2']};
 			proposal.addChaincodeCollectionsInterest('chain2', 'col1', 'col2');
 			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
 		});
 		it('should save chaincode only chaincode collection interest', () => {
-			const chaincode_collection = {name: 'chain2'};
+			const chaincode_collection = {name: 'chain2', noPrivateReads: false};
 			proposal.addChaincodeCollectionsInterest('chain2');
 			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
 			const interest = proposal.buildProposalInterest();
-			interest.should.deep.equal([{name: 'chaincode'}, chaincode_collection]);
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
 		});
 		it('should require a string chaincode name', () => {
 			(() => {
 				proposal.addChaincodeCollectionsInterest({});
+			}).should.throw('Invalid chaincodeId parameter');
+		});
+	});
+
+	describe('#addChaincodeNoPrivateReadsCollectionsInterest', () => {
+		it('should save chaincode collection interest', () => {
+			const chaincode_collection = {name: 'chain2', noPrivateReads: true, collectionNames: ['col1', 'col2']};
+			proposal.addChaincodeNoPrivateReadsCollectionsInterest('chain2', true, 'col1', 'col2');
+			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should save chaincode only chaincode collection interest', () => {
+			const chaincode_collection = {name: 'chain2', noPrivateReads: false};
+			proposal.addChaincodeNoPrivateReadsCollectionsInterest('chain2');
+			proposal.chaincodesCollectionsInterest.should.deep.equal([chaincode_collection]);
+			const interest = proposal.buildProposalInterest();
+			interest.should.deep.equal([{name: 'chaincode', noPrivateReads: false}, chaincode_collection]);
+		});
+		it('should require a string chaincode name', () => {
+			(() => {
+				proposal.addChaincodeNoPrivateReadsCollectionsInterest({});
 			}).should.throw('Invalid chaincodeId parameter');
 		});
 	});

--- a/fabric-common/test/impl/ecdsa/key.js
+++ b/fabric-common/test/impl/ecdsa/key.js
@@ -345,7 +345,7 @@ describe('ECDSA_KEY', () => {
 			const myKey = new ECDSA_KEY_REWIRE(fakeKey);
 			myKey._key.should.deep.equal(fakeKey);
 			myKey.isPrivate = sinon.stub().returns(true);
-			const csr = myKey.generateX509Certificate('penguin');
+			const csr = myKey.generateX509Certificate('/CN=penguin');
 
 			csr.should.equal('your PEM sir');
 			sinon.assert.calledOnce(pemStub);

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -327,6 +327,7 @@ export class Client {
 	public setTlsClientCertAndKey(clientCert: string, clientKey: string): Client;
 	public setTlsClientCertAndKey(): Client;
 	public addTlsClientCertAndKey(options: ConnectOptions): Client;
+	public close(): void;
 }
 
 export interface ConnectOptions {

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -213,7 +213,9 @@ export class Proposal extends ServiceAction {
 	public getTransactionId(): string;
 	public buildProposalInterest(): any;
 	public addCollectionInterest(collectionName: string): Proposal;
+	public setNoPrivateReads(noPrivateReads: boolean): Proposal;
 	public addChaincodeCollectionsInterest(collectionName: string, collectionNames: string[]): Proposal;
+	public addChaincodeNoPrivateReadsCollectionsInterest(collectionName: string, noPrivateReads: boolean, collectionNames: string[]): Proposal;
 	public build(idContext: IdentityContext, request?: BuildProposalRequest): Buffer;
 	public send(request?: SendProposalRequest): Promise<ProposalResponse>;
 	public verifyProposalResponse(proposalResponse?: any): boolean;

--- a/fabric-network/src/contract.ts
+++ b/fabric-network/src/contract.ts
@@ -46,6 +46,7 @@ function verifyNamespace(namespace?: string): void {
 export interface DiscoveryInterest {
 	name: string;
 	collectionNames?: string[];
+	noPrivateReads?: boolean;
 }
 
 export interface Contract {

--- a/fabric-network/src/gateway.ts
+++ b/fabric-network/src/gateway.ts
@@ -4,20 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Network, NetworkImpl } from './network';
+import {Network, NetworkImpl} from './network';
 import * as NetworkConfig from './impl/ccp/networkconfig';
-import { Identity } from './impl/wallet/identity';
-import { Wallet } from './impl/wallet/wallet';
-import { IdentityProvider } from './impl/wallet/identityprovider';
-import { TxEventHandlerFactory } from './impl/event/transactioneventhandler';
-import { QueryHandlerFactory } from './impl/query/queryhandler';
-import { Client, IdentityContext } from 'fabric-common';
+import {Identity} from './impl/wallet/identity';
+import {Wallet} from './impl/wallet/wallet';
+import {IdentityProvider} from './impl/wallet/identityprovider';
+import {TxEventHandlerFactory} from './impl/event/transactioneventhandler';
+import {QueryHandlerFactory} from './impl/query/queryhandler';
+import {Client, IdentityContext} from 'fabric-common';
 import * as EventStrategies from './impl/event/defaulteventhandlerstrategies';
 import * as QueryStrategies from './impl/query/defaultqueryhandlerstrategies';
 import * as IdentityProviderRegistry from './impl/wallet/identityproviderregistry';
 
 import * as Logger from './logger';
-import { X509Identity } from './impl/wallet/x509identity';
+import {X509Identity} from './impl/wallet/x509identity';
+
 const logger = Logger.getLogger('Gateway');
 
 export interface GatewayOptions {
@@ -369,6 +370,9 @@ export class Gateway {
 		logger.debug('in disconnect');
 		this.networks.forEach((network) => network._dispose());
 		this.networks.clear();
+		if (this.client) {
+			this.client.close();
+		}
 	}
 
 	/**

--- a/fabric-network/test/contract.js
+++ b/fabric-network/test/contract.js
@@ -146,8 +146,15 @@ describe('Contract', () => {
 		it ('throws when not an interest', () => {
 			(() => contract.addDiscoveryInterest('intersts')).should.throw('"interest" parameter must be a DiscoveryInterest object');
 		});
-		it('add collection', async () => {
+		it('update collection', async () => {
 			const interest = {name: chaincodeId, collectionNames: ['c1', 'c2']};
+			contract.addDiscoveryInterest(interest);
+			expect(contract.discoveryInterests).to.deep.equal([
+				interest
+			]);
+		});
+		it('update collection with no private reads', async () => {
+			const interest = {name: chaincodeId, collectionNames: ['c1', 'c2'], noPrivateReads: true};
 			contract.addDiscoveryInterest(interest);
 			expect(contract.discoveryInterests).to.deep.equal([
 				interest
@@ -163,6 +170,14 @@ describe('Contract', () => {
 		});
 		it('add chaincode and collection', async () => {
 			const other = {name: 'other', collectionNames: ['c1', 'c2']};
+			contract.addDiscoveryInterest(other);
+			expect(contract.discoveryInterests).to.deep.equal([
+				{name: chaincodeId},
+				other
+			]);
+		});
+		it('add chaincode and collection with no private reads', async () => {
+			const other = {name: 'other', collectionNames: ['c1', 'c2'], noPrivateReads: true};
 			contract.addDiscoveryInterest(other);
 			expect(contract.discoveryInterests).to.deep.equal([
 				{name: chaincodeId},

--- a/test/ts-scenario/features/discovery.feature
+++ b/test/ts-scenario/features/discovery.feature
@@ -63,3 +63,9 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 		Then The gateway named myDiscoveryGateway has a submit type response matching {"key0":"value1","key1":"value2"}
 		When I modify myDiscoveryGateway to evaluate a transaction with transient data using args [getTransient,valueA,valueB] for contract fabcar instantiated on channel discoverychannel
 		Then The gateway named myDiscoveryGateway has a evaluate type response matching {"key0":"valueA","key1":"valueB"}
+
+	Scenario: Using a Gateway I can submit and evaluate transactions on instantiated node smart contract with specific organizations
+		When I use the discovery gateway named myDiscoveryGateway to submit a transaction with args [createCar,2001,Ford,F350,red,Sam] for contract fabcar instantiated on channel discoverychannel using requiredOrgs ["Org1MSP","Org2MSP"]
+		Then The gateway named myDiscoveryGateway has a submit type response
+		When I use the gateway named myDiscoveryGateway to evaluate a transaction with args [queryCar,2001] for contract fabcar instantiated on channel discoverychannel
+		Then The gateway named myDiscoveryGateway has a evaluate type response matching {"color":"red","docType":"car","make":"Ford","model":"F350","owner":"Sam"}

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as FabricCAClient from 'fabric-ca-client';
-import { Contract, DefaultEventHandlerStrategies, DefaultQueryHandlerStrategies, Gateway, GatewayOptions, HsmOptions, HsmX509Provider, Identity, IdentityProvider, Network, QueryHandlerFactory, Transaction, TransientMap, TxEventHandlerFactory, Wallet, Wallets } from 'fabric-network';
+import { Contract, DefaultEventHandlerStrategies, DefaultQueryHandlerStrategies, Gateway, GatewayOptions, HsmOptions, HsmX509Provider, Identity, IdentityProvider, Network, QueryHandlerFactory, Transaction, TransientMap, TxEventHandlerFactory, Wallet, Wallets, DiscoveryInterest } from 'fabric-network';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createQueryHandler as sampleQueryStrategy } from '../../config/handlers/sample-query-handler';
@@ -382,7 +382,7 @@ export async function performGatewayTransaction(gatewayName: string, contractNam
 		BaseUtils.logMsg(` -- adding a discovery interest colletion name to the contrace ${collectionName}`);
 		const chaincodeId = contract.chaincodeId;
 		contract.resetDiscoveryInterests();
-		contract.addDiscoveryInterest({name: chaincodeId, collectionNames: [collectionName]});
+		contract.addDiscoveryInterest({name: chaincodeId, collectionNames: [collectionName], noPrivateReads: false});
 	}
 
 	// Split args

--- a/test/ts-scenario/steps/lib/gateway.ts
+++ b/test/ts-scenario/steps/lib/gateway.ts
@@ -333,7 +333,7 @@ async function createHSMUser(wallet: Wallet, ccp: CommonConnectionProfileHelper,
  * @param {String} txnType the type of transaction (submit/evaluate)
  * @param {String} handlerOption Optional: the handler option to use
  */
-export async function performGatewayTransaction(gatewayName: string, contractName: string, channelName: string, collectionName: string, args: string, txnType: string, handlerOption?: string): Promise<void> {
+export async function performGatewayTransaction(gatewayName: string, contractName: string, channelName: string, collectionName: string, args: string, txnType: string, handlerOption?: string, requiredOrgs?: string[]): Promise<void> {
 
 	const gatewayObj = getGatewayObject(gatewayName);
 	const gateway = gatewayObj.gateway;
@@ -393,6 +393,10 @@ export async function performGatewayTransaction(gatewayName: string, contractNam
 	// Submit/evaluate transaction
 	try {
 		const transaction: Transaction = contract.createTransaction(func);
+		if (requiredOrgs) {
+			transaction.setEndorsingOrganizations(...requiredOrgs);
+		}
+
 		let resultBuffer: Buffer;
 		if (submit) {
 			resultBuffer = await transaction.submit(...funcArgs);

--- a/test/ts-scenario/steps/lib/utility/clientUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/clientUtils.ts
@@ -125,6 +125,10 @@ export async function buildChannelRequest(requestName: string, contractName: str
 		// centralize the endorsement operation, including the endorsement results.
 		// Proposals must be built from channel and chaincode name
 		const endorsement: Endorsement = channel.newEndorsement(contractName);
+
+		// ---- setup DISCOVERY
+		endorsement.setNoPrivateReads(true);
+		endorsement.addCollectionInterest('_implicit_org_Org1MSP');
 		const discovery: DiscoveryService = channel.newDiscoveryService('mydiscovery');
 		const discoverer: Discoverer = client.newDiscoverer('peer1-discovery');
 

--- a/test/ts-scenario/steps/network-model.ts
+++ b/test/ts-scenario/steps/network-model.ts
@@ -38,6 +38,10 @@ Given(/^I have a (.+?) backed gateway named (.+?) with discovery set to (.+?) fo
 	}
 });
 
+When(/^I use the discovery gateway named (.+?) to (.+?) a transaction with args (.+?) for contract (.+?) instantiated on channel (.+?) using requiredOrgs (.+?)$/, { timeout: Constants.STEP_MED as number }, async (gatewayName: string, txnType: string, txnArgs: string, ccName: string, channelName: string, requiredOrgs: string) => {
+	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, '', txnArgs, txnType, '', JSON.parse(requiredOrgs));
+});
+
 When(/^I use the discovery gateway named (.+?) to (.+?) a transaction with args (.+?) for contract (.+?) instantiated on channel (.+?) using collection (.+?)$/, { timeout: Constants.STEP_MED as number }, async (gatewayName: string, txnType: string, txnArgs: string, ccName: string, channelName: string, collectionName: string) => {
 	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, collectionName, txnArgs, txnType);
 });


### PR DESCRIPTION
This PR will cherry pick
FABN-1560 add disconnected peer to channel (#288)
FABN-1564 Enhance subjectDN extensibility (#264)
FABN-1596 add noPrivateReads (#293)
FABN-1601 discovery required organizations (#291)
FABN-1607 Allow future startBlocks on EventService (#286)
FABN-1608 remove error message from discovery (#289)
FABN-1609 close client in gateway disconnect (#287)
FABN-1610 Allow more detailed protos.ChaincodeID (#292) 
FABN-1611 Blockdecoder needs kv_reads array (#297)