### PR TITLE
Fix some wrong descriptions in the documents (#376)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Check the coding styles, run the following command and make sure no ESLint viola
 * `npm run lint`
 
 Run the full test bucket and make sure 100% are passing.  You can also run each test individually to isolate any failures:
-* [Prerequisite](./README.md#Build and Test)
-* [Unit Test](./README.md#Run unit tests)
-* [Integration Test](./README.md#Run Integration Tests)
-* [Configure HSM Test](./test/README.md#Configuring and running Hardware Security Module tests)
+* [Prerequisite](./README.md#Build-and-Test)
+* [Unit Test](./README.md#Run-unit-tests)
+* [Integration Test](./README.md#Run-Integration-Tests)
+* [Configure HSM Test](./test/README.md#Configuring-and-running-Hardware-Security-Module-tests)
 
 ## Test Delivery
 
@@ -27,7 +27,7 @@ Unit tests for each package are held locally under a `package/test` directory th
 - [Nyc](https://www.npmjs.com/package/nyc) for code coverage reports
 
 It is expected that new code deliveries come with unit tests that:
-- are isolated - all unit tests should be capable of being run indiviually as well as in the suite(s)
+- are isolated - all unit tests should be capable of being run individually as well as in the suite(s)
 - are meaningful - all unit tests should test the code intention, and validate with assertions
 - test golden path and failure path
 - provide 100% line coverage

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build and test, the following pre-requisites must be installed first:
 Clone the project and launch the following commands to install the dependencies and perform various tasks.
 
 In the project root folder:
-* Install all dependancies via `npm install`
+* Install all dependencies via `npm install`
 * Optionally, to generate API docs via `npm run docs`
 * To generate the required crypto material used by the tests, use one of the following patform specific commands:
   * For Linux `npm run installAndGenerateCerts`
@@ -29,7 +29,7 @@ In the project root folder:
 * To run the unit tests that do not require any additional set up, use `npm run testHeadless`
 
 ### Run Integration Tests
-Integration tests run on the master branch require the most recent stable Fabric images, which are hosted on Artifactory. A utility script is provided to retrieve non-published docker images, which may be run using the command `npm run retrieveImages`
+Integration tests run on the master branch require the most recent stable Fabric images, which are hosted on Artifactory. A utility script is provided to retrieve non-published docker images, which may be run using the command `npm run pullFabricImages`
 
 Now you are ready to run the integration tests. It is advisable to clear out any previous key value stores that may have cached user enrollment certificates using the command (`rm -rf /tmp/hfc-*`, `rm -rf ~/.hfc-key-store`) prior to testing in isolation.
 


### PR DESCRIPTION
This patch fixes some descriptions in the documents below:
- Update the old command name in the procedure for running integration
tests
- Fix some broken links
- Fix some typos

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>