### PR TITLE
FABN-1646 Support multiple submits (#361)

### DIFF
--- a/fabric-common/lib/Channel.js
+++ b/fabric-common/lib/Channel.js
@@ -411,13 +411,13 @@ const Channel = class {
 			if (mspid) {
 				if (remote.mspid === mspid) {
 					results.push(remote);
-					logger.debug(`${method} - ${type} mspid matched, added ${remote.name}`);
+					logger.debug(`${method} - ${type} mspid matched, added ${remote.name} connected: ${remote.connected}`);
 				} else {
 					logger.debug(`${method} - ${type} mspid not matched, not added ${remote.name} - ${remote.mspid}`);
 				}
 			} else {
 				results.push(remote);
-				logger.debug(`${method} - ${type} added ${remote.name}`);
+				logger.debug(`${method} - ${type} added ${remote.name} connected: ${remote.connected}`);
 			}
 		}
 

--- a/fabric-common/lib/Endorser.js
+++ b/fabric-common/lib/Endorser.js
@@ -44,6 +44,66 @@ class Endorser extends ServiceEndpoint {
 
 		this.type = TYPE;
 		this.serviceClass = fabproto6.protos.Endorser;
+
+		this.chaincodes = [];
+	}
+
+	/**
+	 * Add a chaincode name or ID to this Peer. This will aid in
+	 * determining if this peer should be used to endorse.
+	 *
+	 * This will primarily be used by the {@link DiscoveryService} when
+	 * adding peers to a channel based on the discovery results
+	 *
+	 * @param {String} chaincodeName
+	 */
+	addChaincode(chaincodeName) {
+		const method = `addChaincode[${this.name}]`;
+
+		if (chaincodeName) {
+			if (this.hasChaincode(chaincodeName, true)) {
+				logger.debug(`${method} - chaincode already exist on this endorser - ${chaincodeName}`);
+			} else {
+				this.chaincodes.push(chaincodeName);
+				logger.debug(`${method} - chaincode added to this endorser - ${chaincodeName}`);
+			}
+		}
+
+		return this;
+	}
+
+	/**
+	 * Check if this peer has the chaincode on it's list.
+	 * If the list is empty then this peer has not been told of it's chaincodes
+	 * and therefore might be running the chaincode in question.
+	 * @param {String} chaincodeName
+	 * @param {boolean} [noMaybe] Optional, default false, if noMaybe is true then
+	 * this method will return true when the peer does not have any chaincodes on
+	 * the list.
+	 */
+	hasChaincode(chaincodeName, noMaybe) {
+		const method = `hasChaincode[${this.name}]`;
+		let result = false;
+
+		if (chaincodeName) {
+			if (this.chaincodes.length === 0 && !noMaybe) {
+				result = true;
+				logger.debug(`${method} - peer has no chaincodes - ${chaincodeName} might be installed`);
+			} else {
+				for (const chaincode of this.chaincodes) {
+					if (chaincodeName === chaincode) {
+						result = true;
+						logger.debug(`${method} - chaincode found on this endorser - ${chaincodeName}`);
+						break;
+					}
+				}
+			}
+		}
+		if (!result) {
+			logger.debug(`${method} - chaincode not found on this endorser - ${chaincodeName}`);
+		}
+
+		return result;
 	}
 
 	/**

--- a/fabric-common/lib/EventService.js
+++ b/fabric-common/lib/EventService.js
@@ -92,6 +92,8 @@ class EventService extends ServiceAction {
 		this.startSpecified = false;
 
 		this.myNumber = count++;
+
+		this.inUse = false;
 	}
 
 	/**
@@ -169,7 +171,9 @@ class EventService extends ServiceAction {
 		} else {
 			logger.debug('%s - no current eventer - not shutting down stream', method);
 		}
+
 		this._closeRunning = false;
+		this.inUse = false;
 
 		logger.debug('%s - end', method);
 	}
@@ -223,6 +227,7 @@ class EventService extends ServiceAction {
 		const method = `build[${this.name}] - #${this.myNumber}`;
 		logger.debug(`${method} - start`);
 
+		this.inUse = true;
 		const {startBlock, endBlock, blockType = FILTERED_BLOCK} = options;
 		this.startBlock = this._checkBlockNum(startBlock);
 		this.endBlock = this._checkBlockNum(endBlock);
@@ -422,7 +427,6 @@ class EventService extends ServiceAction {
 
 			}, requestTimeout);
 
-			logger.debug('%s - create stream based on blockType', method, this.blockType);
 			eventer.setStreamByType(this.blockType);
 
 			// the promise and streams live on and we need
@@ -432,7 +436,7 @@ class EventService extends ServiceAction {
 			const mystreamCount = streamCount++;
 			this.currentStreamNumber = mystreamCount;
 
-			logger.debug('%s - create stream listening callbacks - onData, onEnd, onStatus, onError', method);
+			logger.debug('%s - created stream % based on blockType %s', method, this.currentStreamNumber, this.blockType);
 
 			eventer.stream.on('data', (deliverResponse) => {
 				logger.debug('on.data %s- peer:%s - stream:%s', me, eventer.endpoint.url, mystreamCount);
@@ -607,17 +611,30 @@ class EventService extends ServiceAction {
 	}
 
 	/**
+	 * Use this method to indicate if application has already started using this
+	 * service. The service will have been asked to build the service request
+	 * and will not have commpleted the service startup.
+	 */
+	isInUse() {
+		const method = `isInUse[${this.name}]  - #${this.myNumber}`;
+		logger.debug('%s inUse - %s', method, this.inUse);
+
+		return this.inUse;
+	}
+
+	/**
 	 * Use this method to indicate if this event service has an event endpoint
 	 * {@link Eventer} assigned and the event endpoint has a listening stream
 	 * connected and active.
 	 */
 	isStarted() {
 		const method = `isStarted[${this.name}]  - #${this.myNumber}`;
-		logger.debug('%s - start', method);
 
 		if (this._currentEventer && this._currentEventer.isStreamReady()) {
+			logger.debug('%s - true', method);
 			return true;
 		} else {
+			logger.debug('%s - false', method);
 			return false;
 		}
 	}

--- a/fabric-common/lib/ServiceEndpoint.js
+++ b/fabric-common/lib/ServiceEndpoint.js
@@ -145,7 +145,7 @@ class ServiceEndpoint {
 	 * @param {boolean} [reset] - Optional, attempt to reconnect if endpoint is not connected
 	 */
 	async checkConnection(reset = true) {
-		const method = `checkConnection[${this.name}]`;
+		const method = `checkConnection[${this.type}-${this.name}]`;
 		logger.debug('%s - start - connected:%s', method, this.connected);
 
 		if (reset && this.connected) {
@@ -172,7 +172,7 @@ class ServiceEndpoint {
 	 * Reset the connection
 	 */
 	async resetConnection() {
-		const method = `resetConnection[${this.name}]`;
+		const method = `resetConnection[${this.type}-${this.name}]`;
 		logger.debug('%s - start - connected:%s', method, this.connected);
 
 		this.disconnect(); // clean up possible old service

--- a/fabric-common/test/Endorser.js
+++ b/fabric-common/test/Endorser.js
@@ -43,6 +43,52 @@ describe('Endorser', () => {
 		});
 	});
 
+	describe('#hasChaincode', () => {
+		it('should be false without name', () => {
+			const result = endorser.hasChaincode();
+			result.should.be.false;
+		});
+		it('should be true with name and no chaincodes on peer', () => {
+			const result = endorser.hasChaincode('chaincode');
+			result.should.be.true;
+		});
+		it('should be false with name and no chaincodes on peer using "noMaybe"', () => {
+			const result = endorser.hasChaincode('chaincode', true);
+			result.should.be.false;
+		});
+		it('should be true with name and found', () => {
+			endorser.chaincodes = ['chaincode'];
+			const result = endorser.hasChaincode('chaincode');
+			result.should.be.true;
+		});
+		it('should be true with name and found using "noMaybe"', () => {
+			endorser.chaincodes = ['chaincode'];
+			const result = endorser.hasChaincode('chaincode', true);
+			result.should.be.true;
+		});
+	});
+
+	describe('#addChaincode', () => {
+		it('should run without name', () => {
+			endorser.addChaincode();
+			endorser.chaincodes.should.be.deep.equal([]);
+		});
+		it('should run with name', () => {
+			endorser.addChaincode('chaincode');
+			endorser.chaincodes.should.be.deep.equal(['chaincode']);
+		});
+		it('should run with same name', () => {
+			endorser.addChaincode('chaincode');
+			endorser.addChaincode('chaincode');
+			endorser.chaincodes.should.be.deep.equal(['chaincode']);
+		});
+		it('should run with different name', () => {
+			endorser.addChaincode('chaincode');
+			endorser.addChaincode('other');
+			endorser.chaincodes.should.be.deep.equal(['chaincode', 'other']);
+		});
+	});
+
 	describe('#sendProposal', () => {
 		it('should reject if no proposal', async () => {
 			await endorser.sendProposal().should.be.rejectedWith(/Missing signedProposal parameter/);

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -150,6 +150,8 @@ export class Committer extends ServiceEndpoint {
 export class Endorser extends ServiceEndpoint {
 	constructor(name: string, client: Client, mspid: string);
 	public sendProposal(signedProposal?: Buffer, timeout?: number): Promise<any>;
+	public addChaincode(chaincodeName: string): Endorser;
+	public hasChaincode(chaincodeName: string): boolean;
 }
 
 export class Eventer extends ServiceEndpoint {
@@ -209,6 +211,7 @@ export interface SendProposalRequest {
 }
 
 export class Proposal extends ServiceAction {
+	readonly chaincodeId: string;
 	constructor(chaincodeName: string, channel: Channel);
 	public getTransactionId(): string;
 	public buildProposalInterest(): any;
@@ -230,6 +233,7 @@ export class DiscoveryService extends ServiceAction {
 	public send(request?: any): Promise<any>;
 	public getDiscoveryResults(refresh?: boolean): Promise<any>;
 	public close(): void;
+	public hasDiscoveryResults(): boolean;
 }
 export interface RegistrationOpts {
 	startBlock?: number|string|Long;
@@ -287,8 +291,9 @@ export class EventService extends ServiceAction {
 	public registerTransactionListener(txid: string, callback: EventCallback, options: EventRegistrationOptions): EventListener;
 	public registerChaincodeListener(chaincodeId: string, eventName: string, callback: EventCallback, options: EventRegistrationOptions): EventListener;
 	public registerBlockListener(callback: EventCallback, options: EventRegistrationOptions): EventListener;
-	setTargets(targets: Eventer[]): void;
-	isStarted(): boolean;
+	public setTargets(targets: Eventer[]): void;
+	public isStarted(): boolean;
+	public isInUse(): boolean;
 }
 
 export interface StartEventRequest {

--- a/fabric-network/src/impl/event/blockeventsource.ts
+++ b/fabric-network/src/impl/event/blockeventsource.ts
@@ -51,6 +51,7 @@ export class BlockEventSource {
 			this.notifyListeners.bind(this)
 		);
 		this.blockType = options.type || defaultBlockType;
+		logger.debug('constructor - blockType:%s', this.blockType);
 	}
 
 	async addBlockListener(listener: BlockListener): Promise<BlockListener> {
@@ -70,6 +71,8 @@ export class BlockEventSource {
 	}
 
 	private async start() {
+		logger.debug('start - started:%s', this.started);
+
 		if (this.started) {
 			return;
 		}
@@ -79,6 +82,8 @@ export class BlockEventSource {
 		try {
 			this.eventService = this.eventServiceManager.newDefaultEventService();
 			this.registerListener(); // Register before start so no events are missed
+			logger.debug('start - calling startEventService');
+
 			await this.startEventService();
 		} catch (error) {
 			logger.error('Failed to start event service', error);
@@ -116,6 +121,7 @@ export class BlockEventSource {
 			blockType: this.blockType,
 			startBlock
 		};
+
 		await this.eventServiceManager.startEventService(this.eventService!, options);
 	}
 

--- a/fabric-network/src/impl/event/eventservicemanager.ts
+++ b/fabric-network/src/impl/event/eventservicemanager.ts
@@ -14,6 +14,8 @@ import {
 	StartRequestOptions,
 	Eventer
 } from 'fabric-common';
+import * as Logger from '../../logger';
+const logger = Logger.getLogger('EventSourceManager');
 
 export class EventServiceManager {
 	private readonly network: Network;
@@ -27,6 +29,7 @@ export class EventServiceManager {
 		this.channel = network.getChannel();
 		this.mspId = network.getGateway().getIdentity().mspId;
 		this.identityContext = this.network.getGateway().identityContext!;
+		logger.debug('constructor - network:%s', this.network.getChannel().name);
 	}
 
 	/**
@@ -53,7 +56,9 @@ export class EventServiceManager {
 	 * @param options The options to start the event service.
 	 */
 	async startEventService(eventService: EventService, options = {} as StartRequestOptions): Promise<void> {
-		if (eventService.isStarted()) {
+		logger.debug('startEventService - start %s', this.network.getChannel().name);
+
+		if (eventService.isStarted() || eventService.isInUse()) {
 			return this.assertValidOptionsForStartedService(options, eventService);
 		}
 

--- a/fabric-network/test/impl/event/stubeventservice.ts
+++ b/fabric-network/test/impl/event/stubeventservice.ts
@@ -79,6 +79,7 @@ export class StubEventService implements EventService {
 	startBlock: string | Long;
 	endBlock: string | Long;
 	blockType: BlockType = 'filtered';
+	inUse: boolean = false;
 
 	started = false;
 
@@ -86,6 +87,10 @@ export class StubEventService implements EventService {
 
 	constructor(name: string) {
 		this.name = name;
+	}
+
+	isInUse(): boolean {
+		return this.inUse;
 	}
 
 	setEventer(discoverer: Eventer): EventService {

--- a/fabric-network/test/impl/event/transactioneventhandler.spec.ts
+++ b/fabric-network/test/impl/event/transactioneventhandler.spec.ts
@@ -11,6 +11,7 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 import {
+	Channel,
 	Endorser,
 	EventInfo,
 	IdentityContext
@@ -73,7 +74,9 @@ describe('TransactionEventHandler', () => {
 			type: 'stub'
 		});
 
-		network = new NetworkImpl(gateway as unknown as Gateway, null);
+		const channel = sinon.createStubInstance(Channel);
+		(channel as any).name = 'mychannel';
+		network = new NetworkImpl(gateway as unknown as Gateway, channel);
 		(network as any).eventServiceManager = eventServiceManager;
 
 		stubStrategy = sinon.createStubInstance(TransactionEventStrategy);

--- a/test/ts-scenario/features/base_api_v2.feature
+++ b/test/ts-scenario/features/base_api_v2.feature
@@ -31,6 +31,12 @@ Scenario: Using only fabric-common on V2 channel
 	Then the query named myFirstQuery for client fred has a general result matching {"result":"SUCCESS"}
 	And the query named myFirstQuery for client fred has a peer0 result matching {"color":"blue","docType":"car","make":"Toyota","model":"Prius","owner":"Tomoko"}
 
+	When I submit a chaincode query named checkChaincodeName with args [queryCar,CAR0] for contract fabcar as client fred on channel basev2channel
+	Then the query named checkChaincodeName for client fred has a general result matching {"result":"SUCCESS"}
+	Then the query named checkChaincodeName for client fred has a chaincodecheck result matching {"result":"FAILURE"}
+	And the query named checkChaincodeName for client fred has a peer1 result matching {"color":"blue","docType":"car","make":"Toyota","model":"Prius","owner":"Tomoko"}
+	And the query named checkChaincodeName for client fred has a peer0 result matching Error: Peer peer0.org1.example.com is not running chaincode fabcar
+
 	When I build a new endorsement request named myDiscoveryRequest for smart contract named fabcar with arguments [createCar,2008,Chrysler,PTCurser,white,Jones] as client fred on discovery channel basev2channel
 	And I commit the endorsement request named myDiscoveryRequest as client fred on channel basev2channel
 	Then the request named myDiscoveryRequest for client fred has discovery results

--- a/test/ts-scenario/features/discovery.feature
+++ b/test/ts-scenario/features/discovery.feature
@@ -69,3 +69,7 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 		Then The gateway named myDiscoveryGateway has a submit type response
 		When I use the gateway named myDiscoveryGateway to evaluate a transaction with args [queryCar,2001] for contract fabcar instantiated on channel discoverychannel
 		Then The gateway named myDiscoveryGateway has a evaluate type response matching {"color":"red","docType":"car","make":"Ford","model":"F350","owner":"Sam"}
+
+	Scenario: Using a Gateway I can use transient data
+		When I use the discovery gateway named myDiscoveryGateway to submit a transaction a 100 times with args [createCar,2001,Ford,F350,red,Sam] for contract fabcar instantiated on channel discoverychannel
+		Then The gateway named myDiscoveryGateway has a submit type response

--- a/test/ts-scenario/steps/base_api.ts
+++ b/test/ts-scenario/steps/base_api.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as ClientHelper from './lib/utility/clientUtils';
+import * as BaseUtils from './lib/utility/baseUtils';
 import { Constants } from './constants';
 import { CommonConnectionProfileHelper } from './lib/utility/commonConnectionProfileHelper';
 
@@ -16,7 +17,10 @@ Given(/^I have created a client named (.+?) based on information in profile (.+?
 
 	// Get a CCP Helper
 	const profilePath: string = path.join(__dirname, '../config', ccpName);
+	BaseUtils.logMsg(`loading profile ${profilePath}`);
+
 	const ccp: CommonConnectionProfileHelper = new CommonConnectionProfileHelper(profilePath, true);
+	BaseUtils.logMsg(`     ${JSON.stringify(ccp.getProfile())}`);
 
 	// Create the user
 	await ClientHelper.createAdminClient(clientName, ccp, userOrg);
@@ -44,7 +48,12 @@ When(/^I commit the endorsement request named (.+?) as client (.+?) on channel (
 
 When(/^I submit a query named (.+?) with args (.+?) for contract (.+?) as client (.+?) on channel (.+?)$/, { timeout: Constants.HUGE_TIME as number },
 	async (queryName: string, queryArgs: string, contractName: string, clientName: string, channelName: string) => {
-	await ClientHelper.queryChannelRequest(clientName, channelName, contractName, queryArgs, queryName);
+	await ClientHelper.queryChannelRequest(clientName, channelName, contractName, queryArgs, queryName, false);
+});
+
+When(/^I submit a chaincode query named (.+?) with args (.+?) for contract (.+?) as client (.+?) on channel (.+?)$/, { timeout: Constants.HUGE_TIME as number },
+	async (queryName: string, queryArgs: string, contractName: string, clientName: string, channelName: string) => {
+	await ClientHelper.queryChannelRequest(clientName, channelName, contractName, queryArgs, queryName, true);
 });
 
 Then(/^the (request|query) named (.+?) for client (.+?) has a (.+?) result matching (.+?)$/, { timeout: Constants.INC_SHORT as number },

--- a/test/ts-scenario/steps/network-model.ts
+++ b/test/ts-scenario/steps/network-model.ts
@@ -46,6 +46,10 @@ When(/^I use the discovery gateway named (.+?) to (.+?) a transaction with args 
 	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, collectionName, txnArgs, txnType);
 });
 
+When(/^I use the discovery gateway named (.+?) to (.+?) a transaction a (.+?) times with args (.+?) for contract (.+?) instantiated on channel (.+?)$/, { timeout: Constants.STEP_MED as number }, async (gatewayName: string, txnType: string, txnCount: number, txnArgs: string, ccName: string, channelName: string) => {
+	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, '', txnArgs, txnType, undefined, undefined, txnCount);
+});
+
 When(/^I use the gateway named (.+?) to (.+?) a transaction with args (.+?) for contract (.+?) instantiated on channel (.+?)$/, { timeout: Constants.STEP_MED as number }, async (gatewayName: string, txnType: string, txnArgs: string, ccName: string, channelName: string) => {
 	return await Gateway.performGatewayTransaction(gatewayName, ccName, channelName, '', txnArgs, txnType);
 });


### PR DESCRIPTION
Allow submitting multiple submit from a contract. This
will allow for the sharing of discovery results to avoid
each submit fetching an endorsement plan. Eventing was also
enhanced to allow for sharing of the event service connection.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>