### PR TITLE
[FABN-1670] Fix type definition for DiscoveryResults (#375)

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -479,9 +479,9 @@ export interface DiscoveryResults {
 	msps?: { [mspid: string]: DiscoveryResultMSPConfig };
 	orderers?: { [mspid: string]: DiscoveryResultEndpoints };
 
-	peersByOrg?: { [name: string]: DiscoveryResultPeers };
+	peers_by_org?: { [name: string]: DiscoveryResultPeers };
 
-	endorsement_plans: DiscoveryResultEndorsementPlan[];
+	endorsement_plan?: DiscoveryResultEndorsementPlan[];
 
 	timestamp: number;
 }


### PR DESCRIPTION
This patch fixes the name of the members of DiscoveryResults
to align with the actual code in fabric-common/lib/DiscoveryService.js.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>