### PR TITLE
FABN-1617: Don't publish development configuration in fabric-network (release-2.2)

### DIFF
--- a/fabric-network/.npmignore
+++ b/fabric-network/.npmignore
@@ -16,3 +16,6 @@ npm-debug.log
 
 # Source files #
 /src
+
+tsconfig.json
+/.*


### PR DESCRIPTION
Specifically ignore tsconfig.json and .eslintignore.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>