### PR TITLE
Update npm version used by Node

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
+      - name: Update npm
+        run: |
+          npm update --global npm
+          npm --version
       - uses: actions/checkout@v3
       - run: npm install
       - run: npm run compile
@@ -35,6 +39,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - name: Update npm
+        run: |
+          npm update --global npm
+          npm --version
       - name: Checkout source
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,34 +29,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.checkout-ref }}
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
+      - name: Update npm
+        run: |
+          npm update --global npm
+          npm --version
       - name: Install SoftHSM
         run: |
           sudo apt-get install softhsm2
           softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
-
       - run: npm install
-
       - name: Generate credentials
         run: npm run installAndGenerateCerts
-
       - name: Pull Fabric images
         run: npm run pullFabricImages
-
       - run: npm test
-
       - name: "Archive unit test debug log"
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.node-version }}-unit-test-debug.log
           path: test/temp/debug.log
-
       - name: "Archive scenario test debug log"
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+      - name: Update npm
+        run: |
+          npm update --global npm
+          npm --version
       - name: Scan
         run: |
           npm install --package-lock-only


### PR DESCRIPTION
npm v9.3.1 that shipped with Node v18.14.0 broke linked dependencies. This is fixed in later npm v9.x releases. Update the npm version after Node install to pick up any npm fixes available as quickly as possible.