### PR TITLE
feat(FabricCAClient.js): addDefaultHeader

### DIFF
--- a/fabric-ca-client/lib/FabricCAClient.js
+++ b/fabric-ca-client/lib/FabricCAClient.js
@@ -69,6 +69,8 @@ const FabricCAClient = class {
 		this._baseAPI = '/api/v1/';
 
 		this._cryptoPrimitives = cryptoPrimitives;
+		
+		this.default_headers = {};
 
 		logger.debug(`Successfully constructed Fabric CA client from options - ${util.inspect(connect_opts)}`);
 	}
@@ -269,6 +271,11 @@ const FabricCAClient = class {
 				Authorization: await this.generateAuthToken(requestObj, signingIdentity, path, http_method)
 			};
 		}
+		
+		for (let key in self.default_headers) {
+			requestOptions.headers[key] = self.default_headers[key];
+		};
+		
 		Object.assign(requestOptions, extraRequestOptions);
 		return new Promise(((resolve, reject) => {
 
@@ -428,6 +435,11 @@ const FabricCAClient = class {
 
 		const requestOptions = {
 			auth: `${enrollmentID}:${enrollmentSecret}`,
+			headers: {}
+		};
+		
+		for (let key in self.default_headers) {
+			requestOptions.headers[key] = self.default_headers[key];
 		};
 
 		const enrollRequest = {
@@ -491,6 +503,15 @@ const FabricCAClient = class {
 			}
 		}
 
+	}
+	
+	/**
+	 * Add default custom header in request
+	 * @param {string} key The key of default custom header value
+	 * @param {string} value The value of default custom header
+	 */
+	async addDefaultHeader(key, value) {
+		this.default_headers[key] = value
 	}
 };
 


### PR DESCRIPTION
- add "addDefaultHeader" function in FabricCAClient.js 
- add "default_headers" object in constructor
- iterate on "default_headers" object in "request" and "enroll" functions

Signed-off-by: Ivan <69165620+IvanSerebryakov@users.noreply.github.com>