### PR TITLE
FABN-1722: export BlockDecoder for typescript definition

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -245,6 +245,15 @@ export class Proposal extends ServiceAction {
 	public compareProposalResponseResults(proposalResponses: any[]): boolean;
 }
 
+export class BlockDecoder {
+	constructor();
+	public static decode(blockBuf: Buffer): fabproto6.common.Block;
+	public static decodeBlock(blockProto: object): fabproto6.common.Block;
+	public static decodeFilteredBlock(filteredBlockProto: object): fabproto6.protos.FilteredBlock;
+	public static decodeBlockWithPrivateData(BlockAndPrivateData: object): fabproto6.protos.BlockAndPrivateData;
+	public static decodeTransaction(processedTransactionBuf: Buffer): fabproto6.protos.ProcessedTransaction;
+}
+
 export class DiscoveryService extends ServiceAction {
 	readonly targets: Discoverer[];
 	constructor(chaincodeName: string, channel: Channel);


### PR DESCRIPTION
Signed-off-by: jsjs026 <jasonhack518@gmail.com>

I refer to https://hyperledger.github.io/fabric-sdk-node/release-2.2/BlockDecoder.html
I am not sure I did it right, there are some questions/discussions.

1. For parameters end with suffix proto, I used type object here
2. Do I need to do additional things besides modifying the index.d.ts file?