### PR TITLE
Fix chaincode dependencies to v2.2.x in test fixtures

### DIFF
--- a/test/fixtures/chaincode/node_cc/example_cc/package.json
+++ b/test/fixtures/chaincode/node_cc/example_cc/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fabric-shim": "^2.0.0"
+    "fabric-shim": "~2.2.0"
   }
 }

--- a/test/ts-fixtures/chaincode/node/events/package.json
+++ b/test/ts-fixtures/chaincode/node/events/package.json
@@ -13,7 +13,7 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2.0",
+        "fabric-shim": "~2.2.0"
 	}
 }

--- a/test/ts-fixtures/chaincode/node/fabcar/package.json
+++ b/test/ts-fixtures/chaincode/node/fabcar/package.json
@@ -17,8 +17,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2.0",
+        "fabric-shim": "~2.2.0"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/test/ts-fixtures/chaincode/node/fabcarUpgrade/package.json
+++ b/test/ts-fixtures/chaincode/node/fabcarUpgrade/package.json
@@ -17,8 +17,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2.0",
+        "fabric-shim": "~2.2.0"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/test/ts-fixtures/chaincode/node/legacyNode/package.json
+++ b/test/ts-fixtures/chaincode/node/legacyNode/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fabric-shim": "^2.0.0"
+    "fabric-shim": "~2.2.0"
   }
 }


### PR DESCRIPTION
v2.5.x introduced some changes that broke the tests.