### PR TITLE
Add OpenTelemetry to Fabric node SDK

### DIFF
--- a/fabric-network/package.json
+++ b/fabric-network/package.json
@@ -25,6 +25,9 @@
   },
   "types": "./types/index.d.ts",
   "dependencies": {
+    "@opentelemetry/instrumentation": "^0.24.0",
+    "@opentelemetry/instrumentation-grpc": "^0.24.0",
+    "@opentelemetry/node": "^0.24.0",
     "fabric-common": "file:../fabric-common",
     "fabric-protos": "file:../fabric-protos",
     "long": "^4.0.0",

--- a/fabric-network/src/gateway.ts
+++ b/fabric-network/src/gateway.ts
@@ -18,6 +18,16 @@ import * as IdentityProviderRegistry from './impl/wallet/identityproviderregistr
 
 import * as Logger from './logger';
 import {X509Identity} from './impl/wallet/x509identity';
+import {NodeTracerProvider} from '@opentelemetry/node';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
+
+const otelProvider = new NodeTracerProvider();
+
+registerInstrumentations({
+	instrumentations: [new GrpcInstrumentation()],
+	tracerProvider: otelProvider,
+});
 
 const logger = Logger.getLogger('Gateway');
 


### PR DESCRIPTION
Fixes #503

It introduces OpenTelemetry instrumentation of gRPC messages through tracing.

Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>