### PR TITLE
FABN-1621 getChannelCapabilities handle only valid envelope

### DIFF
--- a/fabric-client/lib/Channel.js
+++ b/fabric-client/lib/Channel.js
@@ -1814,10 +1814,33 @@ const Channel = class {
 	 * @returns {String[]} An array of strings with this channels capablities
 	 */
 	getChannelCapabilities(configEnvelope) {
-		const _capabilities = _commonConfigurationProto.Capabilities.decode(configEnvelope.config.channel_group.values.map.Capabilities.value.value);
-		const capabilities = _capabilities.capabilities.map;
-		const keys = Object.keys(capabilities);
+		const method = 'getChannelCapabilities';
+		logger.debug('%s - start', method);
+		let keys = [];
+		if (
+			configEnvelope &&
+			configEnvelope.config &&
+			configEnvelope.config.channel_group
+		) {
+			if (
+				configEnvelope.config.channel_group.values &&
+				configEnvelope.config.channel_group.values.map &&
+				configEnvelope.config.channel_group.values.map.Capabilities
+			) {
+				const _capabilities = _commonConfigurationProto.Capabilities.decode(
+					configEnvelope.config.channel_group.values.map.Capabilities.value.value
+				);
+				const capabilities = _capabilities.capabilities.map;
+				keys = Object.keys(capabilities);
+			} else {
+				logger.debug('%s - capabilities not found', method);
+			}
+		} else {
+			logger.debug('%s - invalid config envelope', method);
+			throw Error('Invalid ConfigEnvelope');
+		}
 
+		logger.debug('%s - end %s', method, keys);
 		return keys;
 	}
 

--- a/fabric-client/test/Channel.js
+++ b/fabric-client/test/Channel.js
@@ -1460,14 +1460,27 @@ describe('Channel', () => {
 	describe('#getChannelConfig', () => {});
 
 	describe('#getChannelCapabilities', () => {
-		const block = commonProto.Block.decode(configBlock);
-		const envelope = commonProto.Envelope.decode(block.data.data[0]);
-		const payload = commonProto.Payload.decode(envelope.payload);
-
-		const configEnvelope = configtxProto.ConfigEnvelope.decode(payload.data);
-
 		it('should run', () => {
+			const block = commonProto.Block.decode(configBlock);
+			const envelope = commonProto.Envelope.decode(block.data.data[0]);
+			const payload = commonProto.Payload.decode(envelope.payload);
+			const configEnvelope = configtxProto.ConfigEnvelope.decode(payload.data);
 			channel.getChannelCapabilities(configEnvelope).should.deep.equal(['V1_1']);
+		});
+
+		it('should run with no capabilities', () => {
+			const block = commonProto.Block.decode(configBlock);
+			const envelope = commonProto.Envelope.decode(block.data.data[0]);
+			const payload = commonProto.Payload.decode(envelope.payload);
+			const configEnvelope = configtxProto.ConfigEnvelope.decode(payload.data);
+			delete configEnvelope.config.channel_group.values.map.Capabilities;
+			channel.getChannelCapabilities(configEnvelope).should.deep.equal([]);
+		});
+
+		it('should throw an error if missing config envelope', () => {
+			(() => {
+				channel.getChannelCapabilities();
+			}).should.throw(Error, 'Invalid ConfigEnvelope');
 		});
 	});
 


### PR DESCRIPTION
The method must handle cases where configs do not have the
Capabilities and throw an error if the input is not a valid
config envelope.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>