### PR TITLE
Use require to import long

### DIFF
--- a/fabric-common/types/index.d.ts
+++ b/fabric-common/types/index.d.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-import Long from 'long';
+import Long = require('long');
 import * as fabproto6 from 'fabric-protos';
 import winston = require('winston');
 

--- a/fabric-network/src/checkpointer.ts
+++ b/fabric-network/src/checkpointer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Long from 'long';
+import Long = require('long');
 
 export interface Checkpointer {
 	addTransactionId(transactionId: string): Promise<void>;

--- a/fabric-network/src/events.ts
+++ b/fabric-network/src/events.ts
@@ -7,7 +7,7 @@
 import {BlockType, Endorser} from 'fabric-common';
 import * as fabproto6 from 'fabric-protos';
 import {Checkpointer} from './checkpointer';
-import Long from 'long';
+import Long = require('long');
 
 export type EventType = BlockType;
 

--- a/fabric-network/src/impl/event/blockeventsource.ts
+++ b/fabric-network/src/impl/event/blockeventsource.ts
@@ -15,7 +15,7 @@ import {newFullBlockEvent} from './fullblockeventfactory';
 import {OrderedBlockQueue} from './orderedblockqueue';
 import {newPrivateBlockEvent} from './privateblockeventfactory';
 import {notNullish} from '../gatewayutils';
-import Long from 'long';
+import Long = require('long');
 
 const logger = Logger.getLogger('BlockEventSource');
 

--- a/fabric-network/src/impl/event/orderedblockqueue.ts
+++ b/fabric-network/src/impl/event/orderedblockqueue.ts
@@ -5,7 +5,7 @@
  */
 
 import {BlockEvent} from '../../events';
-import Long from 'long';
+import Long = require('long');
 
 export class OrderedBlockQueue {
 	private readonly queue = new Map<string, BlockEvent>();

--- a/fabric-network/src/impl/filecheckpointer.ts
+++ b/fabric-network/src/impl/filecheckpointer.ts
@@ -5,7 +5,7 @@
  */
 
 import {Checkpointer} from '../checkpointer';
-import Long from 'long';
+import Long = require('long');
 import * as fs from 'fs';
 
 const encoding = 'utf8';

--- a/fabric-network/test/impl/event/commitlistener.spec.ts
+++ b/fabric-network/test/impl/event/commitlistener.spec.ts
@@ -16,7 +16,7 @@ import {
 	Client,
 	Eventer
 } from 'fabric-common';
-import Long from 'long';
+import Long = require('long');
 
 import {NetworkImpl} from '../../../src/network';
 import {EventServiceManager} from '../../../src/impl/event/eventservicemanager';

--- a/fabric-network/test/impl/event/contractlistener.spec.ts
+++ b/fabric-network/test/impl/event/contractlistener.spec.ts
@@ -12,7 +12,7 @@
 
 import * as sinon from 'sinon';
 import {expect} from 'chai';
-import Long from 'long';
+import Long = require('long');
 
 import {Channel, Client, Endorser, Eventer, EventInfo, IdentityContext} from 'fabric-common';
 import * as fabproto6 from 'fabric-protos';

--- a/fabric-network/test/impl/event/listeners.spec.ts
+++ b/fabric-network/test/impl/event/listeners.spec.ts
@@ -7,7 +7,7 @@
 import * as Listeners from '../../../src/impl/event/listeners';
 import {StubCheckpointer} from './stubcheckpointer';
 import {BlockEvent, BlockListener, TransactionEvent, ContractEvent} from '../../../src/events';
-import Long from 'long';
+import Long = require('long');
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 

--- a/fabric-network/test/impl/event/orderedblockqueue.spec.ts
+++ b/fabric-network/test/impl/event/orderedblockqueue.spec.ts
@@ -6,7 +6,7 @@
 
 import {BlockEvent} from '../../../src/events';
 import {OrderedBlockQueue} from '../../../src/impl/event/orderedblockqueue';
-import Long from 'long';
+import Long = require('long');
 
 import * as chai from 'chai';
 const expect = chai.expect;

--- a/fabric-network/test/impl/event/stubcheckpointer.ts
+++ b/fabric-network/test/impl/event/stubcheckpointer.ts
@@ -5,7 +5,7 @@
  */
 
 import {Checkpointer} from '../../../src/checkpointer';
-import Long from 'long';
+import Long = require('long');
 
 export class StubCheckpointer implements Checkpointer {
 	private blockNumber: Long;

--- a/fabric-network/test/impl/event/transactioneventhandler.spec.ts
+++ b/fabric-network/test/impl/event/transactioneventhandler.spec.ts
@@ -19,7 +19,7 @@ import {
 	EventInfo,
 	IdentityContext
 } from 'fabric-common';
-import Long from 'long';
+import Long = require('long');
 
 import {Gateway, ConnectedGatewayOptions} from '../../../src/gateway';
 import {Network, NetworkImpl} from '../../../src/network';

--- a/fabric-network/test/impl/filecheckpointer.spec.ts
+++ b/fabric-network/test/impl/filecheckpointer.spec.ts
@@ -7,7 +7,7 @@
 import {Checkpointer} from '../../src/checkpointer';
 import {DefaultCheckpointers} from '../../src/defaultcheckpointers';
 import * as testUtils from '../testutils';
-import Long from 'long';
+import Long = require('long');
 import * as path  from 'path';
 import * as fs from 'fs';
 import * as chai from 'chai';

--- a/test/ts-scenario/src/steps/lib/listeners.ts
+++ b/test/ts-scenario/src/steps/lib/listeners.ts
@@ -12,7 +12,7 @@ import * as Constants from '../constants';
 import * as GatewayHelper from './gateway';
 import * as BaseUtils from './utility/baseUtils';
 import {StateStore} from './utility/stateStore';
-import Long from 'long';
+import Long = require('long');
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/test/ts-scenario/src/steps/lib/utility/clientUtils.ts
+++ b/test/ts-scenario/src/steps/lib/utility/clientUtils.ts
@@ -15,7 +15,7 @@ import {
 	StartRequestOptions, SendEventOptions, BuildProposalRequest, SendProposalRequest, EventRegistrationOptions, EventListener
 } from 'fabric-common';
 import * as fs from 'fs';
-import Long from 'long';
+import Long = require('long');
 import * as Constants from '../../constants';
 import * as BaseUtils from './baseUtils';
 import {CommonConnectionProfileHelper} from './commonConnectionProfileHelper';


### PR DESCRIPTION
Explicit require provides better TypeScript compatibility regardless of esModuleInterop setting.