### PR TITLE
FABN-1716: Update @grpc/grpc-js version (release-2.2)

### DIFF
--- a/fabric-common/config/default.json
+++ b/fabric-common/config/default.json
@@ -17,7 +17,7 @@
  		"grpc.http2.min_time_between_pings_ms": 120000,
 		"grpc.keepalive_timeout_ms": 20000,
 		"grpc.http2.max_pings_without_data": 0,
-		"grpc.keepalive_permit_without_calls": 0,
+		"grpc.keepalive_permit_without_calls": 1,
 		"grpc-wait-for-ready-timeout": 3000,
 		"request-timeout" : 45000
 	},

--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -32,7 +32,7 @@
   ],
   "types": "./types/index.d.ts",
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.3",
+    "@grpc/grpc-js": "^1.3.4",
     "@grpc/proto-loader": "^0.6.2",
     "protobufjs": "^6.11.2"
   },


### PR DESCRIPTION
@grpc/grpc-js v1.3.4 fixes application hang on exit issue in gRPC, so allows the `grpc.keepalive_permit_without_calls` setting to be re-enabled by default.