### PR TITLE
FABN-1632 improve commit failover

### DIFF
--- a/fabric-common/lib/DiscoveryService.js
+++ b/fabric-common/lib/DiscoveryService.js
@@ -591,12 +591,12 @@ class DiscoveryService extends ServiceAction {
 		const end_point = this.client.newEndpoint(this._buildOptions(address, url, host, msp_id));
 		try {
 			// first check to see if orderer is already on this channel
-			let same = false;
+			let same;
 			const channelOrderers = this.channel.getCommitters();
 			for (const channelOrderer of channelOrderers) {
 				logger.debug('%s - checking %s', method, channelOrderer);
 				if (channelOrderer.endpoint && channelOrderer.endpoint.url === url) {
-					same = true;
+					same = channelOrderer;
 					break;
 				}
 			}
@@ -604,6 +604,7 @@ class DiscoveryService extends ServiceAction {
 				await orderer.connect(end_point);
 				this.channel.addCommitter(orderer);
 			} else {
+				await same.checkConnection();
 				logger.debug('%s - %s - already added to this channel', method, orderer);
 			}
 		} catch (error) {

--- a/fabric-common/lib/ServiceEndpoint.js
+++ b/fabric-common/lib/ServiceEndpoint.js
@@ -142,12 +142,13 @@ class ServiceEndpoint {
 
 	/**
 	 * Check the connection status
+	 * @param {boolean} [reset] - Optional, attempt to reconnect if endpoint is not connected
 	 */
-	async checkConnection() {
+	async checkConnection(reset = true) {
 		const method = `checkConnection[${this.name}]`;
 		logger.debug('%s - start - connected:%s', method, this.connected);
 
-		if (this.connected) {
+		if (reset && this.connected) {
 			try {
 				await this.waitForReady();
 			} catch (error) {
@@ -155,7 +156,7 @@ class ServiceEndpoint {
 			}
 		}
 
-		if (!this.connected && this.isConnectable()) {
+		if (reset && !this.connected && this.isConnectable()) {
 			try {
 				await this.resetConnection();
 			} catch (error) {

--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -551,6 +551,12 @@ describe('DiscoveryService', () => {
 			await discovery._buildOrderers(orderers);
 			sinon.assert.calledWith(FakeLogger.debug, '_buildOrderers[mydiscovery] - orderer msp:OrdererMSP');
 		});
+		it('should remove old orderers from channel', async () => {
+			should.equal(channel.getCommitters().length, 0);
+			await discovery._buildOrderers(orderers); // add one orderer
+			sinon.assert.calledWith(FakeLogger.debug, '_buildOrderers[mydiscovery] - orderer msp:OrdererMSP');
+			should.equal(channel.getCommitters().length, 1);
+		});
 	});
 
 	describe('#_buildOrderer', () => {

--- a/fabric-common/test/ServiceEndpoint.js
+++ b/fabric-common/test/ServiceEndpoint.js
@@ -121,6 +121,18 @@ describe('ServiceEndpoint', () => {
 	});
 
 	describe('#checkConnection', () => {
+		it('should resolve false if not connected', async () => {
+			serviceEndpoint.connected = false;
+			sinon.stub(serviceEndpoint, 'waitForReady').resolves(true);
+			sinon.stub(serviceEndpoint, 'resetConnection').resolves(true);
+			sinon.stub(serviceEndpoint, 'isConnectable').resolves(true);
+
+			const result = await serviceEndpoint.checkConnection(false);
+			should.equal(result, false);
+			sinon.assert.notCalled(serviceEndpoint.waitForReady);
+			sinon.assert.notCalled(serviceEndpoint.resetConnection);
+			sinon.assert.notCalled(serviceEndpoint.isConnectable);
+		});
 		it('should resolve true if connected', async () => {
 			serviceEndpoint.connected = true;
 			sinon.stub(serviceEndpoint, 'waitForReady').resolves(true);


### PR DESCRIPTION
Randomize the discovered orderer list. On a first pass
through the list, check if the orderer is connected before sending.
if sending fails, try the next connected orderer. If sending fails
on the first pass, try making another pass through the list, this time
attempt to reconnect the orderer before using.
The discovered list will be refreshed and reconnect by default after
five minutes.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>