### PR TITLE
Reference Asset Transfer samples in SDK docs

### DIFF
--- a/docs/redirectTemplates/index.md
+++ b/docs/redirectTemplates/index.md
@@ -22,4 +22,4 @@ npm install fabric-network
 
 ## Samples
 
-Sample Node.js client applications can be found in the _Fabcar_ and _Commercial Paper_ samples within the [fabric-samples repository](https://github.com/hyperledger/fabric-samples).
+Sample Node.js client applications can be found in the _Asset Transfer_ samples within the [fabric-samples repository](https://github.com/hyperledger/fabric-samples).

--- a/fabric-network/README.md
+++ b/fabric-network/README.md
@@ -9,6 +9,8 @@ Additional packages are also provided:
 2. `fabric-common`, encapsulates the common code used by all fabric-sdk-node packages supporting fine grain interactions with the Fabric network to send transaction invocations.
 3. `fabric-protos`, encapsulates the Protocol Buffer files and generated JavaScript classes for Hyperledger Fabric.
 
-For application developer documentations, please visit [hyperledger.github.io/fabric-sdk-node/](https://hyperledger.github.io/fabric-sdk-node/)
+For application developer documentation, please visit [hyperledger.github.io/fabric-sdk-node/](https://hyperledger.github.io/fabric-sdk-node/)
+
+Sample Node.js client applications can be found in the _Asset Transfer_ samples within the [fabric-samples repository](https://github.com/hyperledger/fabric-samples).
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Reference Asset Transfer samples in SDK docs instead of
Fabcar and Commercial Paper.  The Asset Transfer
samples have corresponding beginner tutorials and
Fabric docs and is the recommend place to start now.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>