### PR TITLE
FABN-1624 handle discovery peer connection error (#327)

### DIFF
--- a/fabric-network/src/network.ts
+++ b/fabric-network/src/network.ts
@@ -325,7 +325,7 @@ export class NetworkImpl implements Network {
 			const discoverers = [];
 			for (const peer of targets) {
 				const discoverer = this.channel.client.newDiscoverer(peer.name, peer.mspid);
-				await discoverer.connect(peer.endpoint);
+				discoverer.setEndpoint(peer.endpoint);
 				discoverers.push(discoverer);
 			}
 			this.discoveryService = this.channel.newDiscoveryService(this.channel.name);


### PR DESCRIPTION
Connection errors are not being handled during the assignment
phase when a network is beingh initialized. Postpone the connection
check until discovery service needs the connection.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>