### PR TITLE
FABN-1686: Encapsulate uint64 to/from number implementation

### DIFF
--- a/fabric-common/lib/BlockDecoder.js
+++ b/fabric-common/lib/BlockDecoder.js
@@ -699,7 +699,7 @@ function decodePrivateData(privateDataMapProto) {
 			}
 			tx_pvt_read_write_set.ns_pvt_rwset.push(ns_pvt_rwset);
 		}
-		const intIndex = fabproto6.util.longFromHash(txIndex).toInt();
+		const intIndex = fabproto6.uint64ToNumber(txIndex);
 		private_data_map[intIndex] = tx_pvt_read_write_set;
 		found = true;
 	}

--- a/fabric-common/test/BlockDecoder.js
+++ b/fabric-common/test/BlockDecoder.js
@@ -2330,7 +2330,7 @@ describe('BlockDecoder', () => {
 	describe('#decodePrivateData', () => {
 		let decodePrivateData;
 		let decodeKVRWSet;
-		const privateDataMapProto = {[fabproto6.util.longToHash(3)]: // map key is transaction index
+		const privateDataMapProto = {[fabproto6.numberToUint64(3)]: // map key is transaction index
 			// TxPvtReadWriteSet
 			{
 				data_model: 0, // enum KV

--- a/fabric-protos/index.js
+++ b/fabric-protos/index.js
@@ -15,7 +15,14 @@ const protobuf = require('protobufjs');
 // messages which have create, decode, and encode. The services do not have a backing
 // implementation
 module.exports = require('./bundle.js');
-module.exports.util = protobuf.util;
+
+// Allow client code to translate the obscure uint64 field format to/from a number
+module.exports.numberToUint64 = protobuf.util.longToHash;
+module.exports.uint64ToNumber = (uint64Value) => {
+	const value = protobuf.util.longFromHash(uint64Value, true);
+	return typeof value === 'number' ? value : value.toInt();
+}
+
 // Build the services
 // fabric.proto file must have an import for every needed proto files
 const protoPath = path.resolve(__dirname, 'protos', 'fabric.proto');


### PR DESCRIPTION
Keep the implementation details of un/marshalling of uint64 protobuf fields to/from numbers encapsulated within the fabric-protos package.