### PR TITLE
FABN-1637: Build and test with Node 14 (master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ test/fixtures/fabricca/test*.*
 test/ts-fixtures/crypto-material/crypto-config/
 test/ts-fixtures/crypto-material/channel-config/
 test/ts-fixtures/crypto-material/config-base/twoorgs.genesis.block
+test/ts-fixtures/crypto-material/config-base/threeorgs.genesis.block
 # - generated typescript files
 test/typescript/**/*.js
 test/typescript/**/*.js.map

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,8 @@ stages:
             versionSpec: '10.x'
           Node12:
             versionSpec: '12.x'
+          Node14:
+            versionSpec: '14.x'
       steps:
         - task: NodeTool@0
           inputs:

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ The following tables show versions of Fabric, Node and other dependencies that a
 |     | Tested | Supported |
 | --- | ------ | --------- |
 | **Fabric** | 2.2 | 2.2 |
-| **Node** | 10, 12 | 10.13+, 12.13+ |
+| **Node** | 10, 12, 14 | 10 LTS, 12 LTS, 14 LTS |
 | **Platform** | Ubuntu 18.04 | |
 
 

--- a/fabric-ca-client/package.json
+++ b/fabric-ca-client/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/hyperledger/fabric-sdk-node"
   },
   "engines": {
-    "node": "^10.15.3 || ^12.13.1",
+    "node": "^10.15.3 || ^12.13.1 || ^14.13.1",
     "npm": "^6.4.1"
   },
   "types": "./types/index.d.ts",

--- a/fabric-common/package.json
+++ b/fabric-common/package.json
@@ -20,7 +20,7 @@
 		"test": "nyc mocha --exclude 'test/data/**/*.js' --recursive  -t 10000"
 	},
 	"engines": {
-		"node": "^10.15.3 || ^12.13.1",
+		"node": "^10.15.3 || ^12.13.1 || ^14.13.1",
 		"npm": "^6.4.1"
 	},
 	"types": "./types/index.d.ts",

--- a/fabric-network/package.json
+++ b/fabric-network/package.json
@@ -20,7 +20,7 @@
     "test": "nyc mocha --recursive  -t 10000"
   },
   "engines": {
-    "node": "^10.15.3 || ^12.13.1",
+    "node": "^10.15.3 || ^12.13.1 || ^14.13.1",
     "npm": "^6.4.1"
   },
   "types": "./types/index.d.ts",

--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/hyperledger/fabric-sdk-node"
   },
   "engines": {
-    "node": "^8.9.0 || ^10.15.3 || ^12.13.1",
-    "npm": "^5.5.1 || ^6.4.1"
+    "node": "^10.15.3 || ^12.13.1 || ^14.13.1",
+    "npm": "^6.4.1"
   },
   "keywords": [
     "hyperledger",


### PR DESCRIPTION
Indicate that Node v14 LTS is tested and supported in API documentation.