### PR TITLE
Use only GitHub Actions for PR and scheduled builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,12 @@
-name: Tests
+name: Build
 
 on:
-  push:
-    branches: [ main ]
+  # push:
+  #   branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+  schedule:
+    - cron: "30 23 * * *"
 
 env:
   FABRIC_VERSION: 2.2
@@ -12,29 +14,34 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [14.x, 16.x]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Install SoftHSM
-      run: |
-        sudo apt-get install softhsm2
-        softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
+      - name: Install SoftHSM
+        run: |
+          sudo apt-get install softhsm2
+          softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
 
-    - name: Build and run tests
-      run: |
-        npm install
-        npm run installAndGenerateCerts
-        npm run pullFabricImages
-        npm test
+      - name: npm install
+        run: npm install
 
+      - name: Generate credentials
+        run: npm run installAndGenerateCerts
+
+      - name: Pull Fabric images
+        run: npm run pullFabricImages
+
+      - name: Run tests
+        run: npm test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,19 +5,13 @@
 
 # Pipeline-level keywords belong here
 
-schedules:
-  - cron: "0 0 * * *" # https://crontab.guru/#0_0_*_*_*
-    displayName: "Daily midnight build"
-    branches:
-      include:
-        - main
-    always: true
-
 trigger:
 - main
 
 pr:
-  - main
+  branches:
+    exclude:
+      - '*'
 
 pool:
   vmImage: 'ubuntu-20.04'


### PR DESCRIPTION
Azure Pipelines now only triggers on pushes when a PR is merged, to deal with publishing, until this can be migrated to GitHub Actions.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>