### PR TITLE
Add testing with Node 18 (release-2.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,13 @@
 name: Build
 
 on:
+  # Merge build (including publishing) runs on Azure Pipelines
   # push:
-  #   branches: ["release-2.2"]
+  #   branches:
+  #     - release-2.2
   pull_request:
-    branches: ["release-2.2"]
+    branches:
+      - release-2.2
   schedule:
     - cron: "45 23 * * *"
 
@@ -14,12 +17,12 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [ 10, 12, 14, 16, 18 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
       - '*'
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-22.04'
 
 variables:
 - group: credentials
@@ -44,6 +44,8 @@ stages:
             versionSpec: '14.x'
           Node16:
             versionSpec: '16.x'
+          Node18:
+            versionSpec: '18.x'
       steps:
         - task: NodeTool@0
           inputs:

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,8 +35,8 @@ The following tables show versions of Fabric, Node and other dependencies that a
 |     | Tested | Supported |
 | --- | ------ | --------- |
 | **Fabric** | 2.2 | 2.2 |
-| **Node** | 10, 12, 14, 16 | 10 LTS, 12 LTS, 14 LTS, 16 LTS |
-| **Platform** | Ubuntu 20.04 | |
+| **Node** | 10, 12, 14, 16, 18 | 10 LTS, 12 LTS, 14 LTS, 16 LTS, 18 LTS |
+| **Platform** | Ubuntu 22.04 | |
 
 
 ### API reference

--- a/fabric-protos/package.json
+++ b/fabric-protos/package.json
@@ -31,7 +31,7 @@
   ],
   "types": "./types/index.d.ts",
   "dependencies": {
-    "@grpc/grpc-js": "~1.6.9",
+    "@grpc/grpc-js": "~1.7.3",
     "@grpc/proto-loader": "^0.7.0",
     "protobufjs": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "tapeAndCucumber": "run-s tapeIntegration dockerClean cucumberScenario"
   },
   "devDependencies": {
-    "@ampretia/x509": "^0.4.8",
     "@cucumber/cucumber": "^7.3.2",
     "@cucumber/pretty-formatter": "^1.0.0-alpha.1",
     "@tsconfig/node10": "^1.0.8",


### PR DESCRIPTION
@ampretia/x509 package does not work with Node 18 so changed to use jsrsasign to decode X.509 certificates in tests. This mostly works fine but seems to truncate non-standard extension values so some testing for custom attributes in CA enrollment are commented out for now.

Contributes to #621 