### PR TITLE
FABN-1653: Fix snapshot publishing for multi-digit versions (release-1.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fabric-sdk-node",
-  "version": "1.4.13",
-  "tag": "latest-1.4",
+  "version": "1.4.14-snapshot",
+  "tag": "unstable-1.4",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/scripts/ci_scripts/azurePublishNpmPackages.sh
+++ b/scripts/ci_scripts/azurePublishNpmPackages.sh
@@ -96,7 +96,7 @@ readNextUnstablePackageVersion() {
         ver=$NF
         sub(/\".*/, "", ver)
         print ver+1
-    }' | sort -r | head -1)
+    }' | tail -1)
     echo "${RELEASE_VERSION}.${nextVersion:-1}"
 }
 
@@ -124,6 +124,7 @@ publishPackage() {
         echoLog "Successfully published ${RELEASE_TAG} tag of $1"
     else
         echoLog "FAILED to publish ${RELEASE_TAG} of $1"
+        false
     fi
 }
 


### PR DESCRIPTION
Also have publish script exit with a failure status if a publish fails.