### PR TITLE
FABN-1547:JSDoc Cleanup

### DIFF
--- a/fabric-common/lib/Channel.js
+++ b/fabric-common/lib/Channel.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Client.js
+++ b/fabric-common/lib/Client.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019, 2020 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Commit.js
+++ b/fabric-common/lib/Commit.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Committer.js
+++ b/fabric-common/lib/Committer.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Discoverer.js
+++ b/fabric-common/lib/Discoverer.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/DiscoveryService.js
+++ b/fabric-common/lib/DiscoveryService.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Endorsement.js
+++ b/fabric-common/lib/Endorsement.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Endorser.js
+++ b/fabric-common/lib/Endorser.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Endpoint.js
+++ b/fabric-common/lib/Endpoint.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/EventListener.js
+++ b/fabric-common/lib/EventListener.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/EventService.js
+++ b/fabric-common/lib/EventService.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Eventer.js
+++ b/fabric-common/lib/Eventer.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/IdentityContext.js
+++ b/fabric-common/lib/IdentityContext.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Proposal.js
+++ b/fabric-common/lib/Proposal.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Query.js
+++ b/fabric-common/lib/Query.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/ServiceAction.js
+++ b/fabric-common/lib/ServiceAction.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/ServiceEndpoint.js
+++ b/fabric-common/lib/ServiceEndpoint.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/ServiceHandler.js
+++ b/fabric-common/lib/ServiceHandler.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/Utils.js
+++ b/fabric-common/lib/Utils.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/fabric-common/lib/hash/hash_sha2_256.js
+++ b/fabric-common/lib/hash/hash_sha2_256.js
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Implement hash primitives.
- */
+
 const crypto = require('crypto');
 const Hash = require('../Hash');
-
+/*
+ * Implement hash primitives.
+ */
 class hash_sha2_256 extends Hash {
 
 	constructor() {

--- a/fabric-common/lib/hash/hash_sha2_384.js
+++ b/fabric-common/lib/hash/hash_sha2_384.js
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Implement hash primitives.
- */
+
 const crypto = require('crypto');
 const Hash = require('../Hash');
-
+/*
+ * Implement hash primitives.
+ */
 class hash_sha2_384 extends Hash {
 
 	constructor() {


### PR DESCRIPTION
Signed-off-by: sapthasurendran <saptha.surendran@ibm.com>
Removed double asterisk from copyright comments causing repeated <constant> TYPE in jsdoc