### PR TITLE
Socket connection fix: destroy() used instead of abort()

### DIFF
--- a/fabric-ca-client/lib/FabricCAClient.js
+++ b/fabric-ca-client/lib/FabricCAClient.js
@@ -311,7 +311,7 @@ const FabricCAClient = class {
 			request.on('socket', (socket) => {
 				socket.setTimeout(CONNECTION_TIMEOUT);
 				socket.on('timeout', () => {
-					request.abort();
+					request.destroy();
 					reject(new Error(`Calling ${api_method} endpoint failed, CONNECTION Timeout`));
 				});
 			});


### PR DESCRIPTION
While testing the `fabric-node-SDK`, found that the connections were not getting reused creating more connections in the pool. 

While debugging the issue further found that the issue is the connection was not getting destroyed. The `request.abort()` method was deprecated for a really long time too, so it makes sense this could be changed. 

Thus, this minor code change fixes this issue and we're able to decrease the number of active GRPC connections on the network.