### PR TITLE
FABN-1649: Tag stable releases of fabric-client as latest

### DIFF
--- a/scripts/ci_scripts/azurePublishNpmPackages.sh
+++ b/scripts/ci_scripts/azurePublishNpmPackages.sh
@@ -17,6 +17,10 @@ publishAllPackages() {
     loadPackageInfo
     forEachNodePackage preparePackage
     forEachNodePackage publishPackage
+
+    if isStableRelease; then
+        (cd fabric-client && tagPackage latest)
+    fi
 }
 
 loadPackageInfo() {
@@ -126,6 +130,13 @@ publishPackage() {
 npmPublish() {
     echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > '.npmrc'
     npm publish --tag "${RELEASE_TAG}"
+}
+
+tagPackage() {
+    local packageName packageVersion
+    packageName=$(readPackageProperty name)
+    packageVersion=$(readPackageProperty version)
+    npm dist-tag add "${packageName}@${packageVersion}" "$1"
 }
 
 (cd "${PROJECT_DIR}" && publishAllPackages)


### PR DESCRIPTION
v2 packages are tagged as latest so all v1.4 packages are now tagged as latest-1.4. However, there is no v2 fabric-client so the latest tag has been orphaned. To avoid this, explicitly tag stable releases of fabric-client as latest.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>