### PR TITLE
Use chaincode action response payload as transaction result

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -115,7 +115,7 @@ export interface EndorsementResponse {
 		payload: Buffer;
 	};
 	payload: Buffer;
-	endorsement: {
+	endorsement?: {
 		endorser: Buffer;
 		signature: Buffer;
 	};

--- a/fabric-network/src/impl/gatewayutils.ts
+++ b/fabric-network/src/impl/gatewayutils.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {EndorsementResponse} from 'fabric-common';
+import {protos} from 'fabric-protos';
+
 /**
  * Knuth shuffle of array elements. The supplied array is directly modified.
  * @private
@@ -75,3 +78,25 @@ export function notNullish<T>(value?: T): value is T {
 }
 
 export type Mandatory<T> = { [P in keyof T]-?: NonNullable<T[P]> };
+
+export function assertDefined<T>(value: T | null | undefined, message: string): T {
+	if (value == undefined) { // eslint-disable-line eqeqeq
+		throw new Error(message);
+	}
+
+	return value;
+}
+
+export function asBuffer(bytes: Uint8Array | null | undefined): Buffer {
+	if (!bytes) {
+		return Buffer.alloc(0);
+	}
+
+	return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength); // Create a Buffer view to avoid copying
+}
+
+export function getTransactionResponse(proposalResponse: EndorsementResponse): protos.IResponse {
+	const responsePayload = protos.ProposalResponsePayload.decode(proposalResponse.payload);
+	const chaincodeAction = protos.ChaincodeAction.decode(responsePayload.extension);
+	return assertDefined(chaincodeAction.response, 'Missing chaincode action response');
+}

--- a/fabric-network/src/transaction.ts
+++ b/fabric-network/src/transaction.ts
@@ -9,14 +9,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import {BuildProposalRequest, CommitSendRequest, EndorsementResponse, Endorser, IdentityContext, ProposalResponse, SendProposalRequest} from 'fabric-common';
+import * as util from 'util';
 import {ContractImpl} from './contract';
+import {ConnectedGatewayOptions} from './gateway';
+import * as EventHandlers from './impl/event/defaulteventhandlerstrategies';
 import {TxEventHandlerFactory} from './impl/event/transactioneventhandler';
+import {asBuffer, getTransactionResponse} from './impl/gatewayutils';
 import {QueryImpl} from './impl/query/query';
 import {QueryHandler} from './impl/query/queryhandler';
-import * as EventHandlers from './impl/event/defaulteventhandlerstrategies';
 import * as Logger from './logger';
-import * as util from 'util';
-import {ConnectedGatewayOptions} from './gateway';
+
 const logger = Logger.getLogger('Transaction');
 
 function getResponsePayload(proposalResponse: ProposalResponse): Buffer {
@@ -28,7 +30,9 @@ function getResponsePayload(proposalResponse: ProposalResponse): Buffer {
 		throw error;
 	}
 
-	return validEndorsementResponse.response.payload;
+	const payload = getTransactionResponse(validEndorsementResponse).payload;
+
+	return asBuffer(payload);
 }
 
 function getValidEndorsementResponse(endorsementResponses: EndorsementResponse[]): EndorsementResponse | undefined {

--- a/fabric-network/test/testutils.ts
+++ b/fabric-network/test/testutils.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as os from 'os';
+import {EndorsementResponse} from 'fabric-common';
+import {protos} from 'fabric-protos';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
+
 import _rimraf = require('rimraf');
 const rimraf = util.promisify(_rimraf);
 
@@ -65,3 +68,32 @@ export async function rmdir(directory: string): Promise<void> {
 }
 
 export type Mutable<T> = { -readonly [P in keyof T]: T[P]; }
+
+export function newEndorsementResponse(response: protos.IResponse, properties: Partial<EndorsementResponse> = {}): EndorsementResponse {
+	const payload = protos.ProposalResponsePayload.encode({
+		extension: protos.ChaincodeAction.encode({
+			response,
+		}).finish(),
+	}).finish();
+
+	const template: EndorsementResponse = {
+		connection: {
+			name: 'name',
+			options: {},
+			type: 'peer',
+			url: 'grpc://example.org:1337',
+		},
+		endorsement: {
+			endorser: Buffer.alloc(0),
+			signature: Buffer.alloc(0),
+		},
+		payload: Buffer.from(payload),
+		response: {
+			message: response.message,
+			payload: Buffer.alloc(0),
+			status: response.status ?? 200,
+		},
+	};
+
+	return Object.assign(template, properties);
+}


### PR DESCRIPTION
The top-level response payload in the proposal response is not required to contain the transaction result and may be used to hold metadata. Even though current Fabric implementations typically duplicate the transaction result in the top-level response payload, this actually causes failures due to message size limits in some cases, so might change and should not be relied upon.