### PR TITLE
Update @grpc/grpc-js version (release-2.2)

### DIFF
--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -31,9 +31,9 @@
   ],
   "types": "./types/index.d.ts",
   "dependencies": {
-    "@grpc/grpc-js": "1.5.3",
-    "@grpc/proto-loader": "^0.6.2",
-    "protobufjs": "^6.11.2"
+    "@grpc/grpc-js": "~1.6.9",
+    "@grpc/proto-loader": "^0.7.0",
+    "protobufjs": "^7.0.0"
   },
   "devDependencies": {
     "cpx": "^1.5.0",


### PR DESCRIPTION
Accompanying updated to suitable @grpc/proto-loader and protobufjs versions.

This addresses a gRPC bug that could cause pings to be sent on destroyed HTTP sessions, resulting in the following error:

Error [ERR_HTTP2_INVALID_SESSION]: The session has been destroyed

Closes #593