### PR TITLE
Publish Contract JSDoc

### DIFF
--- a/fabric-network/src/contract.ts
+++ b/fabric-network/src/contract.ts
@@ -62,6 +62,9 @@ export interface Contract {
 	resetDiscoveryInterests(): Contract;
 }
 
+
+type DiscoveryResultsCallback = (hasResults: boolean) => void;
+
 /**
  * <p>Represents a smart contract (chaincode) instance in a network.
  * Applications should get a Contract instance using the
@@ -175,7 +178,6 @@ export interface Contract {
  * @memberof module:fabric-network
  * @return {DiscoveryInterest[]} - An array of DiscoveryInterest
  */
-
 /**
  * A callback function that will be invoked when a block event is received.
  * @callback ContractListener
@@ -184,8 +186,6 @@ export interface Contract {
  * @param {module:fabric-network.ContractEvent} event Contract event.
  * @returns {Promise<void>}
  */
-type DiscoveryResultsCallback = (hasResults: boolean) => void;
-
 export class ContractImpl {
 	readonly chaincodeId: string;
 	readonly namespace: string;

--- a/fabric-network/src/transaction.ts
+++ b/fabric-network/src/transaction.ts
@@ -242,6 +242,8 @@ export class Transaction {
 	 * @returns {Buffer} Payload response from the transaction function.
 	 * @throws {module:fabric-network.TimeoutError} If the transaction was successfully submitted to the orderer but
 	 * timed out before a commit event was received from peers.
+	 * @throws {module:fabric-network.TransactionError} If the transaction committed with an unsuccessful transaction
+	 * validation code, and so did not update the ledger.
 	 */
 	async submit(...args: string[]): Promise<Buffer> {
 		const method = `submit[${this.name}]`;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dockerClean": "./scripts/npm_scripts/dockerClean.sh",
     "compile": "tsc --project fabric-network/tsconfig.json",
     "lint": "eslint . --ext .ts,.js",
-    "docs": "node -e 'require(\"./scripts/npm_scripts/testFunctions.js\").cleanUpDocs()' && jsdoc -c docs/jsdoc.json -t ./node_modules/ink-docstrap/template",
+    "docs": "node -e 'require(\"./scripts/npm_scripts/testFunctions.js\").cleanUpDocs()' && jsdoc -c docs/jsdoc.json -t ./node_modules/ink-docstrap/template --pedantic --recurse",
     "unitTest:all": "export HFC_LOGGING='{\"debug\":\"test/temp/debug.log\"}' && nyc run-s unitTest:common unitTest:ca-client unitTest:network",
     "unitTest:common": "mocha --reporter list 'fabric-common/test/**/*.js'",
     "unitTest:ca-client": "mocha --reporter list 'fabric-ca-client/test/**/*.js'",


### PR DESCRIPTION
This was being excluded from the generated JavaScript files as it was not immediately above a class definition that would be written to the JavaScript file by the TypeScript compiler.

Also add the TransactionError as a possible thrown exception from Transaction.submit().

Resolves #504 