### PR TITLE
FABN-1598 Check discovery endorsements (#314)

### DIFF
--- a/fabric-common/lib/DiscoveryHandler.js
+++ b/fabric-common/lib/DiscoveryHandler.js
@@ -11,6 +11,7 @@ const Long = require('long');
 const settle = require('promise-settle');
 
 const ServiceHandler = require('./ServiceHandler.js');
+const fabproto6 = require('fabric-protos');
 const {randomize, checkParameter, getLogger, getConfigSetting, convertToLong} = require('./Utils.js');
 
 const logger = getLogger(TYPE);
@@ -261,24 +262,35 @@ class DiscoveryHandler extends ServiceHandler {
 		// always randomize the layouts
 		endorsement_plan.layouts = this._getRandom(endorsement_plan.layouts);
 
+		let matchError = false;
+
 		// loop through the layouts trying to complete one successfully
 		for (const layout_index in endorsement_plan.layouts) {
 			logger.debug('%s - starting layout plan %s', method, layout_index);
 			const layout_results = await this._endorse_layout(layout_index, endorsement_plan, proposal, timeout);
 			// if this layout is successful then we are done
 			if (layout_results.success) {
-				logger.debug('%s - layout plan %s completed successfully', method, layout_index);
-				results.endorsements = layout_results.endorsements;
-				results.success = true;
-				break;
-			} else {
-				logger.debug('%s - layout plan %s did not complete successfully, try another layout plan', method, layout_index);
-				results.failed_endorsements = results.failed_endorsements.concat(layout_results.endorsements);
+				// make sure all responses have the same endorsement read/write set
+				if (this.compareProposalResponseResults(layout_results.endorsements)) {
+					logger.debug('%s - layout plan %s completed successfully', method, layout_index);
+					results.endorsements = layout_results.endorsements;
+					results.success = true;
+					break;
+				} else {
+					matchError = true;
+				}
 			}
+			logger.debug('%s - layout plan %s did not complete successfully', method, layout_index);
+			results.failed_endorsements = results.failed_endorsements.concat(layout_results.endorsements);
 		}
 
 		if (!results.success) {
-			const error = new Error('Endorsement has failed');
+			let error;
+			if (matchError) {
+				error =  new Error('Peer endorsements do not match');
+			} else {
+				error = new Error('Endorsement has failed');
+			}
 			error.endorsements = results.failed_endorsements;
 			return [error];
 		}
@@ -668,6 +680,58 @@ class DiscoveryHandler extends ServiceHandler {
 		}
 
 		return result;
+	}
+
+	// internal utility method to decode and get the write set from an endorsement
+	_getProposalResponseResults(proposaResponse = checkParameter('proposalResponse')) {
+		if (!proposaResponse.payload) {
+			throw new Error('Parameter must be a ProposalResponse Object');
+		}
+		const payload = fabproto6.protos.ProposalResponsePayload.decode(proposaResponse.payload);
+		const extension = fabproto6.protos.ChaincodeAction.decode(payload.extension);
+
+		return extension.results;
+	}
+
+	/**
+	 * Utility method to examine a set of proposals to check they contain
+	 * the same endorsement result write sets.
+	 * This will validate that the endorsing peers all agree on the result
+	 * of the chaincode execution.
+	 *
+	 * @param {ProposalResponse[]} proposalResponses - The proposal responses
+	 * from all endorsing peers
+	 * @returns {boolean} True when all proposals compare equally, false otherwise.
+	 */
+	compareProposalResponseResults(proposalResponses = checkParameter('proposalResponses')) {
+		const method = `compareProposalResponseResults[${this.chaincodeId}]`;
+		logger.debug('%s - start', method);
+
+		if (!Array.isArray(proposalResponses)) {
+			throw new Error('proposalResponses must be an array, typeof=' + typeof proposalResponses);
+		}
+		if (proposalResponses.length === 0) {
+			throw new Error('proposalResponses is empty');
+		}
+
+		if (proposalResponses.some((response) => response instanceof Error)) {
+
+			return false;
+		}
+
+		const first_one = this._getProposalResponseResults(proposalResponses[0]);
+		for (let i = 1; i < proposalResponses.length; i++) {
+			const next_one = this._getProposalResponseResults(proposalResponses[i]);
+			if (next_one.equals(first_one)) {
+				logger.debug('%s - read/writes result sets match index=%s', method, i);
+			} else {
+				logger.error('%s - read/writes result sets do not match index=%s', method, i);
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	toString() {

--- a/fabric-common/lib/Proposal.js
+++ b/fabric-common/lib/Proposal.js
@@ -395,6 +395,7 @@ message Endorsement {
 		const {handler, targets, requestTimeout} = request;
 		logger.debug('%s - requestTimeout %s', method, requestTimeout);
 		const signedEnvelope = this.getSignedProposal();
+
 		this._proposalResponses = [];
 		this._proposalErrors = [];
 		this._queryResults = [];
@@ -566,65 +567,12 @@ message Endorsement {
 	}
 
 	/**
-	 * Utility method to examine a set of proposals to check they contain
-	 * the same endorsement result write sets.
-	 * This will validate that the endorsing peers all agree on the result
-	 * of the chaincode execution.
-	 *
-	 * @param {ProposalResponse[]} proposalResponses - The proposal responses
-	 * from all endorsing peers
-	 * @returns {boolean} True when all proposals compare equally, false otherwise.
-	 */
-	compareProposalResponseResults(proposalResponses = checkParameter('proposalResponses')) {
-		const method = `compareProposalResponseResults[${this.chaincodeId}]`;
-		logger.debug('%s - start', method);
-
-		if (!Array.isArray(proposalResponses)) {
-			throw new Error('proposalResponses must be an array, typeof=' + typeof proposalResponses);
-		}
-		if (proposalResponses.length === 0) {
-			throw new Error('proposalResponses is empty');
-		}
-
-		if (proposalResponses.some((response) => response instanceof Error)) {
-
-			return false;
-		}
-
-		const first_one = _getProposalResponseResults(proposalResponses[0]);
-		for (let i = 1; i < proposalResponses.length; i++) {
-			const next_one = _getProposalResponseResults(proposalResponses[i]);
-			if (next_one.equals(first_one)) {
-				logger.debug('%s - read/writes result sets match index=%s', method, i);
-			} else {
-				logger.error('%s - read/writes result sets do not match index=%s', method, i);
-
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/**
 	 * return a printable representation of this object
 	 */
 	toString() {
 
 		return `Proposal: {chaincodeId: ${this.chaincodeId}, channel: ${this.channel.name}}`;
 	}
-}
-
-// internal utility method to decode and get the write set
-// from a proposal response
-function _getProposalResponseResults(proposaResponse = checkParameter('proposalResponse')) {
-	if (!proposaResponse.payload) {
-		throw new Error('Parameter must be a ProposalResponse Object');
-	}
-	const payload = fabproto6.protos.ProposalResponsePayload.decode(proposaResponse.payload);
-	const extension = fabproto6.protos.ChaincodeAction.decode(payload.extension);
-
-	return extension.results;
 }
 
 module.exports = Proposal;

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -266,6 +266,7 @@ describe('Proposal', () => {
 			proposal.build(idx);
 			proposal.sign(idx);
 			sinon.stub(endorser, 'sendProposal').resolves({response: {status: 200}});
+			proposal.compareProposalResponseResults = sinon.stub().returns(true);
 			const results = await proposal.send({targets: [endorser]});
 			should.exist(results.responses);
 			if (results.responses && results.responses[0]) {
@@ -303,6 +304,7 @@ describe('Proposal', () => {
 			proposal.build(idx);
 			proposal.sign(idx);
 			sinon.stub(handler, 'endorse').resolves([{response: {status: 200}}]);
+			proposal.compareProposalResponseResults = sinon.stub().returns(true);
 			const results = await proposal.send({handler: handler});
 			should.exist(results.responses);
 			if (results.responses && results.responses[0]) {
@@ -342,70 +344,6 @@ describe('Proposal', () => {
 			}
 		});
 	});
-
-	describe('#compareProposalResponseResults', () => {
-		it('should require a proposalResponses', () => {
-			(() => {
-				proposal.compareProposalResponseResults();
-			}).should.throw('Missing proposalResponses parameter');
-		});
-		it('should require an array of proposalResponses', () => {
-			(() => {
-				proposal.compareProposalResponseResults('string');
-			}).should.throw('proposalResponses must be an array, typeof=string');
-		});
-		it('should require an array of proposalResponses 2', () => {
-			(() => {
-				proposal.compareProposalResponseResults([]);
-			}).should.throw('proposalResponses is empty');
-		});
-		it('if proposalResponses has any error return false', () => {
-			const proposalResponses = [
-				new Error('proposal error')
-			];
-			const results = proposal.compareProposalResponseResults(proposalResponses);
-			results.should.be.false;
-		});
-		it('if only one proposalResponses return true', () => {
-			const proposalResponses = [
-				{payload: TestUtils.createResponsePayload('result1')}
-			];
-			const results = proposal.compareProposalResponseResults(proposalResponses);
-			results.should.be.true;
-		});
-		it('if two same proposalResponses return true', () => {
-			const proposalResponses = [
-				{payload: TestUtils.createResponsePayload('result1')},
-				{payload: TestUtils.createResponsePayload('result1')}
-			];
-			const results = proposal.compareProposalResponseResults(proposalResponses);
-			results.should.be.true;
-		});
-		it('if two not same proposalResponses return false', () => {
-			const proposalResponses = [
-				{payload: TestUtils.createResponsePayload('result1')},
-				{payload: TestUtils.createResponsePayload('result2')}
-			];
-			const results = proposal.compareProposalResponseResults(proposalResponses);
-			results.should.be.false;
-		});
-	});
-
-	describe('#_getProposalResponseResults', () => {
-		const _getProposalResponseResults = Proposal.__get__('_getProposalResponseResults');
-
-		it('should require a proposalResponse', () => {
-			(() => {
-				_getProposalResponseResults();
-			}).should.throw('Missing proposalResponse parameter');
-		});
-		it('should require a proposalResponse.payload', () => {
-			(() => {
-				_getProposalResponseResults({});
-			}).should.throw('Parameter must be a ProposalResponse Object');
-		});
-	});
-
 
 	describe('#verifyProposalResponse', () => {
 		it('should require proposalResponse', () => {


### PR DESCRIPTION
Have the discovery handler check the endorsement responses
to see if the read/write sets are all the same, try another
layout when not the same.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>