### PR TITLE
FABN-1621 Add typescript defs for getChannelCapabilities

### DIFF
--- a/fabric-client/types/index.d.ts
+++ b/fabric-client/types/index.d.ts
@@ -189,11 +189,11 @@ declare namespace Client { // tslint:disable-line:no-namespace
 		public getChannelEventHub(name: string): ChannelEventHub;
 		public getChannelEventHubsForOrg(mspid?: string): ChannelEventHub[];
 		public getPeersForOrg(mspid?: string): ChannelPeer[];
-
 		public getGenesisBlock(request?: OrdererRequest): Promise<Block>;
 
 		public joinChannel(request: JoinChannelRequest, timeout?: number): Promise<ProposalResponse[]>;
 		public getChannelConfig(target?: string | Peer, timeout?: number): Promise<any>;
+		public getChannelCapabilities(configEnvelope: any): string[];
 		public getChannelConfigFromOrderer(): Promise<any>;
 		public loadConfigUpdate(configUpdateBytes: Buffer): any;
 		public loadConfigEnvelope(configEnvelope: any): any;


### PR DESCRIPTION
Add the Channel.getChannelCapabilities() def to the typescript index.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>