### PR TITLE
Fix build break (release-2.2)

### DIFF
--- a/fabric-network/src/impl/query/query.ts
+++ b/fabric-network/src/impl/query/query.ts
@@ -98,7 +98,7 @@ export class QueryImpl implements Query {
 		} catch (error) {
 			// if we get an error, return this error for each peer
 			for (const peer of peers) {
-				results[peer.name] = error;
+				results[peer.name] = error as Error;
 				logger.error('%s - problem with query to peer %s error:%s', method, peer.name, error);
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-mocha": "^8.0.0",
     "ts-node": "^9.1.1",
     "tslint": "^6.1.3",
-    "typescript": "^4.2.4",
+    "typescript": "~4.3.5",
     "winston": "^2.4.5"
   },
   "licenses": [


### PR DESCRIPTION
Cherry-pick of relevant parts of f1378ab7a08f07c29813cd572c0d88defbab8808 from main branch.

New TypeScript release caused compile / lint failures.

- Pinned to a more specific TypeScript version
- Minor type and lint changes

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>