### PR TITLE
[FABN-1674] Fix wrong type definitions on Discovery Service

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -430,7 +430,8 @@ export interface DiscoveryResultMSPConfig {
 	intermediateCerts: string;
 	admins: string;
 	id: string;
-	orgs: string[];
+	name: string;
+	organizationalUnitIdentifiers: string[];
 	tlsRootCerts: string;
 	tlsIntermediateCerts: string;
 }
@@ -469,7 +470,7 @@ export interface DiscoveryResultEndorsementLayout {
 
 export interface DiscoveryResultEndorsementPlan {
 	chaincode: string;
-	plan_id: string;
+	plan_id?: string;
 	groups: {
 		[groupName: string]: DiscoveryResultEndorsementGroup;
 	};
@@ -482,7 +483,7 @@ export interface DiscoveryResults {
 
 	peers_by_org?: { [name: string]: DiscoveryResultPeers };
 
-	endorsement_plan?: DiscoveryResultEndorsementPlan[];
+	endorsement_plan?: DiscoveryResultEndorsementPlan;
 
 	timestamp: number;
 }


### PR DESCRIPTION
This patch fixes wrong type definitions on Discovery Service in fabric-common/types/index.d.ts.

JIRA: https://jira.hyperledger.org/browse/FABN-1674

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>