### PR TITLE
Fix build break

### DIFF
--- a/fabric-network/src/impl/query/query.ts
+++ b/fabric-network/src/impl/query/query.ts
@@ -99,8 +99,7 @@ export class QueryImpl implements Query {
 		} catch (error) {
 			// if we get an error, return this error for each peer
 			for (const peer of peers) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				results[peer.name] = error;
+				results[peer.name] = error as Error;
 				logger.error('%s - problem with query to peer %s error:%s', method, peer.name, error);
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-mocha": "^8.0.0",
     "ts-mock-imports": "^1.3.4",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.4",
+    "typescript": "~4.3.5",
     "winston": "^2.4.5"
   },
   "licenses": [

--- a/scripts/npm_scripts/checkLicense.sh
+++ b/scripts/npm_scripts/checkLicense.sh
@@ -9,12 +9,14 @@ CHECK=$(find . -type f \
     -not -path '*/.git/*' \
     -not -path '*/node_modules/*' \
     -not -path '*/vendor/*' \
+    -not -path './coverage/*' \
     -not -path './docs/*' \
     -not -path './LICENSE' \
     -not -path './test/fixtures/*' \
     -not -path './test/ts-fixtures/*' \
     -not -path './fabric-protos/bundle.js' \
     -not -path './fabric-protos/types/index.d.ts' \
+    -not -path './fabric-network/lib/*' \
     -not -name '.*' \
     -not -name '*.txt' \
     -not -name '*.rst' \
@@ -26,6 +28,7 @@ CHECK=$(find . -type f \
     -not -name '*.id' \
     -not -name '*.gradle' \
     -not -name '*.pem' \
+    -not -name '*.log' \
     -print | sort -u)
 
 if [[ -z "$CHECK" ]]; then

--- a/test/ts-scenario/steps/lib/channel.ts
+++ b/test/ts-scenario/steps/lib/channel.ts
@@ -159,7 +159,7 @@ export async function cli_channel_update(channelName: string, updateTx: string, 
 			BaseUtils.logMsg(`Channel ${channelName} has been updated`);
 		}
 	} catch (err) {
-		BaseUtils.logError('Failed to update channels: ', ((err as unknown as Error).stack ? (err as unknown as Error).stack : err));
+		BaseUtils.logError('Failed to update channels: ', ((err as Error).stack ? (err as Error).stack : err));
 		return Promise.reject(err);
 	}
 }


### PR DESCRIPTION
New TypeScript release caused compile / lint failures.

- Pinned to a more specific TypeScript version
- Minor type and lint changes
- Some additional exclusions to license check to avoid failures in development environment

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>