### PR TITLE
Fix environment variables to correctly data format

### DIFF
--- a/fabric-common/lib/Config.js
+++ b/fabric-common/lib/Config.js
@@ -15,27 +15,20 @@ const nconf = require('nconf');
 class Config {
 
 	constructor() {
-		nconf.use('memory');
 		nconf.argv();
-		nconf.env({parseValues: true});
+		nconf.env({
+			parseValues: true,
+			lowerCase: true,
+			transform: function(obj) {
+				obj.key = obj.key.replace(/_/g, '-');
+				return obj;
+			}
+		});
 		nconf.use('mapenv', {type:'memory'});
-		this.mapSettings(nconf.stores.mapenv, process.env);
+		nconf.stores.mapenv.store = nconf.stores.env.store;
 		this._fileStores = [];
 		// reference to configuration settings
 		this._config = nconf;
-	}
-
-	//
-	//	 utility method to map (convert) the environment(upper case and underscores) style
-	//	 names to configuration (lower case and dashes) style names
-	//
-	mapSettings(store, settings) {
-		for (let key in settings) {
-			const value = settings[key];
-			key = key.toLowerCase();
-			key = key.replace(/_/g, '-');
-			store.set(key, value);
-		}
 	}
 
 	//

--- a/fabric-common/test/Config.js
+++ b/fabric-common/test/Config.js
@@ -30,23 +30,17 @@ describe('Config', () => {
 	});
 
 	describe('#constructor', () => {
-		let mapSettingsStub;
 
 		beforeEach(() => {
 			sandbox.stub(nconf, 'use');
 			sandbox.stub(nconf, 'argv');
 			sandbox.stub(nconf, 'env');
-			nconf.stores.mapenv = 'mapenv';
-			mapSettingsStub = sandbox.stub();
-			revert.push(ConfigRewire.__set__('Config.prototype.mapSettings', mapSettingsStub));
 			revert.push(ConfigRewire.__set__('nconf', nconf));
 			process.env.property = 'test-property';
 		});
 
-		it('should call nconf, Config.mapSettings and set the correct properties', () => {
+		it('should call nconf and set the correct properties', () => {
 			const config = new ConfigRewire();
-			sinon.assert.calledWith(mapSettingsStub, nconf.stores.mapenv, sinon.match.hasOwn('property', 'test-property'));
-			sinon.assert.calledWith(nconf.use, 'memory');
 			sinon.assert.called(nconf.argv);
 			sinon.assert.called(nconf.env);
 			sinon.assert.calledWith(nconf.use, 'mapenv', {type: 'memory'});
@@ -57,25 +51,6 @@ describe('Config', () => {
 		afterEach(() => {
 			// Unset process.env.property
 			process.env.property = undefined;
-		});
-	});
-
-	describe('#mapSettings', () => {
-		let storeStub;
-
-		beforeEach(() => {
-			storeStub = {set: () => {}};
-			sandbox.stub(storeStub, 'set');
-		});
-
-		it('should add the settings to the store', () => {
-			const config = new Config();
-			config.mapSettings(storeStub, {'setting1': 'value1', 'setting2': 'value2'});
-			sinon.assert.calledTwice(storeStub.set);
-			storeStub.set.getCall(0).args[0].should.equal('setting1');
-			storeStub.set.getCall(0).args[1].should.equal('value1');
-			storeStub.set.getCall(1).args[0].should.equal('setting2');
-			storeStub.set.getCall(1).args[1].should.equal('value2');
 		});
 	});
 


### PR DESCRIPTION
process.env will implicitly convert the value to a string.
If an environment value is set as a boolean or number, the value
will be a string. This patch uses environment value from nconf.env
not process.env.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>
Reported-by: Shinsuke Hasegawa <shinsuke.hasegawa.fc@hitachi.com>

Resolves #553