### PR TITLE
[FABN-1671] fix target endorser set when service discovery is disabled

### DIFF
--- a/fabric-network/src/transaction.ts
+++ b/fabric-network/src/transaction.ts
@@ -256,7 +256,7 @@ export class Transaction {
 				accumulator.push(...value);
 				return accumulator;
 			};
-			proposalSendRequest.targets = this.endorsingOrgs.map(channel.getEndorsers).reduce(flatten, []);
+			proposalSendRequest.targets = this.endorsingOrgs.map((mspid) => channel.getEndorsers(mspid)).reduce(flatten, []);
 		} else {
 			logger.debug('%s - targets will default to all that are assigned to this channel', method);
 			proposalSendRequest.targets = channel.getEndorsers();


### PR DESCRIPTION
fix setting of target endorsers when service discovery is disabled (see [FABN-1671](https://jira.hyperledger.org/browse/FABN-1671))

Signed-off-by: Christoph Buttler <christoph.buttler@outlook.com>