### PR TITLE
Use repository variable to refer to workflows in scheduled build

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,6 +9,6 @@ jobs:
     uses: ./.github/workflows/test.yml
   release-2_2:
     name: release-2.2
-    uses: hyperledger/fabric-sdk-node/.github/workflows/test.yml@release-2.2
+    uses: ${{ github.repository }}/.github/workflows/test.yml@release-2.2
     with:
       checkout-ref: release-2.2


### PR DESCRIPTION
Avoids hard-coding the repository organization / name in the workflow.