### PR TITLE
[FABN-1674] Fix wrong type definitions on Discovery Service (#383)

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -429,7 +429,8 @@ export interface DiscoveryResultMSPConfig {
 	intermediateCerts: string;
 	admins: string;
 	id: string;
-	orgs: string[];
+	name: string;
+	organizationalUnitIdentifiers: string[];
 	tlsRootCerts: string;
 	tlsIntermediateCerts: string;
 }
@@ -468,7 +469,7 @@ export interface DiscoveryResultEndorsementLayout {
 
 export interface DiscoveryResultEndorsementPlan {
 	chaincode: string;
-	plan_id: string;
+	plan_id?: string;
 	groups: {
 		[groupName: string]: DiscoveryResultEndorsementGroup;
 	};
@@ -481,7 +482,7 @@ export interface DiscoveryResults {
 
 	peersByOrg?: { [name: string]: DiscoveryResultPeers };
 
-	endorsement_plans: DiscoveryResultEndorsementPlan[];
+	endorsement_plan?: DiscoveryResultEndorsementPlan;
 
 	timestamp: number;
 }


### PR DESCRIPTION
This patch fixes wrong type definitions on Discovery Service
in fabric-common/types/index.d.ts.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>