### PR TITLE
FABN-1657: Retry block event service when no peers available (#481)

### DIFF
--- a/fabric-network/src/impl/event/blockeventsource.ts
+++ b/fabric-network/src/impl/event/blockeventsource.ts
@@ -33,6 +33,8 @@ function asLong(value?: string | number | Long): Long | undefined {
 	return undefined;
 }
 
+type State = 'ready' | 'started' | 'stopped';
+
 export class BlockEventSource {
 	private readonly eventServiceManager: EventServiceManager;
 	private eventService?: EventService;
@@ -41,7 +43,8 @@ export class BlockEventSource {
 	private readonly blockQueue: OrderedBlockQueue;
 	private readonly asyncNotifier: AsyncNotifier<BlockEvent>;
 	private readonly blockType: EventType;
-	private started = false;
+	private state: State = 'ready';
+	private restart?: NodeJS.Immediate;
 
 	constructor(eventServiceManager: EventServiceManager, options: ListenerOptions = {}) {
 		this.eventServiceManager = eventServiceManager;
@@ -64,30 +67,44 @@ export class BlockEventSource {
 		this.listeners.delete(listener);
 	}
 
+	private setState(state: State) {
+		if (this.state !== 'stopped') {
+			this.state = state;
+		}
+	}
+
 	close() {
+		this.setState('stopped');
+		logger.debug('state set to  - :%s', this.state);
+		this._close();
+	}
+
+	private _close() {
 		this.unregisterListener();
 		this.eventService?.close();
-		this.started = false;
+		this.setState('ready');
+		logger.debug('state set to  - :%s', this.state);
+		if (this.restart) {
+			clearImmediate(this.restart);
+		}
 	}
 
 	private async start() {
-		logger.debug('start - started:%s', this.started);
-
-		if (this.started) {
+		logger.debug('state - :%s', this.state);
+		if (this.state !== 'ready') {
 			return;
 		}
-
-		this.started = true;
+		this.state = 'started';
 
 		try {
 			this.eventService = this.eventServiceManager.newDefaultEventService();
 			this.registerListener(); // Register before start so no events are missed
 			logger.debug('start - calling startEventService');
-
 			await this.startEventService();
 		} catch (error) {
 			logger.error('Failed to start event service', error);
-			this.close();
+			this._close();
+			this.restart = setImmediate(() => this.start());
 		}
 	}
 
@@ -127,8 +144,8 @@ export class BlockEventSource {
 
 	private blockEventCallback(error?: Error, event?: EventInfo)  {
 		if (error) {
-			this.close();
-			setImmediate(() => this.start()); // Must schedule after current event loop to avoid recursion in event service notification
+			this._close();
+			this.restart = setImmediate(() => this.start()); // Must schedule after current event loop to avoid recursion in event service notification
 		} else {
 			this.onBlockEvent(event!);
 		}

--- a/fabric-network/test/impl/event/blocklistener.spec.ts
+++ b/fabric-network/test/impl/event/blocklistener.spec.ts
@@ -28,7 +28,7 @@ describe('block listener', () => {
 	let eventServiceManager: EventServiceManager;
 	let eventService: StubEventService;
 	let gateway: sinon.SinonStubbedInstance<Gateway>;
-	let network: Network;
+	let network: NetworkImpl;
 	let channel: sinon.SinonStubbedInstance<Channel>;
 	let listener: StubBlockListener;
 	let listenerOptions: ListenerOptions;
@@ -276,6 +276,45 @@ describe('block listener', () => {
 
 			await startListener.completePromise;
 			sinon.assert.calledWith(stub, eventService, sinon.match.has('startBlock', Long.ONE));
+		});
+		it('retry initial connect of event service', async () => {
+			const startListener = testUtils.newAsyncListener<void>();
+			const stub = sinon.stub(eventServiceManager, "startEventService");
+			stub.onFirstCall().rejects();
+			stub.onSecondCall().callsFake(() => startListener());
+
+			await network.addBlockListener(listener, listenerOptions);
+			await startListener.completePromise
+
+			sinon.assert.callCount(stub, 2);
+		});
+
+		it('retry reconnect of event service after disconnection', async () => {
+			await network.addBlockListener(listener, listenerOptions);
+			const restartListener = testUtils.newAsyncListener<void>();
+			const stub = sinon.stub(eventServiceManager, "startEventService");
+			stub.onFirstCall().rejects();
+			stub.onSecondCall().callsFake(() => restartListener());
+
+			eventService.sendError(new Error('DISCONNECT'));
+			await restartListener.completePromise
+
+			sinon.assert.callCount(stub, 2);
+		});
+
+		it('end infinite event loop condition on peer disconnect', async () => {
+			await network.addBlockListener(listener, listenerOptions);
+			const startEventService = testUtils.newAsyncListener<void>(1);
+			sinon.stub(eventServiceManager, "startEventService").rejects();
+			eventService.sendError(new Error('DISCONNECT'));
+			network._dispose();
+		});
+
+		it('end infinite event loop condition on peer initial connect', async () => {
+			const startEventService = testUtils.newAsyncListener<void>(1);
+			sinon.stub(eventServiceManager, "startEventService").rejects();
+			await network.addBlockListener(listener, listenerOptions);
+			network._dispose();
 		});
 
 		it('listener does not receive old blocks on reconnect', async () => {


### PR DESCRIPTION
Signed-off-by: sapthasurendran <saptha.surendran@ibm.com>
(cherry picked from commit b562ae4d7b8c690cd008c98ff24dfd3fb78ade81)