### PR TITLE
FABN-1724: add support async signing of message

### DIFF
--- a/fabric-ca-client/lib/FabricCAClient.js
+++ b/fabric-ca-client/lib/FabricCAClient.js
@@ -266,7 +266,7 @@ const FabricCAClient = class {
 		};
 		if (signingIdentity) {
 			requestOptions.headers = {
-				Authorization: this.generateAuthToken(requestObj, signingIdentity, path, http_method)
+				Authorization: await this.generateAuthToken(requestObj, signingIdentity, path, http_method)
 			};
 		}
 		Object.assign(requestOptions, extraRequestOptions);
@@ -339,7 +339,7 @@ const FabricCAClient = class {
 	/*
 	 * Generate authorization token required for accessing fabric-ca APIs
 	 */
-	generateAuthToken(reqBody, signingIdentity, path, method) {
+	async generateAuthToken(reqBody, signingIdentity, path, method) {
 		// specific signing procedure is according to:
 		// https://github.com/hyperledger/fabric-ca/blob/main/util/util.go#L168
 		const cert = Buffer.from(signingIdentity._certificate).toString('base64');
@@ -356,7 +356,7 @@ const FabricCAClient = class {
 			signString = `${method}.${s}.${signString}`;
 		}
 
-		const sig = signingIdentity.sign(signString, {hashFunction: this._cryptoPrimitives.hash.bind(this._cryptoPrimitives)});
+		const sig = await signingIdentity.sign(signString, {hashFunction: this._cryptoPrimitives.hash.bind(this._cryptoPrimitives)});
 		logger.debug(`signString: ${signString}`);
 
 		const b64Sign = Buffer.from(sig, 'hex').toString('base64');

--- a/fabric-ca-client/test/FabricCAClient.js
+++ b/fabric-ca-client/test/FabricCAClient.js
@@ -1002,7 +1002,7 @@ describe('FabricCAClient', () => {
 			callArgs[0].should.equal('InRlc3RfYm9keSI=.dGVzdF9jZXJ0');
 		});
 
-		it('should return a concatenation of the cert and signing in base64 string', () => {
+		it('should return a concatenation of the cert and signing in base64 string', async () => {
 			const connect_opts = {
 				caname: 'test-ca-name',
 				protocol: 'https',
@@ -1018,7 +1018,7 @@ describe('FabricCAClient', () => {
 				sign: signStub
 			};
 
-			client.generateAuthToken('test_body', fake).should.equal('dGVzdF9jZXJ0.');
+			(await client.generateAuthToken('test_body', fake)).should.equal('dGVzdF9jZXJ0.');
 		});
 	});
 

--- a/fabric-common/lib/IdentityContext.js
+++ b/fabric-common/lib/IdentityContext.js
@@ -81,14 +81,15 @@ const IdentityContext = class {
 
 	/**
 	 * Sign the bytes provided
+	 * @async
 	 * @param {Buffer} payload - The payload bytes that require a signature
-	 * @return {Buffer} - The signature in bytes
+	 * @return {Buffer} - The signature as promise bytes
 	 */
-	sign(payload = checkParameter('payload')) {
+	async sign(payload = checkParameter('payload')) {
 		const method = 'sign';
 		logger.debug('%s - start', method);
 		const signer = this.user.getSigningIdentity();
-		const signature = Buffer.from(signer.sign(payload));
+		const signature = Buffer.from(await signer.sign(payload));
 
 		logger.debug('%s - end', method);
 		return signature;

--- a/fabric-common/lib/ServiceAction.js
+++ b/fabric-common/lib/ServiceAction.js
@@ -53,20 +53,21 @@ const ServiceAction = class {
 	 * Use this method with a byte[] to set the signature
 	 * when the application has done the signed externally.
 	 * Use the results of the build as the bytes that will be signed.
+	 * @async
 	 * @param {IdentityContext | byte[]} param - When 'param' is a
 	 * {@link IdentityContext} the signing identity of the user
-	 *  will sign the current build bytes.
+	 *  will asynchronously sign the current build bytes.
 	 *  When the 'param' is a byte[], the bytes will be used as the final
 	 *  commit signature.
 	 */
-	sign(param = checkParameter('param')) {
+	async sign(param = checkParameter('param')) {
 		const method = `sign[${this.type}:${this.name}]`;
 		logger.debug('%s - start', method);
 		if (!this._payload) {
 			throw Error('The send payload has not been built');
 		}
 		if (param.type === IdentityContext.TYPE) {
-			this._signature = Buffer.from(param.sign(this._payload));
+			this._signature = Buffer.from(await param.sign(this._payload));
 		} else if (param instanceof Buffer) {
 			this._signature = param;
 		} else {

--- a/fabric-common/test/Commit.js
+++ b/fabric-common/test/Commit.js
@@ -110,14 +110,14 @@ describe('Commit', () => {
 			endorsement._proposalResponses = [];
 			endorsement._proposalResponses.push(proposalResponse);
 			commit.build(idx);
-			commit.sign(idx);
+			await commit.sign(idx);
 			await commit.send().should.be.rejectedWith('Missing targets parameter');
 		});
 		it('uses a handler', async () => {
 			endorsement._proposalResponses = [];
 			endorsement._proposalResponses.push(proposalResponse);
 			commit.build(idx);
-			commit.sign(idx);
+			await commit.sign(idx);
 			const request = {
 				handler: fakeHandler
 			};
@@ -128,7 +128,7 @@ describe('Commit', () => {
 			endorsement._proposalResponses = [];
 			endorsement._proposalResponses.push(proposalResponse);
 			commit.build(idx);
-			commit.sign(idx);
+			await commit.sign(idx);
 			const request = {
 				targets: [fakeCommitter]
 			};
@@ -139,7 +139,7 @@ describe('Commit', () => {
 			endorsement._proposalResponses = [];
 			endorsement._proposalResponses.push(proposalResponse);
 			commit.build(idx);
-			commit.sign(idx);
+			await commit.sign(idx);
 			const request = {
 				targets: [fakeCommitter]
 			};
@@ -151,7 +151,7 @@ describe('Commit', () => {
 			endorsement._proposalResponses = [];
 			endorsement._proposalResponses.push(proposalResponse);
 			commit.build(idx);
-			commit.sign(idx);
+			await commit.sign(idx);
 			fakeCommitter.checkConnection.resolves(false);
 			const request = {
 				targets: [fakeCommitter]

--- a/fabric-common/test/DiscoveryService.js
+++ b/fabric-common/test/DiscoveryService.js
@@ -287,46 +287,46 @@ describe('DiscoveryService', () => {
 	describe('#send', () => {
 		it('throws if targets is missing', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			await discovery.send().should.be.rejectedWith('Missing targets parameter');
 		});
 		it('throws if targets is not an array', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			await discovery.send({targets: ''}).should.be.rejectedWith('Missing targets parameter');
 		});
 		it('throws if targets is an empty array', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			await discovery.send({targets: []}).should.be.rejectedWith('Missing targets parameter');
 		});
 		it('throws no results if targets is not missing', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			sinon.stub(discoverer, 'sendDiscovery').resolves({});
 			await discovery.send({targets: [discoverer]}).should.be.rejectedWith('DiscoveryService has failed to return results');
 		});
 		it('should be able to handle result error', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			sinon.stub(discoverer, 'sendDiscovery').resolves(new Error('forced error'));
 			await discovery.send({targets: [discoverer]}).should.be.rejectedWith('forced error');
 		});
 		it('should be able to handle rejected error', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			sinon.stub(discoverer, 'sendDiscovery').rejects(new Error('forced error'));
 			await discovery.send({targets: [discoverer]}).should.be.rejectedWith('forced error');
 		});
 		it('throws no results if results includes and error', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results:[{result: 'error', error: {content: 'result error'}}]});
 			await discovery.send({targets: [discoverer]}).should.be.rejectedWith('DiscoveryService: mydiscovery error: result error');
 		});
 		it('handle results from config with preexist target', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'peer1';
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult]});
 			discovery.targets = [discoverer];
@@ -335,7 +335,7 @@ describe('DiscoveryService', () => {
 		});
 		it('handle results from config', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'peer1';
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult]});
 			const results = await discovery.send({targets: [discoverer]});
@@ -343,7 +343,7 @@ describe('DiscoveryService', () => {
 		});
 		it('handle results from config with no orderers', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'peer1';
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult2]});
 			const results = await discovery.send({targets: [discoverer]});
@@ -351,7 +351,7 @@ describe('DiscoveryService', () => {
 		});
 		it('handle results from config if endorser exist', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'host.com:1000';
 			channel.addEndorser(endorser);
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult]});
@@ -360,7 +360,7 @@ describe('DiscoveryService', () => {
 		});
 		it('handle results with members', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'peer2';
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult, members]});
 			const results = await discovery.send({targets: [discoverer]});
@@ -368,7 +368,7 @@ describe('DiscoveryService', () => {
 		});
 		it('handle results with bad members', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'peer3';
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult, bad_members]});
 			const results = await discovery.send({targets: [discoverer], asLocalhost: true});
@@ -377,7 +377,7 @@ describe('DiscoveryService', () => {
 		});
 		it('handle results with chaincode query res', async () => {
 			discovery.build(idx);
-			discovery.sign(idx);
+			await discovery.sign(idx);
 			endorser.name = 'peer4';
 			endorser.connect = sinon.stub().throws(new Error('bad connect'));
 			sinon.stub(discoverer, 'sendDiscovery').resolves({results: [configResult, ccQueryRes]});

--- a/fabric-common/test/IdentityContext.js
+++ b/fabric-common/test/IdentityContext.js
@@ -80,12 +80,10 @@ describe('IdentityContext', () => {
 
 	describe('#sign', () => {
 		it('should require a payload', () => {
-			(() => {
-				idx.sign();
-			}).should.throw('Missing payload parameter');
+			return idx.sign().should.be.rejectedWith('Missing payload parameter');
 		});
-		it('should serializeIdentity', () => {
-			const signature = idx.sign(Buffer.from('payload'));
+		it('should serializeIdentity', async () => {
+			const signature = await idx.sign(Buffer.from('payload'));
 			should.exist(signature);
 		});
 	});

--- a/fabric-common/test/Proposal.js
+++ b/fabric-common/test/Proposal.js
@@ -229,12 +229,12 @@ describe('Proposal', () => {
 	describe('#send', () => {
 		it('throws if targets is missing', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			await proposal.send().should.be.rejectedWith('Missing targets parameter');
 		});
 		it('returns no results', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			sinon.stub(endorser, 'sendProposal').resolves({});
 			const results = await proposal.send({targets: [endorser]});
 			should.exist(results.errors);
@@ -244,7 +244,7 @@ describe('Proposal', () => {
 		});
 		it('should be able to handle result error', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			sinon.stub(endorser, 'sendProposal').resolves(new Error('forced resolved error'));
 			const results = await proposal.send({targets: [endorser]});
 			should.exist(results.errors);
@@ -254,7 +254,7 @@ describe('Proposal', () => {
 		});
 		it('should be able to handle rejected error', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			sinon.stub(endorser, 'sendProposal').rejects(new Error('forced rejected error'));
 			const results = await proposal.send({targets: [endorser]});
 			should.exist(results.errors);
@@ -264,7 +264,7 @@ describe('Proposal', () => {
 		});
 		it('should have responses when status included', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			sinon.stub(endorser, 'sendProposal').resolves({response: {status: 200}});
 			proposal.compareProposalResponseResults = sinon.stub().returns(true);
 			const results = await proposal.send({targets: [endorser]});
@@ -275,7 +275,7 @@ describe('Proposal', () => {
 		});
 		it('should have queryResults when this is a query', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			proposal.type = 'Query';
 			sinon.stub(endorser, 'sendProposal').resolves({response: {status: 400, payload: 'query payload'}});
 			const results = await proposal.send({targets: [endorser]});
@@ -286,7 +286,7 @@ describe('Proposal', () => {
 		});
 		it('should have empty queryResults when this is a query and no good responses', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			proposal.type = 'Query';
 			sinon.stub(endorser, 'sendProposal').resolves({response: {status: 200}});
 			const results = await proposal.send({targets: [endorser]});
@@ -294,7 +294,7 @@ describe('Proposal', () => {
 		});
 		it('should have empty queryResults when this is a query and unknown responses', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			proposal.type = 'Query';
 			sinon.stub(endorser, 'sendProposal').resolves({response: {payload: 'query payload'}});
 			const results = await proposal.send({targets: [endorser]});
@@ -302,7 +302,7 @@ describe('Proposal', () => {
 		});
 		it('should have responses from handler when status included', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			sinon.stub(handler, 'endorse').resolves([{response: {status: 200}}]);
 			proposal.compareProposalResponseResults = sinon.stub().returns(true);
 			const results = await proposal.send({handler: handler});
@@ -313,7 +313,7 @@ describe('Proposal', () => {
 		});
 		it('should have responses from handler when status included', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			proposal.type = 'Query';
 			sinon.stub(handler, 'query').resolves([{response: {status: 200}}]);
 			const results = await proposal.send({handler: handler});
@@ -324,7 +324,7 @@ describe('Proposal', () => {
 		});
 		it('should have errors from handler when error included', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			sinon.stub(handler, 'endorse').resolves([new Error('Endorsement has failed')]);
 			const results = await proposal.send({handler: handler});
 			should.exist(results.errors);
@@ -334,7 +334,7 @@ describe('Proposal', () => {
 		});
 		it('should have errors from handler when error included', async () => {
 			proposal.build(idx);
-			proposal.sign(idx);
+			await proposal.sign(idx);
 			proposal.type = 'Query';
 			sinon.stub(handler, 'query').resolves([new Error('Endorsement has failed')]);
 			const results = await proposal.send({handler: handler});

--- a/fabric-common/test/ServiceAction.js
+++ b/fabric-common/test/ServiceAction.js
@@ -62,29 +62,23 @@ describe('ServiceAction', () => {
 
 	describe('#sign', () => {
 		it('should require param', () => {
-			(() => {
-				serviceAction.sign();
-			}).should.throw('Missing param parameter');
+			return serviceAction.sign().should.be.rejectedWith('Missing param parameter');
 		});
 		it('should require a payload', () => {
-			(() => {
-				serviceAction.sign(idx);
-			}).should.throw('The send payload has not been built');
+			return serviceAction.sign(idx).should.be.rejectedWith('The send payload has not been built');
 		});
 		it('should require a signature or identityContext', () => {
-			(() => {
-				serviceAction._payload = Buffer.from('payload');
-				serviceAction.sign({});
-			}).should.throw('param is an unknown signer or signature type');
-		});
-		it('should sign if identity context provided', () => {
 			serviceAction._payload = Buffer.from('payload');
-			serviceAction.sign(idx);
+			return serviceAction.sign({}).should.be.rejectedWith('param is an unknown signer or signature type');
+		});
+		it('should sign if identity context provided', async () => {
+			serviceAction._payload = Buffer.from('payload');
+			await serviceAction.sign(idx);
 			should.exist(serviceAction._signature);
 		});
-		it('should sign if signature (byte array) provided', () => {
+		it('should sign if signature (byte array) provided', async () => {
 			serviceAction._payload = Buffer.from('payload');
-			serviceAction.sign(Buffer.from('signature'));
+			await serviceAction.sign(Buffer.from('signature'));
 			should.exist(serviceAction._signature);
 		});
 	});

--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -61,7 +61,7 @@ export interface ICryptoSuite {
 	hash(msg: string, opts: any): string;
 	importKey(pem: string, opts?: KeyOpts): ICryptoKey | Promise<ICryptoKey>;
 	setCryptoKeyStore(cryptoKeyStore: ICryptoKeyStore): void;
-	sign(key: ICryptoKey, digest: Buffer): Buffer;
+	sign(key: ICryptoKey, digest: Buffer): Buffer | Promise<Buffer>;
 	verify(key: ICryptoKey, signature: Buffer, digest: Buffer): boolean;
 }
 
@@ -188,7 +188,7 @@ export class Discoverer extends ServiceEndpoint {
 export class ServiceAction {
 	public readonly name: string;
 	constructor(name: string);
-	public sign(parm: IdentityContext | Buffer): ServiceAction;
+	public sign(parm: IdentityContext | Buffer): Promise<ServiceAction>;
 
 	public getSignedProposal(): any;
 	public getSignedEnvelope(): any;
@@ -403,7 +403,7 @@ export class IdentityContext {
 	constructor(user: User, client: Client);
 	calculateTransactionId(): IdentityContext;
 	serializeIdentity(): Buffer;
-	sign(payload: Buffer): Buffer;
+	sign(payload: Buffer): Promise<Buffer>;
 }
 
 export interface BlockData {

--- a/fabric-network/src/contract.ts
+++ b/fabric-network/src/contract.ts
@@ -284,7 +284,7 @@ export class ContractImpl {
 
 			logger.debug('%s - using discovery interest %j', method, this.discoveryInterests);
 			this.discoveryService.build(idx, {interest: this.discoveryInterests});
-			this.discoveryService.sign(idx);
+			await this.discoveryService.sign(idx);
 
 			// go get the endorsement plan from the peer's discovery service
 			// to be ready to be used by the transaction's submit

--- a/fabric-network/src/impl/event/eventservicemanager.ts
+++ b/fabric-network/src/impl/event/eventservicemanager.ts
@@ -63,7 +63,7 @@ export class EventServiceManager {
 		}
 
 		eventService.build(this.identityContext, options);
-		eventService.sign(this.identityContext);
+		await eventService.sign(this.identityContext);
 		// targets must be previously assigned
 		await eventService.send();
 	}

--- a/fabric-network/src/network.ts
+++ b/fabric-network/src/network.ts
@@ -333,7 +333,7 @@ export class NetworkImpl implements Network {
 
 			// do the three steps
 			this.discoveryService.build(idx);
-			this.discoveryService.sign(idx);
+			await this.discoveryService.sign(idx);
 			logger.debug('%s - will discover asLocalhost:%s', method, options.asLocalhost);
 			await this.discoveryService.send({
 				asLocalhost: options.asLocalhost,

--- a/fabric-network/src/transaction.ts
+++ b/fabric-network/src/transaction.ts
@@ -256,7 +256,7 @@ export class Transaction {
 		// from the identity context
 		endorsement.build(this.identityContext, proposalBuildRequest);
 
-		endorsement.sign(this.identityContext);
+		await endorsement.sign(this.identityContext);
 
 		// ------- S E N D   P R O P O S A L
 		// This is where the request gets sent to the peers
@@ -299,7 +299,7 @@ export class Transaction {
 
 			const commit = endorsement.newCommit();
 			commit.build(this.identityContext);
-			commit.sign(this.identityContext);
+			await commit.sign(this.identityContext);
 
 			// -----  C O M M I T   E N D O R S E M E N T
 			// this is where the endorsement results are sent to the orderer
@@ -362,7 +362,7 @@ export class Transaction {
 
 		logger.debug('%s - build and sign the query', method);
 		queryProposal.build(this.identityContext, request);
-		queryProposal.sign(this.identityContext);
+		await queryProposal.sign(this.identityContext);
 
 		const query = new QueryImpl(queryProposal, this.gatewayOptions.queryHandlerOptions);
 

--- a/fabric-network/test/impl/event/stubeventservice.ts
+++ b/fabric-network/test/impl/event/stubeventservice.ts
@@ -149,7 +149,7 @@ export class StubEventService implements EventService {
 		return listener;
 	}
 
-	sign(parm: IdentityContext | Buffer): ServiceAction {
+	async sign(parm: IdentityContext | Buffer): Promise<ServiceAction> {
 		return null;
 	}
 

--- a/test/ts-scenario/steps/lib/utility/clientUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/clientUtils.ts
@@ -144,7 +144,7 @@ export async function buildChannelRequest(requestName: string, contractName: str
 		// and the sending steps broken out into separate API's that must
 		// be called individually.
 		endorsement.build(idx, endorsementRequest);
-		endorsement.sign(idx);
+		await endorsement.sign(idx);
 
 		// unique connection information will be used to build an endpoint
 		// used on connect()
@@ -177,7 +177,7 @@ export async function buildChannelRequest(requestName: string, contractName: str
 		await discoverer.connect(endpoints[0]);
 		// use the endorsement to build the discovery request
 		discovery.build(idx, {endorsement: endorsement});
-		discovery.sign(idx);
+		await discovery.sign(idx);
 		// discovery results will be based on the chaincode of the endorsement
 		const discoveryResults = await discovery.send({targets: [discoverer], asLocalhost: true});
 
@@ -263,7 +263,7 @@ export async function commitChannelRequest(requestName: string, clientName: stri
 			// The event service is channel based
 			const eventService: EventService = channel.newEventService(Constants.EVENT_HUB_DEFAULT_NAME);
 			eventService.build(requestObject.idx, {});
-			eventService.sign(requestObject.idx);
+			await eventService.sign(requestObject.idx);
 			const eventRequest: SendEventOptions = {
 				targets: [eventer],
 				requestTimeout: 10000
@@ -315,7 +315,7 @@ export async function commitChannelRequest(requestName: string, clientName: stri
 			// -When signing internally the idx must have a user with a signing identity.
 			const commit: Commit = endorsement.newCommit();
 			commit.build(requestObject.idx, {});
-			commit.sign(requestObject.idx);
+			await commit.sign(requestObject.idx);
 
 			const commitRequest: any = {
 				targets: [orderer], // could also use the orderer names
@@ -422,7 +422,7 @@ export async function queryChannelRequest(clientName: string, channelName: strin
 
 			// Build and sign the query
 			query.build(idx, buildQueryRequest);
-			query.sign(idx);
+			await query.sign(idx);
 
 			// Construct query request
 			const queryRequest: any = {
@@ -661,7 +661,7 @@ export async function startEventService(
 		}
 
 		eventService.build(idx, buildOptions);
-		eventService.sign(idx);
+		await eventService.sign(idx);
 
 		const peerNames: any = ccp.getPeersForChannel(channelName);
 		const endpoints: Endpoint[] = [];


### PR DESCRIPTION
`ICryptoSuite` interface of `fabric-common` support only synchronous `sign()` method. Which sound correct for `Default X509 Identity` and `HSM X509 Identity` provider. But to support other kind of identity providers (like Vault Transit Engine/PKCS#11 Proxy) which require network `I/O` to get the message signed, will require `sign()` function to be an asynchronous.

Main change in this PR

*From*
```js
export interface ICryptoSuite {
     // ....
     sign(key: ICryptoKey, digest: Buffer): Buffer ;
}
```
*To*
```js
export interface ICryptoSuite {
     // ....
     sign(key: ICryptoKey, digest: Buffer): Buffer | Promise<Buffer>;
}
```
[FABN-1724](https://jira.hyperledger.org/browse/FABN-1724?filter=-2)

Signed-off-by: Pritam Singh <pkspritam16@gmail.com>