### PR TITLE
Reduce reliance on exact error message text in scenario tests (release-2.2)

### DIFF
--- a/test/ts-scenario/features/gateway.feature
+++ b/test/ts-scenario/features/gateway.feature
@@ -23,13 +23,13 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 
 	Scenario: Using a Gateway I receive useful error messages when I submit or evaulate invalid transactions
 		When I use the gateway named mycouchgateway to submit a transaction with args [noSuchSubmitTransaction,1001,Trabant,601 Estate,brown,Simon] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mycouchgateway has a error type response containing Error: You've asked to invoke a function that does not exist: noSuchSubmitTransaction
+		Then The gateway named mycouchgateway has a error type response containing noSuchSubmitTransaction
 		When I use the gateway named mycouchgateway to submit a transaction with args [createCar,9,Ford] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mycouchgateway has a error type response containing Error: Expected 5 parameters, but 2 have been supplied
+		Then The gateway named mycouchgateway has a error type response containing Expected 5 parameters, but 2 have been supplied
 		When I use the gateway named mycouchgateway to evaluate a transaction with args [noSuchEvaluateTransaction,1001] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mycouchgateway has a error type response containing Error: You've asked to invoke a function that does not exist: noSuchEvaluateTransaction
+		Then The gateway named mycouchgateway has a error type response containing noSuchEvaluateTransaction
 		When I use the gateway named mycouchgateway to evaluate a transaction with args [queryCar,because,I,said,so] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mycouchgateway has a error type response containing Error: Expected 1 parameters, but 4 have been supplied
+		Then The gateway named mycouchgateway has a error type response containing Expected 1 parameters, but 4 have been supplied
 
 	Scenario: Using a Gateway to submit transactions I can use different event handler strategies
 		When I modify mycouchgateway to submit a transaction with args [createCar,1002,Ford,Mustang,Silver,Andy] for contract fabcar instantiated on channel gatewaychannel using handler option MSPID_SCOPE_ALLFORTX

--- a/test/ts-scenario/features/hsm-gateway.feature
+++ b/test/ts-scenario/features/hsm-gateway.feature
@@ -23,13 +23,13 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 
 	Scenario: Using a Gateway I recieve useful error messages when I submit or evaulate invalid transactions
 		When I use the gateway named myhsmgateway to submit a transaction with args [noSuchSubmitTransaction,1001,Trabant,601 Estate,brown,Simon] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named myhsmgateway has a error type response containing Error: You've asked to invoke a function that does not exist: noSuchSubmitTransaction
+		Then The gateway named myhsmgateway has a error type response containing noSuchSubmitTransaction
 		When I use the gateway named myhsmgateway to submit a transaction with args [createCar,9,Ford] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named myhsmgateway has a error type response containing Error: Expected 5 parameters, but 2 have been supplied
+		Then The gateway named myhsmgateway has a error type response containing Expected 5 parameters, but 2 have been supplied
 		When I use the gateway named myhsmgateway to evaluate a transaction with args [noSuchEvaluateTransaction,1001] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named myhsmgateway has a error type response containing Error: You've asked to invoke a function that does not exist: noSuchEvaluateTransaction
+		Then The gateway named myhsmgateway has a error type response containing noSuchEvaluateTransaction
 		When I use the gateway named myhsmgateway to evaluate a transaction with args [queryCar,because,I,said,so] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named myhsmgateway has a error type response containing Error: Expected 1 parameters, but 4 have been supplied
+		Then The gateway named myhsmgateway has a error type response containing Expected 1 parameters, but 4 have been supplied
 
 	Scenario: Using a Gateway to submit transactions I can use different event handler strategies
 		When I modify myhsmgateway to submit a transaction with args [createCar,1002,Ford,Mustang,Silver,Andy] for contract fabcar instantiated on channel gatewaychannel using handler option MSPID_SCOPE_ALLFORTX

--- a/test/ts-scenario/features/nontls-gateway.feature
+++ b/test/ts-scenario/features/nontls-gateway.feature
@@ -23,13 +23,13 @@ Feature: Configure Fabric using CLI and submit/evaluate using a network Gateway 
 
 	Scenario: Using a Gateway I recieve useful error messages when I submit or evaulate invalid transactions
 		When I use the gateway named mynontlsgateway to submit a transaction with args [noSuchSubmitTransaction,1001,Trabant,601 Estate,brown,Simon] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mynontlsgateway has a error type response containing Error: You've asked to invoke a function that does not exist: noSuchSubmitTransaction
+		Then The gateway named mynontlsgateway has a error type response containing noSuchSubmitTransaction
 		When I use the gateway named mynontlsgateway to submit a transaction with args [createCar,9,Ford] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mynontlsgateway has a error type response containing Error: Expected 5 parameters, but 2 have been supplied
+		Then The gateway named mynontlsgateway has a error type response containing Expected 5 parameters, but 2 have been supplied
 		When I use the gateway named mynontlsgateway to evaluate a transaction with args [noSuchEvaluateTransaction,1001] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mynontlsgateway has a error type response containing Error: You've asked to invoke a function that does not exist: noSuchEvaluateTransaction
+		Then The gateway named mynontlsgateway has a error type response containing noSuchEvaluateTransaction
 		When I use the gateway named mynontlsgateway to evaluate a transaction with args [queryCar,because,I,said,so] for contract fabcar instantiated on channel gatewaychannel
-		Then The gateway named mynontlsgateway has a error type response containing Error: Expected 1 parameters, but 4 have been supplied
+		Then The gateway named mynontlsgateway has a error type response containing Expected 1 parameters, but 4 have been supplied
 
 	Scenario: Using a Gateway to submit transactions I can use different event handler strategies
 		When I modify mynontlsgateway to submit a transaction with args [createCar,1002,Ford,Mustang,Silver,Andy] for contract fabcar instantiated on channel gatewaychannel using handler option MSPID_SCOPE_ALLFORTX


### PR DESCRIPTION
Some testing of error scenarios checked for exact error message text produced by Fabric and/or the chaincode runtime, which are outside the scope of control of the SDK and failed when the text of those messages changed slightly. This change minimises the checking to text that should either be reasonably expected to be included in the runtime error message, or is produced by the smart contract used for testing and can therefore be relied on.