### PR TITLE
Avoid bug in typescript-eslint@5.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "^10.0.0",
     "@types/tape": "^4.2.33",
-    "@typescript-eslint/eslint-plugin": "^5.3.0",
+    "@typescript-eslint/eslint-plugin": "~5.12.1",
     "@typescript-eslint/parser": "^5.3.0",
     "bn.js": "^5.2.0",
     "chai": "^4.3.4",


### PR DESCRIPTION
Pin to ~5.12.1 to avoid bug in v5.13.0 causing false positives in async Mocha tests.

https://github.com/typescript-eslint/typescript-eslint/issues/4609