### PR TITLE
FABN-1632 Enhance discovery orderer failover

### DIFF
--- a/fabric-client/lib/Channel.js
+++ b/fabric-client/lib/Channel.js
@@ -1431,6 +1431,7 @@ const Channel = class {
 			if (orderer.getUrl() === url) {
 				logger.debug('%s - found existing orderer %s', method, url);
 				found = orderer;
+				found.connected = true; // force a reconnect
 			}
 		});
 		if (!found) {

--- a/fabric-client/lib/Orderer.js
+++ b/fabric-client/lib/Orderer.js
@@ -82,6 +82,7 @@ class Orderer extends Remote {
 		logger.debug('Orderer.const - url: %s timeout: %s', url, this._request_timeout);
 		this._createClients();
 		this._sendDeliverConnect = false;
+		this.connected = true;
 	}
 
 	_createClients() {
@@ -152,10 +153,12 @@ class Orderer extends Remote {
 			const broadcast_timeout = setTimeout(() => {
 				logger.error('sendBroadcast - timed out after:%s', rto);
 				broadcast.end();
+				self.connected = false;
 				return reject(new Error(error_msg));
 			}, rto);
 
 			broadcast.on('data', (response) => {
+				self.connected = true;
 				logger.debug('sendBroadcast - on data response: %j', response);
 				broadcast.end();
 				if (response && response.info) {
@@ -182,6 +185,7 @@ class Orderer extends Remote {
 				if (err && err.code) {
 					if (err.code === 14) {
 						logger.error('sendBroadcast - on error: %j', err.stack ? err.stack : err);
+						self.connected = false;
 						return reject(new Error('SERVICE_UNAVAILABLE'));
 					}
 				}

--- a/test/unit/commit-handler.js
+++ b/test/unit/commit-handler.js
@@ -116,7 +116,7 @@ test('\n\n ** BasicCommitHandler - test **\n\n', async (t) => {
 		t.fail('Should not be here - looking for connect deadline');
 	} catch (error) {
 		if (error instanceof Error) {
-			if (error.toString().indexOf('Failed to connect before the deadline URL:grpc://somehost.com:6666') > -1) {
+			if (error.toString().indexOf('Failed to connect before the deadline') > -1) {
 				t.pass('This should fail with ' + error.toString());
 			} else {
 				t.fail('Did not get deadline error - got ' + error.toString());


### PR DESCRIPTION
Randomize the discovered orderer list for load balance.
Have the discovery commit handler skip orderers that are not
on-line to avoid delays in using non responding orderers.
Orderers will attempt a reconnect on the discovery refresh cycle.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>