### PR TITLE
FABN-1660 Throw error on missing peers

### DIFF
--- a/fabric-common/lib/DiscoveryHandler.js
+++ b/fabric-common/lib/DiscoveryHandler.js
@@ -365,11 +365,22 @@ class DiscoveryHandler extends ServiceHandler {
 		endorsement_plan.groups = {};
 		endorsement_plan.layouts = [{}]; // only one layout which will have all organizations
 
+		const notFound = [];
+
 		for (const mspid of required_orgs) {
 			logger.debug(`${method} - found org:${mspid}`);
-			endorsement_plan.groups[mspid] = {}; // make a group for each organization
-			endorsement_plan.groups[mspid].peers = JSON.parse(JSON.stringify(peers_by_org[mspid].peers)); // now put in all peers from that organization
-			endorsement_plan.layouts[0][mspid] = 1; // add this org to the one layout and require one peer to endorse
+			endorsement_plan.groups[mspid] = {}; // make a group for each
+			if (peers_by_org[mspid] && peers_by_org[mspid].peers && peers_by_org[mspid].peers.length > 0) {
+				endorsement_plan.groups[mspid].peers = JSON.parse(JSON.stringify(peers_by_org[mspid].peers)); // now put in all peers from that organization
+				endorsement_plan.layouts[0][mspid] = 1; // add this org to the one layout and require one peer to endorse
+			} else {
+				logger.debug('%s - discovery plan does not have peers for %', method, mspid);
+				notFound.push(mspid);
+			}
+		}
+
+		if (notFound.length > 0) {
+			throw Error(`The discovery service did not find any peers active for ${notFound} organizations`);
 		}
 
 		return endorsement_plan;

--- a/fabric-common/test/DiscoveryHandler.js
+++ b/fabric-common/test/DiscoveryHandler.js
@@ -148,7 +148,10 @@ describe('DiscoveryHandler', () => {
 					{mspid: org3[0], endpoint: org3[2], ledgerHeight: highest, chaincodes, name: org3[2]},
 					{mspid: org3[0], endpoint: org3[3], ledgerHeight: smaller, chaincodes, name: org3[3]}
 				]
-			}
+			},
+			Org4MSP: {
+				peers: []
+			},
 		}
 	};
 
@@ -176,6 +179,20 @@ describe('DiscoveryHandler', () => {
 			}
 		},
 		layouts: [{Org1MSP: 1, Org2MSP: 1, Org3MSP: 1}]
+	}));
+
+	const organization_plan_one = JSON.parse(JSON.stringify({
+		plan_id: 'required organizations',
+		groups: {
+			Org3MSP: {
+				peers: [
+					{mspid: org3[0], endpoint: org3[1], ledgerHeight, chaincodes, name: org3[1]},
+					{mspid: org3[0], endpoint: org3[2], ledgerHeight: highest, chaincodes, name: org3[2]},
+					{mspid: org3[0], endpoint: org3[3], ledgerHeight: smaller, chaincodes, name: org3[3]}
+				]
+			}
+		},
+		layouts: [{Org3MSP: 1}]
 	}));
 
 	const good = {response: {status: 200}};
@@ -579,11 +596,27 @@ describe('DiscoveryHandler', () => {
 	});
 
 	describe('#_buildRequiredOrgPlan', () => {
-		it('should run ok', () => {
-
+		it('should run ok with all', () => {
 			// TEST CALL
 			const results = discoveryHandler._buildRequiredOrgPlan(config_results.peers_by_org, ['Org1MSP', 'Org2MSP', 'Org3MSP']);
 			results.should.deep.equal(organization_plan);
+		});
+		it('should run ok with one', () => {
+			// TEST CALL
+			const results = discoveryHandler._buildRequiredOrgPlan(config_results.peers_by_org, ['Org3MSP']);
+			results.should.deep.equal(organization_plan_one);
+		});
+		it('should throw for one missing with no peers', () => {
+			(() => {
+				// TEST CALL
+				discoveryHandler._buildRequiredOrgPlan(config_results.peers_by_org, ['Org4MSP']);
+			}).should.throw('The discovery service did not find any peers active for Org4MSP organizations');
+		});
+		it('should throw for two missing when not included in list', () => {
+			(() => {
+				// TEST CALL
+				discoveryHandler._buildRequiredOrgPlan(config_results.peers_by_org, ['Org5MSP', 'Org6MSP']);
+			}).should.throw('The discovery service did not find any peers active for Org5MSP,Org6MSP organizations');
 		});
 	});
 


### PR DESCRIPTION
When using discovery and setting endorsing organizations,
throw an error to indicate that one or more of the required
organizations do not have any peers to endorse.

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>