### PR TITLE
FABN-1716: Fix hang on application exit (release-2.2)

### DIFF
--- a/fabric-common/config/default.json
+++ b/fabric-common/config/default.json
@@ -17,7 +17,7 @@
  		"grpc.http2.min_time_between_pings_ms": 120000,
 		"grpc.keepalive_timeout_ms": 20000,
 		"grpc.http2.max_pings_without_data": 0,
-		"grpc.keepalive_permit_without_calls": 1,
+		"grpc.keepalive_permit_without_calls": 0,
 		"grpc-wait-for-ready-timeout": 3000,
 		"request-timeout" : 45000
 	},

--- a/fabric-common/lib/Committer.js
+++ b/fabric-common/lib/Committer.js
@@ -127,13 +127,12 @@ class Committer extends ServiceEndpoint {
 
 			const broadcast_timeout = setTimeout(() => {
 				logger.error(`${this.name} - ${method} timed out after:${rto}`);
-				broadcast.end();
 				return reject(new Error(error_msg));
 			}, rto);
 
 			broadcast.on('data', (response) => {
 				logger.debug('%s - on data response: %j', method, response);
-				broadcast.end();
+				clearTimeout(broadcast_timeout);
 				if (response && response.info) {
 					logger.debug(`${method} - response info :: ${response.info}`);
 				}
@@ -160,7 +159,6 @@ class Committer extends ServiceEndpoint {
 
 			broadcast.on('error', (err) => {
 				clearTimeout(broadcast_timeout);
-				broadcast.end();
 				if (err && err.code) {
 					if (err.code === 14) {
 						logger.error(`${method} - ${this.name} SERVICE UNAVAILABLE on error code: ${err.code}`);
@@ -172,6 +170,7 @@ class Committer extends ServiceEndpoint {
 			});
 
 			broadcast.write(envelope);
+			broadcast.end();
 			// the send of envelope has completed
 			// if it timeouts after this point we will get a REQUEST TIMEOUT
 			error_msg = 'REQUEST TIMEOUT';

--- a/fabric-common/lib/Discoverer.js
+++ b/fabric-common/lib/Discoverer.js
@@ -64,7 +64,6 @@ class Discoverer extends ServiceEndpoint {
 			}
 
 			const send_timeout = setTimeout(() => {
-				clearTimeout(send_timeout);
 				logger.error(`${method} - timed out after:${rto}`);
 				const return_error = new Error('REQUEST TIMEOUT');
 				this.getCharacteristics(return_error);

--- a/fabric-common/lib/Endorser.js
+++ b/fabric-common/lib/Endorser.js
@@ -138,7 +138,6 @@ class Endorser extends ServiceEndpoint {
 				rto = timeout;
 			}
 			const send_timeout = setTimeout(() => {
-				clearTimeout(send_timeout);
 				logger.error(`${method} - ${this.name} timed out after: ${rto}`);
 				const return_error = new Error('REQUEST TIMEOUT');
 				return reject(return_error);

--- a/fabric-network/src/impl/event/contractlistenersession.ts
+++ b/fabric-network/src/impl/event/contractlistenersession.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BlockEvent, BlockListener, ContractEvent, ContractListener, ListenerOptions, TransactionEvent } from '../../events';
+import { BlockListener, ContractEvent, ContractListener, ListenerOptions } from '../../events';
 import * as Logger from '../../logger';
 import { Network } from '../../network';
-import { ListenerSession } from './listenersession';
 import * as Listeners from './listeners';
+import { ListenerSession } from './listenersession';
 const logger = Logger.getLogger('ContractListenerSession');
 
 export class ContractListenerSession implements ListenerSession {

--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -32,7 +32,7 @@
   ],
   "types": "./types/index.d.ts",
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.1",
+    "@grpc/grpc-js": "^1.3.3",
     "@grpc/proto-loader": "^0.6.2",
     "protobufjs": "^6.11.2"
   },


### PR DESCRIPTION
Cherry-pick of commit f59f91ce209f13b6bf03ad03135993728de7543f from main branch.

A change in v1.2.0 and later versions of @grpc/grpc-js is preventing client applications from exiting due to interval timers on the event queue created by @grpc/grpc-js/src/subchannel.ts. This appears to be linked to behaviour when the `grpc.keepalive_permit_without_calls` setting is enabled, which it is by default in the fabric-common configuration. This change disables that setting by default until a fix to @grpc/grpc-js is released.

Additionally, connection timeout Promises during sends to orderers in Committer.js were not being closed correctly. This did not cause a breakage since the promise they rejected was already resolved if the connection was successful, but could leave timers running unnecessarily in the event queue.