### PR TITLE
[FABN-1686] fix private data index parsing

### DIFF
--- a/fabric-common/lib/BlockDecoder.js
+++ b/fabric-common/lib/BlockDecoder.js
@@ -8,7 +8,6 @@
 
 const fabproto6 = require('fabric-protos');
 const utils = require('./Utils');
-const protobuf = require('protobufjs');
 
 const logger = utils.getLogger('BlockDecoder.js');
 
@@ -700,7 +699,7 @@ function decodePrivateData(privateDataMapProto) {
 			}
 			tx_pvt_read_write_set.ns_pvt_rwset.push(ns_pvt_rwset);
 		}
-		const intIndex = protobuf.util.longFromHash(txIndex).toInt();
+		const intIndex = fabproto6.util.longFromHash(txIndex).toInt();
 		private_data_map[intIndex] = tx_pvt_read_write_set;
 		found = true;
 	}

--- a/fabric-common/lib/BlockDecoder.js
+++ b/fabric-common/lib/BlockDecoder.js
@@ -8,7 +8,7 @@
 
 const fabproto6 = require('fabric-protos');
 const utils = require('./Utils');
-const Long = require('long');
+const protobuf = require('protobufjs');
 
 const logger = utils.getLogger('BlockDecoder.js');
 
@@ -700,7 +700,7 @@ function decodePrivateData(privateDataMapProto) {
 			}
 			tx_pvt_read_write_set.ns_pvt_rwset.push(ns_pvt_rwset);
 		}
-		const intIndex = Long.fromValue(txIndex).toInt();
+		const intIndex = protobuf.util.longFromHash(txIndex).toInt();
 		private_data_map[intIndex] = tx_pvt_read_write_set;
 		found = true;
 	}

--- a/fabric-common/test/BlockDecoder.js
+++ b/fabric-common/test/BlockDecoder.js
@@ -2330,8 +2330,8 @@ describe('BlockDecoder', () => {
 	describe('#decodePrivateData', () => {
 		let decodePrivateData;
 		let decodeKVRWSet;
-
-		const privateDataMapProto = {0: // map key is transaction index
+		const longIndex = fabproto6.util.LongBits.from('3');
+		const privateDataMapProto = {[fabproto6.util.longToHash(longIndex)]: // map key is transaction index
 			// TxPvtReadWriteSet
 			{
 				data_model: 0, // enum KV

--- a/fabric-common/test/BlockDecoder.js
+++ b/fabric-common/test/BlockDecoder.js
@@ -2330,8 +2330,7 @@ describe('BlockDecoder', () => {
 	describe('#decodePrivateData', () => {
 		let decodePrivateData;
 		let decodeKVRWSet;
-		const longIndex = fabproto6.util.LongBits.from('3');
-		const privateDataMapProto = {[fabproto6.util.longToHash(longIndex)]: // map key is transaction index
+		const privateDataMapProto = {[fabproto6.util.longToHash(3)]: // map key is transaction index
 			// TxPvtReadWriteSet
 			{
 				data_model: 0, // enum KV
@@ -2363,9 +2362,9 @@ describe('BlockDecoder', () => {
 
 		it('should return the correct rwset', () => {
 			const private_data_map = decodePrivateData(privateDataMapProto);
-			private_data_map[0].ns_pvt_rwset[0].collection_pvt_rwset[0].rwset.should.equal('rwset-decode');
-			private_data_map[0].ns_pvt_rwset[0].collection_pvt_rwset[0].collection_name.should.equal('collectionName-string');
-			private_data_map[0].ns_pvt_rwset[0].namespace.should.equal('namespace-string');
+			private_data_map[3].ns_pvt_rwset[0].collection_pvt_rwset[0].rwset.should.equal('rwset-decode');
+			private_data_map[3].ns_pvt_rwset[0].collection_pvt_rwset[0].collection_name.should.equal('collectionName-string');
+			private_data_map[3].ns_pvt_rwset[0].namespace.should.equal('namespace-string');
 			sinon.assert.called(decodeKVRWSet);
 		});
 	});

--- a/fabric-protos/index.js
+++ b/fabric-protos/index.js
@@ -7,7 +7,7 @@
 const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
 const path = require('path');
-
+const protobuf = require('protobufjs');
 // The static bundle built by protobufjs (see fabric-proto/package.json npm run command)
 // 'bundle.js' and typescript defs must be manually built when there is a change to the
 // proto files and pushed to the repository
@@ -15,7 +15,7 @@ const path = require('path');
 // messages which have create, decode, and encode. The services do not have a backing
 // implementation
 module.exports = require('./bundle.js');
-
+module.exports.util = protobuf.util;
 // Build the services
 // fabric.proto file must have an import for every needed proto files
 const protoPath = path.resolve(__dirname, 'protos', 'fabric.proto');


### PR DESCRIPTION
Private data was not parsed correctly, Long.fromValue(txIndex).toInt(); always returned zero. As a result, if block contains more than one transaction with private data, only one private data record was parsed (with index 0), all others were undefined.
As for me it is critical issue and should be resolved asap.
I can also mock protobuf in tests, just sometimes mock everything ends badly


Ticket in Jira.
https://jira.hyperledger.org/browse/FABN-1686