### PR TITLE
Fix regression in ECDSA_KEY.generateCSR()

### DIFF
--- a/fabric-common/lib/Utils.js
+++ b/fabric-common/lib/Utils.js
@@ -622,3 +622,43 @@ module.exports.randomize = (items) => {
 module.exports.checkParameter = (name) => {
 	throw Error(`Missing ${name} parameter`);
 };
+
+/**
+ * Map CSRUtil.newCSRPEM style extensions:
+ * ```
+ * {
+ *     subjectAltName: {
+ *         array: [...],
+ *     },
+ * }
+ * ```
+ *
+ * to CertificationRequest style extensions:
+ * ```
+ * {
+ *     extname: 'subjectAltName',
+ *     array: [...],
+ * }
+ * ```
+ * @private
+ */
+module.exports.mapCSRExtensions = (extensions) => {
+	if (!Array.isArray(extensions)) {
+		return extensions;
+	}
+
+	const results = [];
+	extensions.forEach(extension => {
+		const isCertificationRequestExtension = typeof extension.extname === 'string';
+		if (isCertificationRequestExtension) {
+			results.push(extension);
+		} else {
+			Object.entries(extension).forEach(([extname, props]) => {
+				const extensionRequest = Object.assign({}, props, {extname});
+				results.push(extensionRequest);
+			});
+		}
+	});
+
+	return results;
+};

--- a/fabric-common/lib/impl/ecdsa/key.js
+++ b/fabric-common/lib/impl/ecdsa/key.js
@@ -10,6 +10,7 @@
 const Key = require('../../Key');
 const HashPrimitives = require('../../HashPrimitives');
 const jsrsa = require('jsrsasign');
+const Utils = require('../../Utils');
 const asn1 = jsrsa.asn1;
 const KEYUTIL = jsrsa.KEYUTIL;
 const ECDSA = jsrsa.ECDSA;
@@ -118,20 +119,20 @@ class ECDSA_KEY extends Key {
 	 * @throws Will throw an error if CSR generation fails for any other reason
 	 */
 	generateCSR(subjectDN, extensions) {
-
 		// check to see if this is a private key
 		if (!this.isPrivate()) {
 			throw new Error('A CSR cannot be generated from a public key');
 		}
 
-		const csr = asn1.csr.CSRUtil.newCSRPEM({
+		const extreq = Utils.mapCSRExtensions(extensions);
+		const csr = new asn1.csr.CertificationRequest({
 			subject: {str: asn1.x509.X500Name.ldapToOneline(subjectDN)},
 			sbjpubkey: this.getPublicKey()._key,
 			sigalg: 'SHA256withECDSA',
 			sbjprvkey: this._key,
-			ext: extensions
+			extreq,
 		});
-		return csr;
+		return csr.getPEM();
 	}
 
 	/**

--- a/fabric-common/lib/impl/ecdsa/pkcs11_key.js
+++ b/fabric-common/lib/impl/ecdsa/pkcs11_key.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const Key = require('../../Key');
+const Utils = require('../../Utils');
 const jsrsa = require('jsrsasign');
 const asn1 = jsrsa.asn1;
 
@@ -112,16 +113,7 @@ const Pkcs11EcdsaKey = class extends Key {
 		}
 		const ecdsa = new EC(this._cryptoSuite._ecdsaCurve);
 		const pubKey = ecdsa.keyFromPublic(this._pub._ecpt);
-		const extreq = [];
-		if (param.ext !== undefined && param.ext.length !== undefined) {
-			for (const ext of param.ext) {
-				for (const extname in ext) {
-					const extObj = ext[extname];
-					extObj.extname = extname;
-					extreq.push(extObj);
-				}
-			}
-		}
+		const extreq = Utils.mapCSRExtensions(param.ext);
 		const sigAlgName = param.sigalg;
 		const csr = new _KJUR_asn1_csr.CertificationRequest({
 			subject: param.subject,


### PR DESCRIPTION
Subject alternative names extensions were not being correctly handled. Moving to non-deprecated jsrsasign API call and implementing some translation between previous extension format and the one required by the new API call.

Resolves #536