### PR TITLE
Refactor DiscoveryService usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,17 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: "Archive unit test debug log"
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.node-version }}-unit-test-debug.log
+          path: test/temp/debug.log
+
+      - name: "Archive scenario test debug log"
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.node-version }}-cucumber-debug.log
+          path: test/temp/debugc.log

--- a/fabric-common/lib/DiscoveryResultsProcessor.js
+++ b/fabric-common/lib/DiscoveryResultsProcessor.js
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2022 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const TYPE = 'DiscoveryResultsProcessor';
+const Long = require('long');
+
+const {byteToNormalizedPEM, checkParameter, getLogger} = require('./Utils.js');
+
+const logger = getLogger(TYPE);
+
+const fabproto6 = require('fabric-protos');
+
+class DiscoveryResultsProcessor {
+	constructor(service, results) {
+		this.service = service;
+		this.results = results;
+		this.parsedResults = {};
+	}
+
+	async parseDiscoveryResults() {
+		const method = `parseDiscoveryResults[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+
+		for (const index in this.results) {
+			const result = this.results[index];
+			if (result.result === 'error') {
+				logger.error(`${method} - Channel:${this.service.channel.name} received discovery error:${result.error.content}`);
+				throw Error(`DiscoveryService: ${this.service.name} error: ${result.error.content}`);
+			}
+
+			logger.debug(`${method} - process result index:${index}`);
+			if (result.config_result) {
+				logger.debug(`${method} - process result - have configResult in ${index}`);
+				const config = this._processConfig(result.config_result);
+				this.parsedResults.msps = config.msps;
+				this.parsedResults.orderers = await this._buildOrderers(config.orderers);
+			}
+			if (result.members) {
+				logger.debug(`${method} - process result - have members in ${index}`);
+				this.parsedResults.peers_by_org = await this._processMembership(result.members);
+			}
+			if (result.cc_query_res) {
+				logger.debug(`${method} - process result - have ccQueryRes in ${index}`);
+				this.parsedResults.endorsement_plan = await this._processChaincode(result.cc_query_res);
+			}
+			logger.debug(`${method} - completed processing result ${index}`);
+		}
+
+		return this.parsedResults;
+	}
+
+	_processConfig(q_config) {
+		const method = `_processConfig[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+		const config = {};
+		config.msps = {};
+		config.orderers = {};
+
+		try {
+			if (q_config.msps) {
+				for (const id in q_config.msps) {
+					logger.debug(`${method} - found organization ${id}`);
+					const q_msp = q_config.msps[id];
+					const msp_config = {
+						id: id,
+						name: id,
+						organizationalUnitIdentifiers: q_msp.organizational_unit_identifiers,
+						rootCerts: byteToNormalizedPEM(q_msp.root_certs),
+						intermediateCerts: byteToNormalizedPEM(q_msp.intermediate_certs),
+						admins: byteToNormalizedPEM(q_msp.admins),
+						tlsRootCerts: byteToNormalizedPEM(q_msp.tls_root_certs),
+						tlsIntermediateCerts: byteToNormalizedPEM(q_msp.tls_intermediate_certs)
+					};
+					config.msps[id] = msp_config;
+					this.service.channel.addMsp(msp_config, true);
+				}
+			} else {
+				logger.debug(`${method} - no msps found`);
+			}
+			/*
+			"orderers":{"OrdererMSP":{"endpoint":[{"host":"orderer.example.com","port":7050}]}}}
+			*/
+			if (q_config.orderers) {
+				for (const mspid in q_config.orderers) {
+					logger.debug(`${method} - found orderer org: ${mspid}`);
+					config.orderers[mspid] = {};
+					config.orderers[mspid].endpoints = [];
+					for (const endpoint of q_config.orderers[mspid].endpoint) {
+						config.orderers[mspid].endpoints.push(endpoint);
+					}
+				}
+			} else {
+				logger.debug(`${method} - no orderers found`);
+			}
+		} catch (err) {
+			logger.error(`${method} - Problem with discovery config: ${err}`);
+		}
+
+		return config;
+	}
+
+	async _buildOrderers(orderers) {
+		const method = `_buildOrderers[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+
+		if (!orderers) {
+			logger.debug('%s - no orderers to build', method);
+		} else {
+			for (const msp_id in orderers) {
+				logger.debug(`${method} - orderer msp:${msp_id}`);
+				for (const endpoint of orderers[msp_id].endpoints) {
+					endpoint.name = await this._buildOrderer(endpoint.host, endpoint.port, msp_id);
+				}
+			}
+		}
+
+		return orderers;
+	}
+
+	async _buildOrderer(host, port, msp_id) {
+		const method = `_buildOrderer[${this.service.name}]`;
+		logger.debug(`${method} - start mspid:${msp_id} endpoint:${host}:${port}`);
+
+		const name = `${host}:${port}`;
+		const url = this.service._buildUrl(host, port);
+		logger.debug(`${method} - create a new orderer ${url}`);
+		const orderer = this.service.client.newCommitter(name, msp_id);
+		const end_point = this.service.client.newEndpoint(this._buildOptions(name, url, host, msp_id));
+		try {
+			// first check to see if orderer is already on this channel
+			let same;
+			const channelOrderers = this.service.channel.getCommitters();
+			for (const channelOrderer of channelOrderers) {
+				logger.debug('%s - checking %s', method, channelOrderer);
+				if (channelOrderer.endpoint && channelOrderer.endpoint.url === url) {
+					same = channelOrderer;
+					break;
+				}
+			}
+			if (!same) {
+				await orderer.connect(end_point);
+				this.service.channel.addCommitter(orderer);
+			} else {
+				await same.checkConnection();
+				logger.debug('%s - orderer already added to this channel', method);
+			}
+		} catch (error) {
+			logger.error(`${method} - Unable to connect to the discovered orderer ${name} due to ${error}`);
+		}
+
+		return name;
+	}
+
+	_buildOptions(name, url, host, msp_id) {
+		const method = `_buildOptions[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+		const caroots = this._buildTlsRootCerts(msp_id);
+		return {
+			url: url,
+			pem: caroots,
+			'ssl-target-name-override': host,
+			name: name
+		};
+	}
+
+	_buildTlsRootCerts(msp_id = checkParameter('msp_id')) {
+		const method = `_buildTlsRootCerts[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+		let ca_roots = '';
+
+		if (!this.parsedResults.msps) {
+			logger.error('Missing MSPs discovery results');
+			return ca_roots;
+		}
+
+		const mspDiscovered = this.parsedResults.msps[msp_id];
+		if (!mspDiscovered) {
+			logger.error(`Missing msp ${msp_id} in discovery results`);
+			return ca_roots;
+		}
+
+		logger.debug(`Found msp ${msp_id}`);
+
+		if (mspDiscovered.tlsRootCerts) {
+			ca_roots = ca_roots + mspDiscovered.tlsRootCerts;
+		} else {
+			logger.debug('%s - no tls root certs', method);
+		}
+		if (mspDiscovered.tlsIntermediateCerts) {
+			ca_roots = ca_roots + mspDiscovered.tlsIntermediateCerts;
+		} else {
+			logger.debug('%s - no tls intermediate certs', method);
+		}
+
+		return ca_roots;
+	}
+
+	async _processMembership(q_members) {
+		const method = `_processMembership[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+		const peersByOrg = {};
+		if (q_members.peers_by_org) {
+			for (const mspid in q_members.peers_by_org) {
+				logger.debug(`${method} - found org:${mspid}`);
+				peersByOrg[mspid] = {};
+				peersByOrg[mspid].peers = await this._processPeers(q_members.peers_by_org[mspid].peers);
+			}
+		} else {
+			logger.debug(`${method} - missing peers by org`);
+		}
+		return peersByOrg;
+	}
+
+	// message Peers
+	async _processPeers(q_peers) {
+		const method = `_processPeers[${this.service.name}]`;
+		const peers = [];
+		// message Peer
+		for (const q_peer of q_peers) {
+			const peer = {};
+			// IDENTITY
+			const q_identity = fabproto6.msp.SerializedIdentity.decode(q_peer.identity);
+			peer.mspid = q_identity.mspid;
+
+			// MEMBERSHIP - Peer.membership_info
+			// fabproto6.gossip.Envelope.payload
+			const q_membership_message = fabproto6.gossip.GossipMessage.decode(q_peer.membership_info.payload);
+			peer.endpoint = q_membership_message.alive_msg.membership.endpoint;
+			peer.name = q_membership_message.alive_msg.membership.endpoint;
+			logger.debug(`${method} - peer :${peer.endpoint}`);
+
+			// STATE
+			if (q_peer.state_info) {
+				const message_s = fabproto6.gossip.GossipMessage.decode(q_peer.state_info.payload);
+				peer.ledgerHeight = Long.fromValue(message_s.state_info.properties.ledger_height);
+				logger.debug(`${method} - ledgerHeight :${peer.ledgerHeight}`);
+				peer.chaincodes = [];
+				for (const index in message_s.state_info.properties.chaincodes) {
+					const q_chaincode = message_s.state_info.properties.chaincodes[index];
+					const chaincode = {};
+					chaincode.name = q_chaincode.name;
+					chaincode.version = q_chaincode.version;
+					// TODO metadata ?
+					logger.debug(`${method} - chaincode :${JSON.stringify(chaincode)}`);
+					peer.chaincodes.push(chaincode);
+				}
+			} else {
+				logger.debug(`${method} - no state info for peer ${peer.endpoint}`);
+			}
+
+			// all done with this peer
+			peers.push(peer);
+			// build the GRPC instance
+			await this._buildPeer(peer);
+		}
+
+		return peers;
+	}
+
+	async _buildPeer(discovery_peer) {
+		const method = `_buildPeer[${this.service.name}]`;
+		logger.debug(`${method} - start`);
+
+		if (!discovery_peer) {
+			throw Error('Missing discovery_peer parameter');
+		}
+		const address = discovery_peer.endpoint;
+		const msp_id = discovery_peer.mspid;
+
+		const host_port = address.split(':');
+		const url = this.service._buildUrl(host_port[0], host_port[1]);
+
+		// first check to see if peer is already on this channel
+		let peer;
+		const channelPeers = this.service.channel.getEndorsers();
+		for (const channelPeer of channelPeers) {
+			logger.debug('%s - checking channel peer %s', method, channelPeer.name);
+			if (channelPeer.endpoint && channelPeer.endpoint.url === url) {
+				logger.debug('%s - url: %s - already added to this channel', method, url);
+				peer = channelPeer;
+				break;
+			}
+		}
+		if (!peer) {
+			logger.debug(`${method} - create a new endorser ${url}`);
+			peer = this.service.client.newEndorser(address, msp_id);
+			const end_point = this.service.client.newEndpoint(this._buildOptions(address, url, host_port[0], msp_id));
+			try {
+				logger.debug(`${method} - about to connect to endorser ${address} url:${url}`);
+				await peer.connect(end_point);
+				this.service.channel.addEndorser(peer);
+				logger.debug(`${method} - connected to peer ${address} url:${url}`);
+			} catch (error) {
+				logger.error(`${method} - Unable to connect to the discovered peer ${address} due to ${error}`);
+			}
+		} else {
+			// make sure the existing connect is still good
+			await peer.checkConnection();
+		}
+
+		// indicate that this peer has been touched by the discovery service
+		peer.discovered = true;
+
+		// make sure that this peer has all the found installed chaincodes
+		if (discovery_peer.chaincodes) {
+			for (const chaincode of discovery_peer.chaincodes) {
+				logger.debug(`${method} - adding chaincode ${chaincode.name} to peer ${peer.name}`);
+				peer.addChaincode(chaincode.name);
+			}
+		}
+
+		logger.debug(`${method} - end`);
+		return peer;
+	}
+
+	// -- process the ChaincodeQueryResult - fabproto6.discovery.QueryResult.ChaincodeQueryResult
+	async _processChaincode(q_chaincodes) {
+		const method = '_processChaincode';
+		logger.debug(`${method} - start`);
+		const endorsement_plan = {};
+		// repeated EndorsementDescriptor content, but we should only have one
+		if (q_chaincodes && q_chaincodes.content && Array.isArray(q_chaincodes.content)) {
+			for (const q_endors_desc of q_chaincodes.content) {
+				endorsement_plan.chaincode = q_endors_desc.chaincode;
+
+				// named groups of Peers
+				endorsement_plan.groups = {};
+				for (const group_name in q_endors_desc.endorsers_by_groups) {
+					logger.debug(`${method} - found group: ${group_name}`);
+					const group = {};
+					group.peers = await this._processPeers(q_endors_desc.endorsers_by_groups[group_name].peers);
+					// all done with this group
+					endorsement_plan.groups[group_name] = group;
+				}
+
+				// LAYOUTS
+				endorsement_plan.layouts = [];
+				for (const q_layout of q_endors_desc.layouts) {
+					const layout = Object.assign({}, q_layout.quantities_by_group);
+					logger.debug(`${method} - layout :${layout}`);
+					endorsement_plan.layouts.push(layout);
+				}
+			}
+		} else {
+			throw Error('Plan layouts are invalid');
+		}
+
+		return endorsement_plan;
+	}
+}
+
+module.exports = DiscoveryResultsProcessor;

--- a/fabric-common/lib/DiscoveryService.js
+++ b/fabric-common/lib/DiscoveryService.js
@@ -5,9 +5,8 @@
  */
 
 const TYPE = 'DiscoveryService';
-const Long = require('long');
 
-const {byteToNormalizedPEM, checkParameter, getLogger} = require('./Utils.js');
+const {checkParameter, getLogger} = require('./Utils.js');
 const ServiceAction = require('./ServiceAction.js');
 const DiscoveryHandler = require('./DiscoveryHandler.js');
 
@@ -15,6 +14,7 @@ const logger = getLogger(TYPE);
 
 const fabproto6 = require('fabric-protos');
 const {SYSTEMCHAINCODES} = require('./Endorser.js');
+const DiscoveryResultsProcessor = require('./DiscoveryResultsProcessor.js');
 
 /**
  * The DiscoveryService class represents a peer in the target fabric network that
@@ -42,6 +42,7 @@ class DiscoveryService extends ServiceAction {
 		this.client = channel.client;
 		this.type = TYPE;
 		this.refreshAge = 5 * 60 * 1000; // 5 minutes default
+		this.refreshRunning = false;
 
 		this.discoveryResults = null;
 		this.asLocalhost = false;
@@ -328,47 +329,19 @@ class DiscoveryService extends ServiceAction {
 		}
 
 		// -----
-		this.discoveryResults = {};
 		logger.debug(`${method} - processing discovery response`);
-		if (response && response.results) {
-			let errorMsg = null;
-			logger.debug(`${method} - parse discovery response.results`);
-			for (const index in response.results) {
-				const result = response.results[index];
-				if (result.result === 'error') {
-					logger.error(`${method} - Channel:${this.channel.name} received discovery error:${result.error.content}`);
-					errorMsg = result.error.content;
-					break;
-				} else {
-					logger.debug(`${method} - process result index:${index}`);
-					if (result.config_result) {
-						logger.debug(`${method} - process result - have configResult in ${index}`);
-						const config = this._processConfig(result.config_result);
-						this.discoveryResults.msps = config.msps;
-						this.discoveryResults.orderers = await this._buildOrderers(config.orderers);
-					}
-					if (result.members) {
-						logger.debug(`${method} - process result - have members in ${index}`);
-						this.discoveryResults.peers_by_org = await this._processMembership(result.members);
-					}
-					if (result.cc_query_res) {
-						logger.debug(`${method} - process result - have ccQueryRes in ${index}`);
-						this.discoveryResults.endorsement_plan = await this._processChaincode(result.cc_query_res);
-					}
-					logger.debug(`${method} - completed processing result ${index}`);
-				}
-			}
-
-			if (errorMsg) {
-				throw Error(`DiscoveryService: ${this.name} error: ${errorMsg}`);
-			} else {
-				this.discoveryResults.timestamp = (new Date()).getTime();
-				return this.discoveryResults;
-			}
-		} else {
+		if (!response || !response.results) {
 			logger.error('%s - no discovery results', method);
 			throw new Error('DiscoveryService has failed to return results');
 		}
+
+		logger.debug(`${method} - parse discovery response.results`);
+
+		const processor = new DiscoveryResultsProcessor(this, response.results);
+		const results = await processor.parseDiscoveryResults();
+		results.timestamp = currentTimestamp();
+		this.discoveryResults = results;
+		return results;
 	}
 
 	/**
@@ -381,24 +354,29 @@ class DiscoveryService extends ServiceAction {
 	async getDiscoveryResults(refresh) {
 		const method = `getDiscoveryResults[${this.name}]`;
 		logger.debug(`${method} - start`);
-		if (!this.discoveryResults && !this.savedResults) {
+
+		if (!this.discoveryResults) {
 			throw Error('No discovery results found');
 		}
-		// when savedResults exist, then a refresh is running
-		if (this.savedResults) {
-			logger.debug(`${method} - using the saved results`);
-			return this.savedResults;
-		}
 
-		if (refresh && (new Date()).getTime() - this.discoveryResults.timestamp > this.refreshAge) {
+		if (refresh && !this.refreshRunning && this._isRefreshRequired()) {
 			logger.debug(`${method} - will refresh`);
-			this.savedResults = this.discoveryResults;
-			await this.send({asLocalhost: this.asLocalhost, requestTimeout: this.requestTimeout, targets: this.targets});
-			this.savedResults = null;
+			this.refreshRunning = true;
+			try {
+				await this.send({asLocalhost: this.asLocalhost, requestTimeout: this.requestTimeout, targets: this.targets});
+			} finally {
+				this.refreshRunning = false;
+			}
 		} else {
 			logger.debug(`${method} - not refreshing`);
 		}
+
 		return this.discoveryResults;
+	}
+
+	_isRefreshRequired() {
+		const resultsAge = currentTimestamp() - this.discoveryResults.timestamp;
+		return resultsAge > this.refreshAge;
 	}
 
 	/**
@@ -408,11 +386,34 @@ class DiscoveryService extends ServiceAction {
 		const method = `hasDiscoveryResults[${this.name}]`;
 		logger.debug(`${method} - start`);
 
-		if (this.discoveryResults) {
-			return true;
+		return !!this.discoveryResults;
+	}
+
+	_buildUrl(hostname = checkParameter('hostname'), port = checkParameter('port')) {
+		const method = `_buildUrl[${this.name}]`;
+		logger.debug(`${method} - start`);
+
+		let t_hostname = hostname;
+		// endpoints may be running in containers on the local system
+		if (this.asLocalhost) {
+			t_hostname = 'localhost';
 		}
 
-		return false;
+		// If we connect to a discovery peer over TLS, any endpoints returned by
+		// discovery should also use TLS.
+		let protocol = null;
+		let isTLS = true;
+		if (this.currentTarget) {
+			isTLS = this.currentTarget.endpoint.isTLS();
+		}
+		protocol = isTLS ? 'grpcs' : 'grpc';
+		// but if not, use the following to override
+		const overrideProtocol = this.client.getConfigSetting('discovery-override-protocol');
+		if (overrideProtocol) {
+			protocol = overrideProtocol;
+		}
+
+		return `${protocol}://${t_hostname}:${port}`;
 	}
 
 	/* internal method
@@ -449,331 +450,6 @@ class DiscoveryService extends ServiceAction {
 		return chaincodeInterest;
 	}
 
-	// -- process the ChaincodeQueryResult - fabproto6.discovery.QueryResult.ChaincodeQueryResult
-	async _processChaincode(q_chaincodes) {
-		const method = '_processChaincode';
-		logger.debug(`${method} - start`);
-		const endorsement_plan = {};
-		// repeated EndorsementDescriptor content, but we should only have one
-		if (q_chaincodes && q_chaincodes.content && Array.isArray(q_chaincodes.content)) {
-			for (const q_endors_desc of q_chaincodes.content) {
-				endorsement_plan.chaincode = q_endors_desc.chaincode;
-
-				// named groups of Peers
-				endorsement_plan.groups = {};
-				for (const group_name in q_endors_desc.endorsers_by_groups) {
-					logger.debug(`${method} - found group: ${group_name}`);
-					const group = {};
-					group.peers = await this._processPeers(q_endors_desc.endorsers_by_groups[group_name].peers);
-					// all done with this group
-					endorsement_plan.groups[group_name] = group;
-				}
-
-				// LAYOUTS
-				endorsement_plan.layouts = [];
-				for (const q_layout of q_endors_desc.layouts) {
-					const layout = Object.assign({}, q_layout.quantities_by_group);
-					logger.debug(`${method} - layout :${layout}`);
-					endorsement_plan.layouts.push(layout);
-				}
-			}
-		} else {
-			throw Error('Plan layouts are invalid');
-		}
-
-		return endorsement_plan;
-	}
-
-	_processConfig(q_config) {
-		const method = `_processConfig[${this.name}]`;
-		logger.debug(`${method} - start`);
-		const config = {};
-		config.msps = {};
-		config.orderers = {};
-
-		try {
-			if (q_config.msps) {
-				for (const id in q_config.msps) {
-					logger.debug(`${method} - found organization ${id}`);
-					const q_msp = q_config.msps[id];
-					const msp_config = {
-						id: id,
-						name: id,
-						organizationalUnitIdentifiers: q_msp.organizational_unit_identifiers,
-						rootCerts: byteToNormalizedPEM(q_msp.root_certs),
-						intermediateCerts: byteToNormalizedPEM(q_msp.intermediate_certs),
-						admins: byteToNormalizedPEM(q_msp.admins),
-						tlsRootCerts: byteToNormalizedPEM(q_msp.tls_root_certs),
-						tlsIntermediateCerts: byteToNormalizedPEM(q_msp.tls_intermediate_certs)
-					};
-					config.msps[id] = msp_config;
-					this.channel.addMsp(msp_config, true);
-				}
-			} else {
-				logger.debug(`${method} - no msps found`);
-			}
-			/*
-			"orderers":{"OrdererMSP":{"endpoint":[{"host":"orderer.example.com","port":7050}]}}}
-			*/
-			if (q_config.orderers) {
-				for (const mspid in q_config.orderers) {
-					logger.debug(`${method} - found orderer org: ${mspid}`);
-					config.orderers[mspid] = {};
-					config.orderers[mspid].endpoints = [];
-					for (const endpoint of q_config.orderers[mspid].endpoint) {
-						config.orderers[mspid].endpoints.push(endpoint);
-					}
-				}
-			} else {
-				logger.debug(`${method} - no orderers found`);
-			}
-		} catch (err) {
-			logger.error(`${method} - Problem with discovery config: ${err}`);
-		}
-
-		return config;
-	}
-
-	async _processMembership(q_members) {
-		const method = `_processMembership[${this.name}]`;
-		logger.debug(`${method} - start`);
-		const peersByOrg = {};
-		if (q_members.peers_by_org) {
-			for (const mspid in q_members.peers_by_org) {
-				logger.debug(`${method} - found org:${mspid}`);
-				peersByOrg[mspid] = {};
-				peersByOrg[mspid].peers = await this._processPeers(q_members.peers_by_org[mspid].peers);
-			}
-		} else {
-			logger.debug(`${method} - missing peers by org`);
-		}
-		return peersByOrg;
-	}
-
-	// message Peers
-	async _processPeers(q_peers) {
-		const method = `_processPeers[${this.name}]`;
-		const peers = [];
-		// message Peer
-		for (const q_peer of q_peers) {
-			const peer = {};
-			// IDENTITY
-			const q_identity = fabproto6.msp.SerializedIdentity.decode(q_peer.identity);
-			peer.mspid = q_identity.mspid;
-
-			// MEMBERSHIP - Peer.membership_info
-			// fabproto6.gossip.Envelope.payload
-			const q_membership_message = fabproto6.gossip.GossipMessage.decode(q_peer.membership_info.payload);
-			peer.endpoint = q_membership_message.alive_msg.membership.endpoint;
-			peer.name = q_membership_message.alive_msg.membership.endpoint;
-			logger.debug(`${method} - peer :${peer.endpoint}`);
-
-			// STATE
-			if (q_peer.state_info) {
-				const message_s = fabproto6.gossip.GossipMessage.decode(q_peer.state_info.payload);
-				peer.ledgerHeight = Long.fromValue(message_s.state_info.properties.ledger_height);
-				logger.debug(`${method} - ledgerHeight :${peer.ledgerHeight}`);
-				peer.chaincodes = [];
-				for (const index in message_s.state_info.properties.chaincodes) {
-					const q_chaincode = message_s.state_info.properties.chaincodes[index];
-					const chaincode = {};
-					chaincode.name = q_chaincode.name;
-					chaincode.version = q_chaincode.version;
-					// TODO metadata ?
-					logger.debug(`${method} - chaincode :${JSON.stringify(chaincode)}`);
-					peer.chaincodes.push(chaincode);
-				}
-			} else {
-				logger.debug(`${method} - no state info for peer ${peer.endpoint}`);
-			}
-
-			// all done with this peer
-			peers.push(peer);
-			// build the GRPC instance
-			await this._buildPeer(peer);
-		}
-
-		return peers;
-	}
-
-	async _buildOrderers(orderers) {
-		const method = `_buildOrderers[${this.name}]`;
-		logger.debug(`${method} - start`);
-
-		if (!orderers) {
-			logger.debug('%s - no orderers to build', method);
-		} else {
-			for (const msp_id in orderers) {
-				logger.debug(`${method} - orderer msp:${msp_id}`);
-				for (const endpoint of orderers[msp_id].endpoints) {
-					endpoint.name = await this._buildOrderer(endpoint.host, endpoint.port, msp_id);
-				}
-			}
-		}
-
-		return orderers;
-	}
-
-	async _buildOrderer(host, port, msp_id) {
-		const method = `_buildOrderer[${this.name}]`;
-		logger.debug(`${method} - start mspid:${msp_id} endpoint:${host}:${port}`);
-
-		const name = `${host}:${port}`;
-		const url = this._buildUrl(host, port);
-		logger.debug(`${method} - create a new orderer ${url}`);
-		const orderer = this.client.newCommitter(name, msp_id);
-		const end_point = this.client.newEndpoint(this._buildOptions(name, url, host, msp_id));
-		try {
-			// first check to see if orderer is already on this channel
-			let same;
-			const channelOrderers = this.channel.getCommitters();
-			for (const channelOrderer of channelOrderers) {
-				logger.debug('%s - checking %s', method, channelOrderer);
-				if (channelOrderer.endpoint && channelOrderer.endpoint.url === url) {
-					same = channelOrderer;
-					break;
-				}
-			}
-			if (!same) {
-				await orderer.connect(end_point);
-				this.channel.addCommitter(orderer);
-			} else {
-				await same.checkConnection();
-				logger.debug('%s - orderer already added to this channel', method);
-			}
-		} catch (error) {
-			logger.error(`${method} - Unable to connect to the discovered orderer ${name} due to ${error}`);
-		}
-
-		return name;
-	}
-
-	async _buildPeer(discovery_peer) {
-		const method = `_buildPeer[${this.name}]`;
-		logger.debug(`${method} - start`);
-
-		if (!discovery_peer) {
-			throw Error('Missing discovery_peer parameter');
-		}
-		const address = discovery_peer.endpoint;
-		const msp_id = discovery_peer.mspid;
-
-		const host_port = address.split(':');
-		const url = this._buildUrl(host_port[0], host_port[1]);
-
-		// first check to see if peer is already on this channel
-		let peer;
-		const channelPeers = this.channel.getEndorsers();
-		for (const channelPeer of channelPeers) {
-			logger.debug('%s - checking channel peer %s', method, channelPeer.name);
-			if (channelPeer.endpoint && channelPeer.endpoint.url === url) {
-				logger.debug('%s - url: %s - already added to this channel', method, url);
-				peer = channelPeer;
-				break;
-			}
-		}
-		if (!peer) {
-			logger.debug(`${method} - create a new endorser ${url}`);
-			peer = this.client.newEndorser(address, msp_id);
-			const end_point = this.client.newEndpoint(this._buildOptions(address, url, host_port[0], msp_id));
-			try {
-				logger.debug(`${method} - about to connect to endorser ${address} url:${url}`);
-				await peer.connect(end_point);
-				this.channel.addEndorser(peer);
-				logger.debug(`${method} - connected to peer ${address} url:${url}`);
-			} catch (error) {
-				logger.error(`${method} - Unable to connect to the discovered peer ${address} due to ${error}`);
-			}
-		} else {
-			// make sure the existing connect is still good
-			await peer.checkConnection();
-		}
-
-		// indicate that this peer has been touched by the discovery service
-		peer.discovered = true;
-
-		// make sure that this peer has all the found installed chaincodes
-		if (discovery_peer.chaincodes) {
-			for (const chaincode of discovery_peer.chaincodes) {
-				logger.debug(`${method} - adding chaincode ${chaincode.name} to peer ${peer.name}`);
-				peer.addChaincode(chaincode.name);
-			}
-		}
-
-		logger.debug(`${method} - end`);
-		return peer;
-	}
-
-	_buildUrl(hostname = checkParameter('hostname'), port = checkParameter('port')) {
-		const method = `_buildUrl[${this.name}]`;
-		logger.debug(`${method} - start`);
-
-		let t_hostname = hostname;
-		// endpoints may be running in containers on the local system
-		if (this.asLocalhost) {
-			t_hostname = 'localhost';
-		}
-
-		// If we connect to a discovery peer over TLS, any endpoints returned by
-		// discovery should also use TLS.
-		let protocol = null;
-		let isTLS = true;
-		if (this.currentTarget) {
-			isTLS = this.currentTarget.endpoint.isTLS();
-		}
-		protocol = isTLS ? 'grpcs' : 'grpc';
-		// but if not, use the following to override
-		const overrideProtocol = this.client.getConfigSetting('discovery-override-protocol');
-		if (overrideProtocol) {
-			protocol = overrideProtocol;
-		}
-
-		return `${protocol}://${t_hostname}:${port}`;
-	}
-
-	_buildOptions(name, url, host, msp_id) {
-		const method = `_buildOptions[${this.name}]`;
-		logger.debug(`${method} - start`);
-		const caroots = this._buildTlsRootCerts(msp_id);
-		return {
-			url: url,
-			pem: caroots,
-			'ssl-target-name-override': host,
-			name: name
-		};
-	}
-
-	_buildTlsRootCerts(msp_id = checkParameter('msp_id')) {
-		const method = `_buildTlsRootCerts[${this.name}]`;
-		logger.debug(`${method} - start`);
-		let ca_roots = '';
-		let mspDiscovered;
-		if (this.discoveryResults && this.discoveryResults.msps) {
-			mspDiscovered = this.discoveryResults.msps[msp_id];
-		} else {
-			logger.error('Missing MSPs discovery results');
-			return ca_roots;
-		}
-		if (mspDiscovered) {
-			logger.debug(`Found msp ${msp_id}`);
-		} else {
-			logger.error(`Missing msp ${msp_id} in discovery results`);
-			return ca_roots;
-		}
-		if (mspDiscovered.tlsRootCerts) {
-			ca_roots = ca_roots + mspDiscovered.tlsRootCerts;
-		} else {
-			logger.debug('%s - no tls root certs', method);
-		}
-		if (mspDiscovered.tlsIntermediateCerts) {
-			ca_roots = ca_roots + mspDiscovered.tlsIntermediateCerts;
-		} else {
-			logger.debug('%s - no tls intermediate certs', method);
-		}
-
-		return ca_roots;
-	}
-
 	/**
 	 * Close the connection of the discovery service.
 	 */
@@ -792,7 +468,6 @@ class DiscoveryService extends ServiceAction {
 	 * return a printable representation of this object
 	 */
 	toString() {
-
 		return `DiscoveryService: {name: ${this.name}, channel: ${this.channel.name}}`;
 	}
 }
@@ -813,6 +488,10 @@ function _getCollectionNames(names, chaincodeCall) {
 	} else {
 		throw Error('Collection names must be an array of strings');
 	}
+}
+
+function currentTimestamp() {
+	return new Date().getTime();
 }
 
 module.exports = DiscoveryService;

--- a/fabric-common/test/DiscoveryResultsProcessor.js
+++ b/fabric-common/test/DiscoveryResultsProcessor.js
@@ -1,0 +1,252 @@
+/**
+ * Copyright 2019 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const should = chai.should();
+chai.use(chaiAsPromised);
+const sinon = require('sinon');
+
+const Client = require('../lib/Client');
+const Discoverer = require('../lib/Discoverer');
+const Endorser = require('../lib/Endorser');
+const Committer = require('../lib/Committer');
+const TestUtils = require('./TestUtils');
+const DiscoveryResultsProcessor = require('../lib/DiscoveryResultsProcessor');
+const DiscoveryService = require('../lib/DiscoveryService');
+
+describe('DiscoveryResultsProcessor', () => {
+	TestUtils.setCryptoConfigSettings();
+
+	const client = new Client('myclient');
+	client._tls_mutual.clientCertHash = Buffer.from('clientCertHash');
+	const channel = client.newChannel('mychannel');
+
+	const orderers = {
+		OrdererMSP: {endpoints: [{host: 'orderer.example.com', port: 7150, name: 'orderer.example.com'}]}
+	};
+
+	let discoverer;
+	let discovery;
+	let endpoint;
+	let endorser;
+	let committer;
+	let processor;
+
+	beforeEach(async () => {
+		discoverer = new Discoverer('mydiscoverer', client);
+		endpoint = client.newEndpoint({url: 'grpc://somehost.com'});
+		discoverer.endpoint = endpoint;
+		sinon.stub(discoverer, 'waitForReady').resolves(true);
+		sinon.stub(discoverer, 'checkConnection').resolves(true);
+
+		endorser = sinon.createStubInstance(Endorser);
+		endorser.type = 'Endorser';
+		endorser.connected = true;
+		endorser.isConnectable.returns(true);
+		endorser.connect.resolves(true);
+
+		discovery = new DiscoveryService('mydiscovery', channel);
+		sinon.stub(client, 'getEndorser').returns(endorser);
+		sinon.stub(client, 'newEndorser').returns(endorser);
+
+		committer = sinon.createStubInstance(Committer);
+		committer.type = 'Committer';
+		committer.connected = true;
+		committer.isConnectable.returns(true);
+		committer.connect.resolves(true);
+		committer.name = 'mycommitter';
+		sinon.stub(client, 'newCommitter').returns(committer);
+
+		channel.committers = new Map();
+
+		processor = new DiscoveryResultsProcessor(discovery, {});
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe('#_buildTlsRootCerts', () => {
+		it('should handle no parms', () => {
+			(() => {
+				processor._buildTlsRootCerts();
+			}).should.throw('Missing msp_id parameter');
+		});
+		it('should handle missing mspid when no msps', () => {
+			const results = processor._buildTlsRootCerts('msp1');
+			should.equal(results, '');
+		});
+		it('should handle missing mspid when not in msps', () => {
+			processor.parsedResults.msps = {msp1: {
+				id: 'msp1',
+				name: 'msp1',
+				tlsRootCerts: 'root certs',
+				tlsIntermediateCerts: 'intermediate certs'
+			}};
+			const results = processor._buildTlsRootCerts('bad');
+			should.equal(results, '');
+		});
+		it('should handle mspid when in msps', () => {
+			processor.parsedResults.msps = {msp1: {
+				id: 'msp1',
+				name: 'msp1',
+				tlsRootCerts: 'rootcerts',
+				tlsIntermediateCerts: 'intermediatecerts'
+			}};
+			const results = processor._buildTlsRootCerts('msp1');
+			should.equal(results, 'rootcertsintermediatecerts');
+		});
+		it('should handle mspid when in msps and no certs', () => {
+			processor.parsedResults.msps = {msp1: {
+				id: 'msp1',
+				name: 'msp1'
+			}};
+			const results = processor._buildTlsRootCerts('msp1');
+			should.equal(results, '');
+		});
+	});
+
+	describe('#_buildOrderers', () => {
+		it('should add new orderers to the channel', async () => {
+			should.equal(channel.getCommitters().length, 0);
+			await processor._buildOrderers(orderers); // add one orderer
+			should.equal(channel.getCommitters().length, 1);
+		});
+	});
+
+	describe('#_buildOrderer', () => {
+		it('should run', async () => {
+			committer.name = 'mycommitter:80';
+			sinon.stub(channel, 'getCommitter').returns(committer);
+			const results = await processor._buildOrderer('mycommitter', '80', 'mspid');
+			should.equal(results, 'mycommitter:80');
+		});
+		it('should throw connect error', async () => {
+			sinon.stub(channel, 'getCommitter').returns();
+			committer.connect.throws(new Error('failed to connect'));
+			const results = await processor._buildOrderer('mycommitter', '80', 'mspid');
+			should.equal(results, 'mycommitter:80');
+		});
+		it('should handle found same name committer on the channel', async () => {
+			channel.addCommitter(committer);
+			committer.endpoint = endpoint;
+			sinon.stub(discovery, '_buildUrl').returns('grpc://somehost.com:7000');
+			await processor._buildOrderer('somehost.com', 7000, 'mspid');
+			should.equal(channel.getCommitters().length, 1);
+		});
+	});
+
+	describe('#_buildPeer', () => {
+		it('should handle no parms', async () => {
+			await processor._buildPeer().should.be.rejectedWith('Missing discovery_peer parameter');
+		});
+		it('should handle found same name endorser on the channel', async () => {
+			endorser.name = 'mypeer';
+			channel.endorsers = new Map();
+			channel.addEndorser(endorser);
+			const results = await processor._buildPeer({endpoint: 'mypeer:2000', mspid: 'msp1'});
+			should.equal(results, endorser);
+			should.equal(channel.getEndorsers().length, 1);
+		});
+		it('should run', async () => {
+			processor.parsedResults.msps = {msp1: {
+				id: 'msp1',
+				name: 'msp1',
+				tlsRootCerts: 'rootcerts',
+				tlsIntermediateCerts: 'intermediatecerts'
+			}};
+			endorser.name = 'host2.com:1000';
+			const results = await processor._buildPeer({endpoint: 'host2.com:1000', name: 'host2.com:1000', mspid: 'msp1'});
+			should.equal(results.name, 'host2.com:1000');
+		});
+		it('should handle endorser not connect', async () => {
+			processor.parsedResults.msps = {msp1: {
+				id: 'msp1',
+				name: 'msp1',
+				tlsRootCerts: 'rootcerts',
+				tlsIntermediateCerts: 'intermediatecerts'
+			}};
+			endorser.name = 'host3.com:1000';
+			endorser.connect.throws(new Error('failed to connect'));
+			const results = await processor._buildPeer({endpoint: 'host3.com:1000', name: 'host3.com:1000', mspid: 'msp1'});
+			should.equal(results.name, 'host3.com:1000');
+		});
+		it('should handle found same name endorser on the channel', async () => {
+			endorser.name = 'mypeer';
+			channel.endorsers = new Map();
+			channel.addEndorser(endorser);
+			endorser.endpoint = endpoint;
+			sinon.stub(discovery, '_buildUrl').returns('grpc://somehost.com');
+			const results = await processor._buildPeer({endpoint: 'somehost.com', mspid: 'mspid'});
+			should.equal(results, endorser);
+			should.equal(channel.getEndorsers().length, 1);
+		});
+		it('should handle found same name endorser on the channel and add chaincodes', async () => {
+			endorser.name = 'mypeer';
+			channel.endorsers = new Map();
+			channel.addEndorser(endorser);
+			endorser.endpoint = endpoint;
+			sinon.stub(discovery, '_buildUrl').returns('grpc://somehost.com');
+			const results = await processor._buildPeer({endpoint: 'somehost.com', mspid: 'mspid', chaincodes: [{name: 'chaincode'}]});
+			should.equal(results, endorser);
+			should.equal(channel.getEndorsers().length, 1);
+			sinon.assert.calledWith(endorser.addChaincode, 'chaincode');
+		});
+	});
+
+	describe('#_processConfig', () => {
+		it('should handle no parms', async () => {
+			const results = await processor._processConfig();
+			should.exist(results);
+		});
+		it('should handle no msps', async () => {
+			const config = {
+				orderers: {
+					msp1: TestUtils.createEndpoints('hosta', 2),
+					msp2: TestUtils.createEndpoints('hostb', 2)
+				}
+			};
+			const results = await processor._processConfig(config);
+			should.exist(results.orderers);
+		});
+		it('should handle no msps', async () => {
+			const config = {
+				msps: {
+					msp1: TestUtils.createMsp('msp3'),
+					msp2: TestUtils.createMsp('msp4')
+				}
+			};
+			const results = await processor._processConfig(config);
+			should.exist(results.msps);
+		});
+	});
+
+	describe('#_processChaincode', () => {
+		it('should throw error if plans are bad', async () => {
+			await processor._processChaincode().should.be.rejectedWith('Plan layouts are invalid');
+		});
+	});
+
+	describe('#_processPeers', () => {
+		it('should handle missing endorser state info', async () => {
+			channel.endorsers = new Map();
+			const q_peers = [
+				{
+					identity: TestUtils.createSerializedIdentity(),
+					membership_info: {payload: TestUtils.createMembership()}
+				}
+			];
+			await processor._processPeers(q_peers);
+		});
+	});
+
+	describe('#_processMembership', () => {
+		it('should handle missing endorser by org', async () => {
+			await processor._processMembership({});
+		});
+	});
+});

--- a/fabric-network/src/contract.ts
+++ b/fabric-network/src/contract.ts
@@ -12,8 +12,9 @@ const logger = Logger.getLogger('Contract');
 import * as util from 'util';
 import {NetworkImpl} from './network';
 import {ContractListener, ListenerOptions} from './events';
-import {DiscoveryService, DiscoveryHandler} from 'fabric-common';
+import {DiscoveryService, DiscoveryHandler, Discoverer} from 'fabric-common';
 import {Gateway} from './gateway';
+import {withTimeout} from './impl/gatewayutils';
 
 /**
  * Ensure transaction name is a non-empty string.
@@ -61,9 +62,6 @@ export interface Contract {
 	addDiscoveryInterest(interest: DiscoveryInterest): Contract;
 	resetDiscoveryInterests(): Contract;
 }
-
-
-type DiscoveryResultsCallback = (hasResults: boolean) => void;
 
 /**
  * <p>Represents a smart contract (chaincode) instance in a network.
@@ -191,10 +189,9 @@ export class ContractImpl {
 	readonly namespace: string;
 	readonly network: NetworkImpl;
 	readonly gateway: Gateway;
-	private discoveryService?: DiscoveryService;
+	private discoveryService?: Promise<DiscoveryService>;
 	private readonly contractListeners: Map<ContractListener, ListenerSession> = new Map();
 	private discoveryInterests: DiscoveryInterest[];
-	private discoveryResultsListeners: DiscoveryResultsCallback[] = new Array<DiscoveryResultsCallback>();
 
 	constructor(network: NetworkImpl, chaincodeId: string, namespace: string) {
 		const method = `constructor[${namespace}]`;
@@ -277,93 +274,43 @@ export class ContractImpl {
 		// check if we have initialized this contract's discovery
 		if (!this.discoveryService) {
 			logger.debug('%s - setting up contract discovery', method);
+			this.discoveryService = this.newDiscoveryService(this.network.discoveryService.targets);
+		}
 
-			this.discoveryService = this.network.getChannel().newDiscoveryService(this.chaincodeId);
-
-			const targets = this.network.discoveryService.targets;
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const idx = this.gateway.identityContext!;
-			const asLocalhost = this.gateway.getOptions().discovery.asLocalhost;
-
-			logger.debug('%s - using discovery interest %j', method, this.discoveryInterests);
-			this.discoveryService.build(idx, {interest: this.discoveryInterests});
-			this.discoveryService.sign(idx);
-
-			// go get the endorsement plan from the peer's discovery service
-			// to be ready to be used by the transaction's submit
-			await this.discoveryService.send({asLocalhost, targets});
-			logger.debug('%s - endorsement plan retrieved', method);
-
-			const hasDiscoveryResults = this.discoveryService.hasDiscoveryResults();
-			this.notifyDiscoveryResultsListeners(hasDiscoveryResults);
-			logger.debug('%s - completed discovery results as first one', method);
-		} else {
-			if (!this.discoveryService.hasDiscoveryResults()) {
-				// maybe the discovery service was created by another submit of
-				// this same contract, make sure it has completed getting the
-				// discovery results, we do not want this submission to also
-				// get the discovery results, just wait for first one to complete.
-				await this.waitDiscoveryResults();
-			}
+		const service = await withTimeout(this.discoveryService, 30000, 'Timed out waiting for discovery results');
+		if (!service.hasDiscoveryResults()) {
+			const error = new Error('Failed to retrieve discovery results');
+			logger.error('%s - %s', method, error);
+			throw error;
 		}
 
 		// The handler will have access to the endorsement plan fetched
 		// by the parent DiscoveryService instance.
 		logger.debug('%s - returning a new discovery service handler', method);
-		return this.discoveryService.newHandler();
+		return service.newHandler();
 	}
 
-	/*
-	 * Internal method to setup a Promise that will wait to be notified when
-	 * the discovery service has retreived the discovery results.
-	 */
-	waitDiscoveryResults(): Promise<void> {
-		const method = `checkDiscoveryResults[${this.chaincodeId}]`;
+	private async newDiscoveryService(targets: Discoverer[]): Promise<DiscoveryService> {
+		const method = `newDiscoveryService[${this.chaincodeId}]`;
 		logger.debug('%s - start', method);
 
-		return new Promise<void>((resolve, reject) => {
-			const handle: NodeJS.Timeout = setTimeout(() => {
-				reject(new Error('Timed out waiting for discovery results'));
-			}, 30000);
+		const result = this.network.getChannel().newDiscoveryService(this.chaincodeId);
 
-			this.registerDiscoveryResultsListener(
-				(hasDiscoveryResults: boolean): void => {
-					clearTimeout(handle);
-					if (hasDiscoveryResults) {
-						logger.debug('%s - discovery results have been retieved', method);
-						resolve();
-					} else {
-						const error = new Error('Failed to retrieve discovery results');
-						logger.error('%s - %s', method, error);
-						reject(error);
-					}
-				}
-			);
-		});
-	}
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const identityContext = this.gateway.identityContext!;
+		const asLocalhost = this.gateway.getOptions().discovery.asLocalhost;
 
-	/*
-	 * Internal method to register to be notified when
-	 * discovery results are ready to be used.
-	 */
-	registerDiscoveryResultsListener(callback: DiscoveryResultsCallback): void {
-		const method = `registerDiscoveryResultsListener[${this.chaincodeId}]`;
-		logger.debug('%s - start', method);
-		this.discoveryResultsListeners.push(callback);
-	}
+		logger.debug('%s - using discovery interest %j', method, this.discoveryInterests);
+		result.build(identityContext, {interest: this.discoveryInterests});
+		result.sign(identityContext);
 
-	/*
-	 * Interal method to notify all other submits that the discovery
-	 * results are now ready to be used. This will have the Promise
-	 * resolve and all the other submits to continue to process.
-	 */
-	notifyDiscoveryResultsListeners(hasDiscoveryResults: boolean): void {
-		const method = `notifyDiscoveryResultsListeners[${this.chaincodeId}]`;
-		logger.debug('%s - start', method);
-		let listener: DiscoveryResultsCallback | undefined;
-		while ((listener = this.discoveryResultsListeners.pop()) !== undefined) {
-			listener(hasDiscoveryResults);
-		}
+		// go get the endorsement plan from the peer's discovery service
+		// to be ready to be used by the transaction's submit
+		await result.send({asLocalhost, targets});
+		logger.debug('%s - endorsement plan retrieved', method);
+
+		logger.debug('%s - exit', method);
+		return result;
 	}
 
 	addDiscoveryInterest(interest: DiscoveryInterest): Contract {

--- a/fabric-network/src/impl/gatewayutils.ts
+++ b/fabric-network/src/impl/gatewayutils.ts
@@ -100,3 +100,12 @@ export function getTransactionResponse(proposalResponse: EndorsementResponse): p
 	const chaincodeAction = protos.ChaincodeAction.decode(responsePayload.extension);
 	return assertDefined(chaincodeAction.response, 'Missing chaincode action response');
 }
+
+export function withTimeout<T>(promise: Promise<T>, timeoutMillis: number, timeoutMessage: string): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMillis);
+		promise.then(resolve)
+			.catch(reject)
+			.finally(() => clearTimeout(timeout));
+	});
+}

--- a/fabric-network/test/contract.js
+++ b/fabric-network/test/contract.js
@@ -132,7 +132,7 @@ describe('Contract', () => {
 		});
 		it('should run when discover is assigned to network and contract', async () => {
 			network.discoveryService = discoveryService;
-			contract.discoveryService = discoveryService;
+			contract.discoveryService = Promise.resolve(discoveryService);
 			const handler = await contract.getDiscoveryHandler(endorsement);
 			expect(handler).to.equal('handler');
 		});
@@ -202,44 +202,6 @@ describe('Contract', () => {
 				{name: chaincodeId},
 				other
 			]);
-		});
-	});
-
-	describe('#registerDiscoveryResultsListener', () => {
-		it('add', () => {
-			contract.registerDiscoveryResultsListener(() => {});
-			expect(contract.discoveryResultsListeners.length).to.be.equal(1);
-		});
-	});
-
-	describe('#notifyDiscoveryResultsListeners', () => {
-		it('run with none added', () => {
-			contract.notifyDiscoveryResultsListeners();
-			expect(contract.discoveryResultsListeners.length).to.be.equal(0);
-		});
-		it('run with one added', () => {
-			contract.registerDiscoveryResultsListener(() => {});
-			contract.notifyDiscoveryResultsListeners();
-			expect(contract.discoveryResultsListeners.length).to.be.equal(0);
-		});
-	});
-
-	describe('#waitDiscoveryResults', () => {
-		it('runs', async () => {
-			const wait = contract.waitDiscoveryResults();
-			const notify = new Promise((resolve, reject,) => {
-				contract.notifyDiscoveryResultsListeners(false);
-				resolve();
-			});
-			await Promise.all([wait, notify]).should.be.rejectedWith(/Failed to retrieve discovery results/);
-		});
-		it('runs', async () => {
-			const wait = contract.waitDiscoveryResults();
-			const notify = new Promise((resolve, reject,) => {
-				contract.notifyDiscoveryResultsListeners(true);
-				resolve();
-			});
-			await Promise.all([wait, notify]);
 		});
 	});
 });

--- a/test/ts-scenario/steps/lib/utility/clientUtils.ts
+++ b/test/ts-scenario/steps/lib/utility/clientUtils.ts
@@ -76,8 +76,12 @@ interface ListenerState {
 function assertNoErrors(endorsementResults: ProposalResponse): void {
 	if (endorsementResults.errors && endorsementResults.errors.length > 0) {
 		for (const error of endorsementResults.errors) {
-			BaseUtils.logMsg(`Failed to get endorsement with error: ${error.message} and proposal response:`, endorsementResults);
+			BaseUtils.logMsg('Failed to get endorsement with error:', error);
 		}
+		BaseUtils.logMsg('Endorsement results:', {
+			responses: endorsementResults.responses,
+			queryResults: endorsementResults.queryResults,
+		});
 		throw Error('failed endorsement');
 	}
 }


### PR DESCRIPTION
Cherry-pick of b3799f6a0002a1478284737a95a3c073d67ee56c from main branch.

Discovery results parsing makes use of partial results, but these should not be set on the discovery service itself during the parsing process to ensure no callers ever see partial discovery results.

In combination with the above behaviour, the way the Contract obtained discovery results was prone to race conditions that could cause multiple discovery services to be created and invoked under load, and for partial discovery results to be obtained.