### PR TITLE
Define endorseTimeout value in fabric-sdk-node v1.4(Issue #552)

### DIFF
--- a/fabric-network/lib/gateway.js
+++ b/fabric-network/lib/gateway.js
@@ -36,6 +36,8 @@ const logger = require('./logger').getLogger('Gateway');
  * @memberof module:fabric-network
  * @property {number} [commitTimeout = 300] The timeout period in seconds to wait for commit notification to
  * complete.
+ * @property {number} [endorseTimeout = 45] The timeout period in seconds to wait
+ * for the endorsement to complete.
  * @property {?module:fabric-network.Gateway~TxEventHandlerFactory} [strategy=MSPID_SCOPE_ALLFORTX] Event handling strategy to identify
  * successful transaction commits. A null value indicates that no event handling is desired. The default is
  * [MSPID_SCOPE_ALLFORTX]{@link module:fabric-network.DefaultEventHandlerStrategies}.
@@ -154,6 +156,7 @@ class Gateway {
 			},
 			eventHandlerOptions: {
 				commitTimeout: 300, // 5 minutes
+				endorseTimeout: 45, // Same as "request-timeout" default value in fabric-client/config/default.json
 				strategy: EventStrategies.MSPID_SCOPE_ALLFORTX
 			},
 			discovery: {

--- a/fabric-network/lib/transaction.js
+++ b/fabric-network/lib/transaction.js
@@ -175,14 +175,11 @@ class Transaction {
 		}
 		request.endorsement_hint = {chaincodes: this._contract.getDiscoveryInterests()};
 
-		const commitTimeout = options.commitTimeout * 1000; // in ms
-		let timeout = this._contract.gateway.getClient().getConfigSetting('request-timeout', commitTimeout);
-		if (timeout < commitTimeout) {
-			timeout = commitTimeout;
-		}
+		// Same as v2.2, define the endorseTimeout property which is used as the timeout for endorsement of the proposal
+		const endorseTimeout = options.endorseTimeout * 1000; // in ms
 
 		// node sdk will target all peers on the channel that are endorsingPeer or do something special for a discovery environment
-		const results = await channel.sendTransactionProposal(request, timeout);
+		const results = await channel.sendTransactionProposal(request, endorseTimeout);
 		const proposalResponses = results[0];
 		const proposal = results[1];
 

--- a/fabric-network/test/network.js
+++ b/fabric-network/test/network.js
@@ -92,6 +92,7 @@ describe('Network', () => {
 			},
 			eventHandlerOptions: {
 				commitTimeout: 300,
+				endorseTimeout: 45,
 				strategy: EventStrategies.MSPID_SCOPE_ALLFORTX
 			},
 			queryHandlerOptions: {

--- a/fabric-network/test/transaction.js
+++ b/fabric-network/test/transaction.js
@@ -300,16 +300,10 @@ describe('Transaction', () => {
 			return expect(promise).to.be.rejectedWith('Transaction has already been invoked');
 		});
 
-		it('sends proposal with long timeout', async () => {
+		it('uses endorseTimeout option as proposal timeout', async () => {
 			stubContract.getEventHandlerOptions.returns({endorseTimeout: 999});
 			await transaction.submit();
 			sinon.assert.calledWith(channel.sendTransactionProposal, sinon.match(expectedProposal), 999000);
-		});
-
-		it('sends proposal with short timeout', async () => {
-			stubContract.getEventHandlerOptions.returns({endorseTimeout: 3});
-			await transaction.submit();
-			sinon.assert.calledWith(channel.sendTransactionProposal, sinon.match(expectedProposal), 3000);
 		});
 
 		it('sends proposal to specified peers', async () => {

--- a/fabric-network/test/transaction.js
+++ b/fabric-network/test/transaction.js
@@ -301,15 +301,15 @@ describe('Transaction', () => {
 		});
 
 		it('sends proposal with long timeout', async () => {
-			stubContract.getEventHandlerOptions.returns({commitTimeout: 999});
+			stubContract.getEventHandlerOptions.returns({endorseTimeout: 999});
 			await transaction.submit();
 			sinon.assert.calledWith(channel.sendTransactionProposal, sinon.match(expectedProposal), 999000);
 		});
 
 		it('sends proposal with short timeout', async () => {
-			stubContract.getEventHandlerOptions.returns({commitTimeout: 3});
+			stubContract.getEventHandlerOptions.returns({endorseTimeout: 3});
 			await transaction.submit();
-			sinon.assert.calledWith(channel.sendTransactionProposal, sinon.match(expectedProposal), 45000);
+			sinon.assert.calledWith(channel.sendTransactionProposal, sinon.match(expectedProposal), 3000);
 		});
 
 		it('sends proposal to specified peers', async () => {


### PR DESCRIPTION
In fabric-sdk-node v1.4, as well as in v2.2, define "endorseTimeout" value and use it instead of commitTimeout.

Co-Authored-by: Shinsuke Hasegawa <shinsuke.hasegawa.fc@hitachi.com>
Signed-off-by: takayuki-nagai <takayuki.nagai.nu@hitachi.com>

Closes #552 