### PR TITLE
Remove scheduled vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,8 +1,7 @@
 name: "Security vulnerability scan"
 
 on:
-  schedule:
-    - cron: "20 0 * * *"
+  workflow_dispatch:
 
 jobs:
   npm-audit:


### PR DESCRIPTION
Since the project is now deprecated, vulnerabilities are no longer being proactively fixed.