### PR TITLE
Path Traversal Bug

### DIFF
--- a/test/ts-fixtures/chaincode/goLang/src/github.com/legacyGo/vendor/golang.org/x/text/internal/gen/gen.go
+++ b/test/ts-fixtures/chaincode/goLang/src/github.com/legacyGo/vendor/golang.org/x/text/internal/gen/gen.go
@@ -206,7 +206,7 @@ func openUnicode(path string) io.ReadCloser {
 // TODO: automatically periodically update non-versioned files.
 
 func open(file, urlRoot, path string) io.ReadCloser {
-	if f, err := os.Open(file); err == nil {
+	if f, err := os.Open(*file); err == nil {
 		return f
 	}
 	r := get(urlRoot, path)


### PR DESCRIPTION
Unsanitized input from a CLI argument flows into `os.Open`, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to open arbitrary files

Signed-off-by: Bhaskar Ram <bhaskarvilles@duck.com>