### PR TITLE
add: more clear exception log error for no peers

### DIFF
--- a/fabric-network/src/impl/query/roundrobinqueryhandler.ts
+++ b/fabric-network/src/impl/query/roundrobinqueryhandler.ts
@@ -28,6 +28,13 @@ export class RoundRobinQueryHandler implements QueryHandler {
 		const method = 'evaluate';
 		logger.debug('%s - start', method);
 
+		if (this.peers.length == 0){
+			const message = util.format('Query failed. No available endorser peers.');
+			const error = new FabricError(message);
+			logger.error('evaluate:', error);
+			throw error;
+		}
+
 		const startPeerIndex = this.currentPeerIndex;
 		this.currentPeerIndex = (this.currentPeerIndex + 1) % this.peers.length;
 		const errorMessages = [];

--- a/fabric-network/src/impl/query/singlequeryhandler.ts
+++ b/fabric-network/src/impl/query/singlequeryhandler.ts
@@ -28,6 +28,13 @@ export class SingleQueryHandler implements QueryHandler {
 		const method = 'evaluate';
 		logger.debug('%s - start', method);
 
+		if (this.peers.length == 0){
+			const message = util.format('Query failed. No available endorser peers.');
+			const error = new FabricError(message);
+			logger.error('evaluate:', error);
+			throw error;
+		}
+
 		const startPeerIndex = this.currentPeerIndex;
 		const errorMessages = [];
 


### PR DESCRIPTION
# What does this PR do?

- Raises an exception if there are no endorsing peers in SingleQueryHandler peers list with a more informative error log;

# Why does it is relevant?

The evaluation method works like the presented fluxogram:

![image](https://user-images.githubusercontent.com/6313981/131119231-e2732f3f-505e-42b1-aa05-8e42ea1b972f.png)

By throwing an exception that doesn't inform the reason for the error (by presenting an empty error list), it may cause problems for developers to understand what it have to do in order to fix it.

Here is a some stackoverflow entries of users confused about this error:

- [SOUPTIK BANERJEE](https://stackoverflow.com/questions/66316846/singlequeryhandler-evaluate-message-query-failed-errors-stack-fabricer)