### PR TITLE
[FABN-1672] Fix wrong type and field names (#381)

### DIFF
--- a/docs/tutorials/commonconnectionprofile.md
+++ b/docs/tutorials/commonconnectionprofile.md
@@ -12,7 +12,7 @@ The connection profile has specific addresses and settings of the network endpoi
 ### Loading connection profile configurations
 The application may build a Javascript object from a yaml or a json
 formatted file.
-The applicatioin will then pass this to the `Gateway.connect`
+The application will then pass this to the `Gateway.connect`
 which provides the network configuration.
 
 The following examples will create a new instance of the `Gateway` using a

--- a/docs/tutorials/query-peers.md
+++ b/docs/tutorials/query-peers.md
@@ -6,7 +6,7 @@ query.
 
 The SDK provides two strategies to evaluate transactions.
 The available strategies are defined
-in `QueryHandlerStrategies`. The desired strategy is (optionally)
+in `DefaultQueryHandlerStrategies`. The desired strategy is (optionally)
 specified as an argument to `connect()` on the `Gateway`, and is used for
 all transaction evaluations on Contracts obtained from that Gateway
 instance.
@@ -36,12 +36,12 @@ gateway's organization has no peers, use `MSPID_SCOPE_ROUND_ROBIN` instead which
 fail when there are no peers in the gateway's organization.
 
 ```javascript
-const { Gateway, QueryHandlerStrategies } = require('fabric-network');
+const { Gateway, DefaultQueryHandlerStrategies } = require('fabric-network');
 
 const connectOptions = {
-    query: {
+    queryHandlerOptions: {
         timeout: 3, // timeout in seconds
-        strategy: QueryHandlerStrategies.MSPID_SCOPE_SINGLE
+        strategy: DefaultQueryHandlerStrategies.MSPID_SCOPE_SINGLE
     }
 }
 


### PR DESCRIPTION
This patch fixes wrong type and field names in docs/tutorials/query-peers.md.
Also, the patch fixes a minor typo.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>