### PR TITLE
Update @grpc/grpc-js version

### DIFF
--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/hyperledger/fabric-sdk-node"
   },
   "engines": {
-	"node": ">=14.15.0"
-},
+    "node": ">=14.15.0"
+  },
   "keywords": [
     "hyperledger",
     "blockchain"
@@ -31,9 +31,9 @@
   ],
   "types": "./types/index.d.ts",
   "dependencies": {
-    "@grpc/grpc-js": "1.6.7",
-    "@grpc/proto-loader": "^0.6.10",
-    "protobufjs": "^6.11.2"
+    "@grpc/grpc-js": "~1.6.9",
+    "@grpc/proto-loader": "^0.7.0",
+    "protobufjs": "^7.0.0"
   },
   "devDependencies": {
     "cpx": "^1.5.0",


### PR DESCRIPTION
Accompanying updated to suitable @grpc/proto-loader and protobufjs versions.

This addresses a gRPC bug that could cause pings to be sent on destroyed HTTP sessions, resulting in the following error:

Error [ERR_HTTP2_INVALID_SESSION]: The session has been destroyed

Closes #593