### PR TITLE
Fabric-Network 2 critical vulns with jsrsasign (release-2.2)

### DIFF
--- a/fabric-ca-client/package.json
+++ b/fabric-ca-client/package.json
@@ -21,7 +21,7 @@
   "types": "./types/index.d.ts",
   "dependencies": {
     "fabric-common": "file:../fabric-common",
-    "jsrsasign": "^8.0.24",
+    "jsrsasign": "^10.4.1",
     "url": "^0.11.0",
     "winston": "^2.4.5"
   },

--- a/fabric-common/lib/impl/ecdsa/key.js
+++ b/fabric-common/lib/impl/ecdsa/key.js
@@ -162,18 +162,17 @@ class ECDSA_KEY extends Key {
 			sbjpubkey: this.getPublicKey()._key,
 			ext: [
 				{
-					basicConstraints: {
-						cA: false,
-						critical: true
-					}
+					extname: 'basicConstraints',
+					cA: false,
+					critical: true
 				},
 				{
-					keyUsage: {bin: '11'}
+					extname: 'keyUsage',
+					bin: '11'
 				},
 				{
-					extKeyUsage: {
-						array: [{name: 'clientAuth'}]
-					}
+					extname: 'extKeyUsage',
+					array: [{name: 'clientAuth'}]
 				}
 			],
 			cakey: this._key

--- a/fabric-common/package.json
+++ b/fabric-common/package.json
@@ -29,7 +29,7 @@
 		"elliptic": "^6.5.4",
 		"fabric-protos": "file:../fabric-protos",
 		"js-sha3": "^0.8.0",
-		"jsrsasign": "^8.0.24",
+		"jsrsasign": "^10.4.1",
 		"long": "^4.0.0",
 		"nconf": "^0.11.2",
 		"promise-settle": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "fabric-protos": "file:./fabric-protos",
     "ink-docstrap": "^1.3.2",
     "jsdoc": "^3.6.6",
-    "jsrsasign": "^8.0.24",
+    "jsrsasign": "^10.4.1",
     "mocha": "^8.4.0",
     "nano": "^9.0.3",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Cherry-pick of 63fa2195d7c1981e3b28875a6e291608cee36d99 from main branch.

Resolves #500

* Bump jsrsasign from 8.0.24 to 10.4.1
* Primary changes made to support jsrsagin in Pkcs11EcdsaKey module
* replaced hexSig with sighex in csr object
* Changes made in CertificationRequest as per the new format
* Made changes in signCSR function as per jsrsasign package

Signed-off-by: Rajat Sharma <rajat.sharma@dltlabs.io>
Signed-off-by: Deepak Singh <deepak.singh2@dltlabs.io>
Co-authored-by: Rajat Sharma <rajat.sharma@dltlabs.io>
Co-authored-by: Deepak Singh <deepak.singh2@dltlabs.io>