### PR TITLE
FABN-1650: Info logs for handled errors in NetworkConfig (release-2.2)

### DIFF
--- a/fabric-network/src/impl/ccp/networkconfig.ts
+++ b/fabric-network/src/impl/ccp/networkconfig.ts
@@ -78,14 +78,14 @@ async function buildOrderer(client: Client, ordererName: string, ordererConfig: 
 	const mspid: string = ordererConfig.mspid;
 	const options = await buildOptions(ordererConfig);
 	const endpoint = client.newEndpoint(options);
+	logger.debug('%s - about to connect to committer %s url:%s mspid:%s', method, ordererName, ordererConfig.url, mspid);
+	// since the client saves the orderer, no need to save here
+	const orderer = client.getCommitter(ordererName, mspid);
 	try {
-		logger.debug('%s - about to connect to committer %s url:%s mspid:%s', method, ordererName, ordererConfig.url, mspid);
-		// since the client saves the orderer, no need to save here
-		const orderer = client.getCommitter(ordererName, mspid);
 		await orderer.connect(endpoint);
 		logger.debug('%s - connected to committer %s url:%s', method, ordererName, ordererConfig.url);
 	} catch (error) {
-		logger.error('%s - Unable to connect to the committer %s due to %s', method, ordererName, error);
+		logger.info('%s - Unable to connect to the committer %s due to %s', method, ordererName, error);
 	}
 }
 
@@ -96,14 +96,14 @@ async function buildPeer(client: Client, peerName: string, peerConfig: any, conf
 	const mspid = findPeerMspid(peerName, config);
 	const options = await buildOptions(peerConfig);
 	const endpoint = client.newEndpoint(options);
+	logger.debug('%s - about to connect to endorser %s url:%s mspid:%s', method, peerName, peerConfig.url, mspid);
+	// since this adds to the clients list, no need to save
+	const peer = client.getEndorser(peerName, mspid);
 	try {
-		logger.debug('%s - about to connect to endorser %s url:%s mspid:%s', method, peerName, peerConfig.url, mspid);
-		// since this adds to the clients list, no need to save
-		const peer = client.getEndorser(peerName, mspid);
 		await peer.connect(endpoint);
 		logger.debug('%s - connected to endorser %s url:%s', method, peerName, peerConfig.url);
 	} catch (error) {
-		logger.error('%s - Unable to connect to the endorser %s due to %s', method, peerName, error);
+		logger.info('%s - Unable to connect to the endorser %s due to %s', method, peerName, error);
 	}
 }
 

--- a/fabric-network/test/impl/ccp/networkconfig.js
+++ b/fabric-network/test/impl/ccp/networkconfig.js
@@ -17,7 +17,6 @@ const Endpoint = require('fabric-common/lib/Endpoint');
 const NetworkConfig = rewire('fabric-network/lib/impl/ccp/networkconfig');
 
 describe('NetworkConfig', () => {
-	let sandbox;
 	let buildChannel;
 	let buildPeer;
 	let buildOrderer;
@@ -37,12 +36,11 @@ describe('NetworkConfig', () => {
 
 	beforeEach(() => {
 		revert = [];
-		sandbox = sinon.createSandbox();
-		endorser = sandbox.createStubInstance(Endorser);
-		committer = sandbox.createStubInstance(Committer);
-		endorser.connect = sandbox.stub().rejects(Error('BAD'));
-		committer.connect = sandbox.stub().rejects(Error('BAD'));
-		endpoint = sandbox.createStubInstance(Endpoint);
+		endorser = sinon.createStubInstance(Endorser);
+		committer = sinon.createStubInstance(Committer);
+		endorser.connect = sinon.stub().rejects(Error('BAD'));
+		committer.connect = sinon.stub().rejects(Error('BAD'));
+		endpoint = sinon.createStubInstance(Endpoint);
 		client = new Client('myclient');
 		client.getCommitter = sinon.stub().returns(committer);
 		client.getEndorser = sinon.stub().returns(endorser);
@@ -56,14 +54,11 @@ describe('NetworkConfig', () => {
 		getPEMfromConfig = NetworkConfig.__get__('getPEMfromConfig');
 
 		FakeLogger = {
-			debug: () => {
-			},
-			error: () => {
-			},
-			warn: () => {
-			}
+			debug: sinon.fake(),
+			error: sinon.fake(),
+			warn: sinon.fake(),
+			info: sinon.fake()
 		};
-		sandbox.stub(FakeLogger);
 		revert.push(NetworkConfig.__set__('logger', FakeLogger));
 
 		const fakeFS = {
@@ -76,7 +71,7 @@ describe('NetworkConfig', () => {
 
 	afterEach(() => {
 		revert.forEach((f) => f());
-		sandbox.reset();
+		sinon.restore();
 	});
 
 	const config = {
@@ -220,11 +215,11 @@ describe('NetworkConfig', () => {
 		it('should run buildOrderer with params and bad connect', async () => {
 			revert.push(NetworkConfig.__set__('buildOptions', sinon.stub().returns({url: 'url'})));
 			await buildOrderer(client, 'name', {url: 'url'});
-			sinon.assert.calledWith(FakeLogger.error, '%s - Unable to connect to the committer %s due to %s');
+			sinon.assert.calledWith(FakeLogger.info, '%s - Unable to connect to the committer %s due to %s');
 		});
 		it('should run buildOrderer with params and good connect', async () => {
 			revert.push(NetworkConfig.__set__('buildOptions', sinon.stub().returns({url: 'url'})));
-			committer.connect = sandbox.stub().resolves('GOOD');
+			committer.connect = sinon.stub().resolves('GOOD');
 			await buildOrderer(client, 'name', {url: 'url'}, {});
 			sinon.assert.calledWith(FakeLogger.debug, '%s - connected to committer %s url:%s');
 		});
@@ -235,12 +230,12 @@ describe('NetworkConfig', () => {
 			revert.push(NetworkConfig.__set__('findPeerMspid', sinon.stub().returns('mspid')));
 			revert.push(NetworkConfig.__set__('buildOptions', sinon.stub().returns({url: 'url'})));
 			await buildPeer(client, 'name', {url: 'url'}, {});
-			sinon.assert.calledWith(FakeLogger.error, '%s - Unable to connect to the endorser %s due to %s');
+			sinon.assert.calledWith(FakeLogger.info, '%s - Unable to connect to the endorser %s due to %s');
 		});
 		it('should run buildPeer with params and good connect', async () => {
 			revert.push(NetworkConfig.__set__('findPeerMspid', sinon.stub().returns('mspid')));
 			revert.push(NetworkConfig.__set__('buildOptions', sinon.stub().returns({url: 'url'})));
-			endorser.connect = sandbox.stub().resolves('GOOD');
+			endorser.connect = sinon.stub().resolves('GOOD');
 			await buildPeer(client, 'name', {url: 'url'}, {});
 			sinon.assert.calledWith(FakeLogger.debug, '%s - connected to endorser %s url:%s');
 		});


### PR DESCRIPTION
Cherry-pick of change from master branch.

Errors are thrown on a failure to connect to a peer or orderer during parsing of network config but, since this is an allowable condition that may occur if a node is temporarily unavailable, the code swallows this error and continues as normal. These events were generating error logs, which are confusing for users since no error condition has occurred. These error log messages are now info messages.