### PR TITLE
FABN-1629 Set release-2.2 to snapshots

### DIFF
--- a/fabric-ca-client/package.json
+++ b/fabric-ca-client/package.json
@@ -5,7 +5,7 @@
     "hyperledger",
     "blockchain"
   ],
-  "version": "2.2.2",
+  "version": "2.2.3-snapshot",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --recursive  -t 10000"

--- a/fabric-common/package.json
+++ b/fabric-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fabric-common",
-	"version": "2.2.2",
+	"version": "2.2.3-snapshot",
 	"description": "This package encapsulates the common code used by the `fabric-ca-client`, `fabric-network` packages.",
 	"keywords": [
 		"blockchain",

--- a/fabric-network/package.json
+++ b/fabric-network/package.json
@@ -5,7 +5,7 @@
     "hyperledger",
     "blockchain"
   ],
-  "version": "2.2.2",
+  "version": "2.2.3-snapshot",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric-protos",
-  "version": "2.2.2",
+  "version": "2.2.3-snapshot",
   "description": "Protocol Buffer files and generated JavaScript classes for Hyperledger Fabric",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fabric-sdk-node",
-  "version": "2.2.2",
-  "tag": "latest",
+  "version": "2.2.3-snapshot",
+  "tag": "unstable-2.2",
   "main": "index.js",
   "private": true,
   "repository": {


### PR DESCRIPTION
Set the package.jsons to publish snapshots for
2.2.3-snapshot package and unstable-2.2 tag

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>